### PR TITLE
Use Positions for start/stop in Span

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ obj
 .fake
 TestResults
 coverage.opencover.xml
+.idea
+*.DotSettings.user

--- a/src/Escalier.Data/Escalier.Data.fsproj
+++ b/src/Escalier.Data/Escalier.Data.fsproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="Library.fs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FParsec" Version="1.1.1" />
+  </ItemGroup>
 </Project>

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -1,7 +1,9 @@
 ﻿namespace rec Escalier.Data
 
+open FParsec
+
 module Syntax =
-  type Span = { start: int; stop: int }
+  type Span = { start: Position; stop: Position }
 
   type DeclKind =
     | TypeDecl of

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -8,17 +8,15 @@ open FParsec
 
 open Escalier.Parser
 
-let settings = new VerifySettings()
+let settings = VerifySettings()
 settings.UseDirectory("snapshots")
-
-[<Fact>]
-let ``My test`` () = Assert.True(true)
+settings.DisableDiff()
 
 [<Fact>]
 let ParseArithmetic () =
   let src = "0.1 + 2 * (3 - 4) / -5.6"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -26,7 +24,7 @@ let ParseArithmetic () =
 let ParseString () =
   let src = """msg = "Hello,\n\t\"world!\"" """
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -34,7 +32,7 @@ let ParseString () =
 let ParseTemplateString () =
   let src = """msg = `foo ${`bar ${baz}`}`"""
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -42,7 +40,7 @@ let ParseTemplateString () =
 let ParseFunctionCall () =
   let src = "add(x, y)"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -50,7 +48,7 @@ let ParseFunctionCall () =
 let ParseFunctionCallExtraSpaces () =
   let src = "add( x , y )"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -58,7 +56,7 @@ let ParseFunctionCallExtraSpaces () =
 let ParseEmptyCall () =
   let src = "add()"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -66,7 +64,7 @@ let ParseEmptyCall () =
 let ParseIndexer () =
   let src = "array[0]"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -74,7 +72,7 @@ let ParseIndexer () =
 let ParseIndexerThenCall () =
   let src = "array[0]()"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -82,7 +80,7 @@ let ParseIndexerThenCall () =
 let ParseCallThenIndexer () =
   let src = "foo()[0]"
   let expr = run ExprParser.expr src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -90,7 +88,7 @@ let ParseCallThenIndexer () =
 let ParseFuncDef () =
   let src = "fn (x, y) { x }"
   let expr = run ExprParser.func src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -98,7 +96,7 @@ let ParseFuncDef () =
 let ParseUnionType () =
   let src = "number | string | boolean"
   let expr = run ExprParser.typeAnn src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -106,7 +104,7 @@ let ParseUnionType () =
 let ParseIntersectionType () =
   let src = "number & string & boolean"
   let expr = run ExprParser.typeAnn src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -114,7 +112,7 @@ let ParseIntersectionType () =
 let ParseUnionAndIntersectionType () =
   let src = "A & B | C & D"
   let expr = run ExprParser.typeAnn src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -122,7 +120,7 @@ let ParseUnionAndIntersectionType () =
 let ParseArrayType () =
   let src = "number[][]"
   let expr = run ExprParser.typeAnn src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
@@ -130,6 +128,6 @@ let ParseArrayType () =
 let ParseParenthesizedType () =
   let src = "(number | string)[]"
   let expr = run ExprParser.typeAnn src
-  let result = sprintf "input: %s\noutput: %A" src expr
+  let result = $"input: %s{src}\noutput: %A{expr}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseArithmetic.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseArithmetic.verified.txt
@@ -2,43 +2,43 @@
 output: Success: { kind =
    Binary
      ({ kind = Literal (Number "0.1")
-        span = { start = 0
-                 stop = 3 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 4) }
         inferred_type = None }, Add,
       { kind =
          Binary
            ({ kind =
                Binary
                  ({ kind = Literal (Number "2")
-                    span = { start = 6
-                             stop = 7 }
+                    span = { start = (Ln: 1, Col: 7)
+                             stop = (Ln: 1, Col: 8) }
                     inferred_type = None }, Mul,
                   { kind =
                      Binary
                        ({ kind = Literal (Number "3")
-                          span = { start = 11
-                                   stop = 12 }
+                          span = { start = (Ln: 1, Col: 12)
+                                   stop = (Ln: 1, Col: 13) }
                           inferred_type = None }, Sub,
                         { kind = Literal (Number "4")
-                          span = { start = 15
-                                   stop = 16 }
+                          span = { start = (Ln: 1, Col: 16)
+                                   stop = (Ln: 1, Col: 17) }
                           inferred_type = None })
-                    span = { start = 11
-                             stop = 16 }
+                    span = { start = (Ln: 1, Col: 12)
+                             stop = (Ln: 1, Col: 17) }
                     inferred_type = None })
-              span = { start = 6
-                       stop = 16 }
+              span = { start = (Ln: 1, Col: 7)
+                       stop = (Ln: 1, Col: 17) }
               inferred_type = None }, Div,
             { kind = Unary ("-", { kind = Literal (Number "5.6")
-                                   span = { start = 21
-                                            stop = 24 }
+                                   span = { start = (Ln: 1, Col: 22)
+                                            stop = (Ln: 1, Col: 25) }
                                    inferred_type = None })
-              span = { start = 21
-                       stop = 24 }
+              span = { start = (Ln: 1, Col: 22)
+                       stop = (Ln: 1, Col: 25) }
               inferred_type = None })
-        span = { start = 6
-                 stop = 24 }
+        span = { start = (Ln: 1, Col: 7)
+                 stop = (Ln: 1, Col: 25) }
         inferred_type = None })
-  span = { start = 0
-           stop = 24 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 25) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrayType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrayType.verified.txt
@@ -1,11 +1,11 @@
 ﻿input: number[][]
 output: Success: { kind = Array { kind = Array { kind = Keyword Number
-                                span = { start = 0
-                                         stop = 6 }
+                                span = { start = (Ln: 1, Col: 1)
+                                         stop = (Ln: 1, Col: 7) }
                                 inferred_type = None }
-                 span = { start = 0
-                          stop = 8 }
+                 span = { start = (Ln: 1, Col: 1)
+                          stop = (Ln: 1, Col: 9) }
                  inferred_type = None }
-  span = { start = 0
-           stop = 10 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 11) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
@@ -1,14 +1,14 @@
 ﻿input: foo()[0]
 output: Success: { kind = Index ({ kind = Call ({ kind = Identifer "foo"
-                                 span = { start = 0
-                                          stop = 3 }
+                                 span = { start = (Ln: 1, Col: 1)
+                                          stop = (Ln: 1, Col: 4) }
                                  inferred_type = None }, None, [], false, None)
-                  span = { start = 0
-                           stop = 4 }
+                  span = { start = (Ln: 1, Col: 1)
+                           stop = (Ln: 1, Col: 5) }
                   inferred_type = None }, { kind = Literal (Number "0")
-                                            span = { start = 6
-                                                     stop = 7 }
+                                            span = { start = (Ln: 1, Col: 7)
+                                                     stop = (Ln: 1, Col: 8) }
                                             inferred_type = None }, false)
-  span = { start = 0
-           stop = 6 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 7) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: add()
 output: Success: { kind = Call ({ kind = Identifer "add"
-                 span = { start = 0
-                          stop = 3 }
+                 span = { start = (Ln: 1, Col: 1)
+                          stop = (Ln: 1, Col: 4) }
                  inferred_type = None }, None, [], false, None)
-  span = { start = 0
-           stop = 4 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 5) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
@@ -1,14 +1,15 @@
 ﻿input: fn (x, y) { x }
 output: Success: { kind =
    Function
-     (["x"; "y"], Block { span = { start = 0
-                                   stop = 0 }
-                          stmts = [{ span = { start = 12
-                                              stop = 14 }
-                                     kind = Expr { kind = Identifer "x"
-                                                   span = { start = 12
-                                                            stop = 14 }
-                                                   inferred_type = None } }] })
-  span = { start = 0
-           stop = 15 }
+     (["x"; "y"],
+      Block { span = { start = (Ln: 1, Col: 11)
+                       stop = (Ln: 1, Col: 16) }
+              stmts = [{ span = { start = (Ln: 1, Col: 13)
+                                  stop = (Ln: 1, Col: 15) }
+                         kind = Expr { kind = Identifer "x"
+                                       span = { start = (Ln: 1, Col: 13)
+                                                stop = (Ln: 1, Col: 15) }
+                                       inferred_type = None } }] })
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 16) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
@@ -2,16 +2,16 @@
 output: Success: { kind =
    Call
      ({ kind = Identifer "add"
-        span = { start = 0
-                 stop = 3 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 4) }
         inferred_type = None }, None,
       [{ kind = Identifer "x"
-         span = { start = 4
-                  stop = 5 }
+         span = { start = (Ln: 1, Col: 5)
+                  stop = (Ln: 1, Col: 6) }
          inferred_type = None }; { kind = Identifer "y"
-                                   span = { start = 7
-                                            stop = 8 }
+                                   span = { start = (Ln: 1, Col: 8)
+                                            stop = (Ln: 1, Col: 9) }
                                    inferred_type = None }], false, None)
-  span = { start = 0
-           stop = 4 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 5) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
@@ -2,16 +2,16 @@
 output: Success: { kind =
    Call
      ({ kind = Identifer "add"
-        span = { start = 0
-                 stop = 3 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 4) }
         inferred_type = None }, None,
       [{ kind = Identifer "x"
-         span = { start = 5
-                  stop = 7 }
+         span = { start = (Ln: 1, Col: 6)
+                  stop = (Ln: 1, Col: 8) }
          inferred_type = None }; { kind = Identifer "y"
-                                   span = { start = 9
-                                            stop = 11 }
+                                   span = { start = (Ln: 1, Col: 10)
+                                            stop = (Ln: 1, Col: 12) }
                                    inferred_type = None }], false, None)
-  span = { start = 0
-           stop = 4 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 5) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
@@ -1,11 +1,11 @@
 ﻿input: array[0]
 output: Success: { kind = Index ({ kind = Identifer "array"
-                  span = { start = 0
-                           stop = 5 }
+                  span = { start = (Ln: 1, Col: 1)
+                           stop = (Ln: 1, Col: 6) }
                   inferred_type = None }, { kind = Literal (Number "0")
-                                            span = { start = 6
-                                                     stop = 7 }
+                                            span = { start = (Ln: 1, Col: 7)
+                                                     stop = (Ln: 1, Col: 8) }
                                             inferred_type = None }, false)
-  span = { start = 0
-           stop = 6 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 7) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
@@ -1,16 +1,17 @@
 ﻿input: array[0]()
 output: Success: { kind =
    Call
-     ({ kind = Index ({ kind = Identifer "array"
-                        span = { start = 0
-                                 stop = 5 }
-                        inferred_type = None }, { kind = Literal (Number "0")
-                                                  span = { start = 6
-                                                           stop = 7 }
-                                                  inferred_type = None }, false)
-        span = { start = 0
-                 stop = 6 }
+     ({ kind =
+         Index ({ kind = Identifer "array"
+                  span = { start = (Ln: 1, Col: 1)
+                           stop = (Ln: 1, Col: 6) }
+                  inferred_type = None }, { kind = Literal (Number "0")
+                                            span = { start = (Ln: 1, Col: 7)
+                                                     stop = (Ln: 1, Col: 8) }
+                                            inferred_type = None }, false)
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 7) }
         inferred_type = None }, None, [], false, None)
-  span = { start = 0
-           stop = 9 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 10) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIntersectionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIntersectionType.verified.txt
@@ -2,16 +2,16 @@
 output: Success: { kind =
    Intersection
      [{ kind = Keyword Number
-        span = { start = 0
-                 stop = 7 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 8) }
         inferred_type = None }; { kind = Keyword String
-                                  span = { start = 9
-                                           stop = 16 }
+                                  span = { start = (Ln: 1, Col: 10)
+                                           stop = (Ln: 1, Col: 17) }
                                   inferred_type = None };
       { kind = Keyword Boolean
-        span = { start = 18
-                 stop = 25 }
+        span = { start = (Ln: 1, Col: 19)
+                 stop = (Ln: 1, Col: 26) }
         inferred_type = None }]
-  span = { start = 0
-           stop = 25 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 26) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseParenthesizedType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseParenthesizedType.verified.txt
@@ -1,15 +1,17 @@
 ﻿input: (number | string)[]
 output: Success: { kind =
-   Array { kind = Union [{ kind = Keyword Number
-                           span = { start = 1
-                                    stop = 8 }
-                           inferred_type = None }; { kind = Keyword String
-                                                     span = { start = 10
-                                                              stop = 16 }
-                                                     inferred_type = None }]
-           span = { start = 1
-                    stop = 16 }
-           inferred_type = None }
-  span = { start = 1
-           stop = 19 }
+   Array
+     { kind =
+        Union [{ kind = Keyword Number
+                 span = { start = (Ln: 1, Col: 2)
+                          stop = (Ln: 1, Col: 9) }
+                 inferred_type = None }; { kind = Keyword String
+                                           span = { start = (Ln: 1, Col: 11)
+                                                    stop = (Ln: 1, Col: 17) }
+                                           inferred_type = None }]
+       span = { start = (Ln: 1, Col: 2)
+                stop = (Ln: 1, Col: 17) }
+       inferred_type = None }
+  span = { start = (Ln: 1, Col: 2)
+           stop = (Ln: 1, Col: 20) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
@@ -2,14 +2,14 @@
 output: Success: { kind =
    Assign
      ({ kind = Identifer "msg"
-        span = { start = 0
-                 stop = 4 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 5) }
         inferred_type = None }, Assign,
       { kind = Literal (String "Hello,
 	"world!"")
-        span = { start = 6
-                 stop = 28 }
+        span = { start = (Ln: 1, Col: 7)
+                 stop = (Ln: 1, Col: 29) }
         inferred_type = None })
-  span = { start = 0
-           stop = 28 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 29) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
@@ -2,24 +2,26 @@
 output: Success: { kind =
    Assign
      ({ kind = Identifer "msg"
-        span = { start = 0
-                 stop = 4 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 5) }
         inferred_type = None }, Assign,
       { kind =
          TemplateLiteral
            { parts = ["foo "; ""]
              exprs =
-              [{ kind = TemplateLiteral { parts = ["bar "; ""]
-                                          exprs = [{ kind = Identifer "baz"
-                                                     span = { start = 20
-                                                              stop = 23 }
-                                                     inferred_type = None }] }
-                 span = { start = 13
-                          stop = 25 }
+              [{ kind =
+                  TemplateLiteral
+                    { parts = ["bar "; ""]
+                      exprs = [{ kind = Identifer "baz"
+                                 span = { start = (Ln: 1, Col: 21)
+                                          stop = (Ln: 1, Col: 24) }
+                                 inferred_type = None }] }
+                 span = { start = (Ln: 1, Col: 14)
+                          stop = (Ln: 1, Col: 26) }
                  inferred_type = None }] }
-        span = { start = 6
-                 stop = 27 }
+        span = { start = (Ln: 1, Col: 7)
+                 stop = (Ln: 1, Col: 28) }
         inferred_type = None })
-  span = { start = 0
-           stop = 27 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 28) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionAndIntersectionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionAndIntersectionType.verified.txt
@@ -2,27 +2,29 @@
 output: Success: { kind =
    Union
      [{ kind =
-         Intersection [{ kind = TypeRef ("A", None)
-                         span = { start = 0
-                                  stop = 2 }
-                         inferred_type = None }; { kind = TypeRef ("B", None)
-                                                   span = { start = 4
-                                                            stop = 6 }
-                                                   inferred_type = None }]
-        span = { start = 0
-                 stop = 6 }
+         Intersection
+           [{ kind = TypeRef ("A", None)
+              span = { start = (Ln: 1, Col: 1)
+                       stop = (Ln: 1, Col: 3) }
+              inferred_type = None }; { kind = TypeRef ("B", None)
+                                        span = { start = (Ln: 1, Col: 5)
+                                                 stop = (Ln: 1, Col: 7) }
+                                        inferred_type = None }]
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 7) }
         inferred_type = None };
       { kind =
-         Intersection [{ kind = TypeRef ("C", None)
-                         span = { start = 8
-                                  stop = 10 }
-                         inferred_type = None }; { kind = TypeRef ("D", None)
-                                                   span = { start = 12
-                                                            stop = 13 }
-                                                   inferred_type = None }]
-        span = { start = 8
-                 stop = 13 }
+         Intersection
+           [{ kind = TypeRef ("C", None)
+              span = { start = (Ln: 1, Col: 9)
+                       stop = (Ln: 1, Col: 11) }
+              inferred_type = None }; { kind = TypeRef ("D", None)
+                                        span = { start = (Ln: 1, Col: 13)
+                                                 stop = (Ln: 1, Col: 14) }
+                                        inferred_type = None }]
+        span = { start = (Ln: 1, Col: 9)
+                 stop = (Ln: 1, Col: 14) }
         inferred_type = None }]
-  span = { start = 0
-           stop = 13 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 14) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionType.verified.txt
@@ -2,16 +2,16 @@
 output: Success: { kind =
    Union
      [{ kind = Keyword Number
-        span = { start = 0
-                 stop = 7 }
+        span = { start = (Ln: 1, Col: 1)
+                 stop = (Ln: 1, Col: 8) }
         inferred_type = None }; { kind = Keyword String
-                                  span = { start = 9
-                                           stop = 16 }
+                                  span = { start = (Ln: 1, Col: 10)
+                                           stop = (Ln: 1, Col: 17) }
                                   inferred_type = None };
       { kind = Keyword Boolean
-        span = { start = 18
-                 stop = 25 }
+        span = { start = (Ln: 1, Col: 19)
+                 stop = (Ln: 1, Col: 26) }
         inferred_type = None }]
-  span = { start = 0
-           stop = 25 }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 26) }
   inferred_type = None }

--- a/src/Escalier.Parser/Library.fs
+++ b/src/Escalier.Parser/Library.fs
@@ -1,7 +1,9 @@
 ﻿namespace Escalier.Parser
 
+open FParsec
+
 module Say =
-  let hello name = printfn "Hello %s" name
+  let hello name = printfn $"Hello %s{name}"
 
   open Escalier.Data.Type
 
@@ -11,9 +13,12 @@ module Say =
 
   open Escalier.Data.Syntax
 
+  let start = Position("source.esc", 0, 0, 0)
+  let stop = Position("source.esc", 5, 0, 5)
+
   let expr: Expr =
     { kind = Identifer("foo")
-      span = { start = 0; stop = 5 }
+      span = { start = start; stop = stop }
       inferred_type = Some(t) }
 
   t.provenance.Value <- Some(Provenance.Expr(expr))


### PR DESCRIPTION
`FParsec`'s `Position` type includes not only line:column data but also the name of the stream.  This will come in very handy once Escalier is able to support multi file programs.