### PR TITLE
Add support for type decls and function type annotations

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -193,7 +193,7 @@ module Syntax =
   type TypeParam =
     { span: Span
       name: string
-      bound: option<TypeAnn>
+      constraint_: option<TypeAnn>
       default_: option<TypeAnn> }
 
   type FuncSig<'T> =

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -219,10 +219,7 @@ module Syntax =
     { extends: TypeAnn; true_type: TypeAnn }
 
   type TypeAnnKind =
-    // TODO: collapse these into a single `Literal` type ann kind
-    | BooleanLiteral of value: bool
-    | NumberLiteral of value: string
-    | StringLiteral of value: string
+    | Literal of Literal
     | Keyword of keyword: KeywordTypeAnn
     | Object of elems: list<ObjTypeAnnElem>
     | Tuple of elems: list<TypeAnn>
@@ -276,7 +273,11 @@ module Type =
         sprintf
           "{%A}"
           (elems |> List.map (fun e -> e.ToString()) |> String.concat ", ")
-      | Tuple(elems) -> $"[{elems |> List.map (fun e -> e.ToString())}]"
+      | Tuple(elems) ->
+        let elems =
+          elems |> List.map (fun e -> e.ToString()) |> String.concat ", "
+
+        $"[{elems}]"
       | Wildcard -> "_"
       | Literal(lit) -> lit.ToString()
       | Is(target, id) -> $"{target} is {id}"
@@ -492,9 +493,10 @@ module Type =
       | Literal(lit) -> lit.ToString()
       | Primitive(prim) -> prim.ToString()
       | Tuple(elems) ->
-        sprintf
-          "[%A]"
-          (elems |> List.map (fun e -> e.ToString()) |> String.concat ", ")
+        let elems =
+          elems |> List.map (fun e -> e.ToString()) |> String.concat ", "
+
+        $"[{elems}]"
       | Array(elem) -> $"{elem}[]"
       | Union(types) ->
         (types |> List.map (fun t -> t.ToString()) |> String.concat " | ")

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -132,10 +132,7 @@ module Syntax =
       optional: bool }
 
   type Function =
-    { param_list: list<FuncParam<option<TypeAnn>>>
-      return_type: option<TypeAnn>
-      type_params: option<list<TypeParam>>
-      throws: option<TypeAnn>
+    { sig': FuncSig<option<TypeAnn>>
       body: BlockOrExpr }
 
   type ExprKind =
@@ -199,11 +196,13 @@ module Syntax =
       bound: option<TypeAnn>
       default_: option<TypeAnn> }
 
-  type FunctionType =
+  type FuncSig<'T> =
     { type_params: option<list<TypeParam>>
-      params_: list<FuncParam<TypeAnn>>
-      return_type: TypeAnn
+      param_list: list<FuncParam<'T>>
+      return_type: 'T
       throws: option<TypeAnn> }
+
+  type FunctionType = FuncSig<TypeAnn>
 
   type ConditionType =
     { check: TypeAnn

--- a/src/Escalier.Data/Visitor.fs
+++ b/src/Escalier.Data/Visitor.fs
@@ -162,7 +162,7 @@ module Visitor =
           | Some(typeParams) ->
             List.iter
               (fun (typeParam: Syntax.TypeParam) ->
-                this.MaybeWalkTypeAnn typeParam.bound
+                this.MaybeWalkTypeAnn typeParam.constraint_
                 this.MaybeWalkTypeAnn typeParam.default_)
               typeParams
           | None -> ()

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -92,6 +92,14 @@ let ParseFuncDef () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseFuncDefWithTypes () =
+  let src = "fn (x: number) -> number throws \"RangeError\" { x }"
+  let expr = Parser.expr src
+  let result = $"input: %s{src}\noutput: %A{expr}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
 let ParseTuple () =
   let src = "[1, 2, 3]"
   let expr = Parser.expr src
@@ -142,6 +150,14 @@ let ParseArrayType () =
 [<Fact>]
 let ParseParenthesizedType () =
   let src = "(number | string)[]"
+  let expr = Parser.typeAnn src
+  let result = $"input: %s{src}\noutput: %A{expr}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseFunctionType () =
+  let src = "fn (x: number) -> number throws \"RangeError\""
   let expr = Parser.typeAnn src
   let result = $"input: %s{src}\noutput: %A{expr}"
 

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -92,8 +92,24 @@ let ParseFuncDef () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseTuple () =
+  let src = "[1, 2, 3]"
+  let expr = Parser.expr src
+  let result = $"input: %s{src}\noutput: %A{expr}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
 let ParseUnionType () =
   let src = "number | string | boolean"
+  let expr = Parser.typeAnn src
+  let result = $"input: %s{src}\noutput: %A{expr}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseUnionTypeWithLiterals () =
+  let src = "5 | \"hello\""
   let expr = Parser.typeAnn src
   let result = $"input: %s{src}\noutput: %A{expr}"
 

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -100,6 +100,14 @@ let ParseFuncDefWithTypes () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseFuncDefWithTypeParams () =
+  let src = "fn <T: Foo = Bar>(x: T) -> T { x }"
+  let expr = Parser.expr src
+  let result = $"input: %s{src}\noutput: %A{expr}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
 let ParseTuple () =
   let src = "[1, 2, 3]"
   let expr = Parser.expr src
@@ -157,7 +165,7 @@ let ParseParenthesizedType () =
 
 [<Fact>]
 let ParseFunctionType () =
-  let src = "fn (x: number) -> number throws \"RangeError\""
+  let src = "fn <T: Foo = Bar>(x: T) -> T throws \"RangeError\""
   let expr = Parser.typeAnn src
   let result = $"input: %s{src}\noutput: %A{expr}"
 

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
@@ -1,28 +1,29 @@
 ﻿input: fn (x, y) { x }
 output: Success: { kind =
    Function
-     { param_list =
-        [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 5)
-                                                    stop = (Ln: 1, Col: 6) }
-                                           name = "x"
-                                           isMut = false }
-                       span = { start = (Ln: 1, Col: 5)
-                                stop = (Ln: 1, Col: 6) }
-                       inferred_type = None }
-           typeAnn = None
-           optional = false };
-         { pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 8)
-                                                    stop = (Ln: 1, Col: 9) }
-                                           name = "y"
-                                           isMut = false }
-                       span = { start = (Ln: 1, Col: 8)
-                                stop = (Ln: 1, Col: 9) }
-                       inferred_type = None }
-           typeAnn = None
-           optional = false }]
-       return_type = None
-       type_params = None
-       throws = None
+     { sig' =
+        { type_params = None
+          param_list =
+           [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 5)
+                                                       stop = (Ln: 1, Col: 6) }
+                                              name = "x"
+                                              isMut = false }
+                          span = { start = (Ln: 1, Col: 5)
+                                   stop = (Ln: 1, Col: 6) }
+                          inferred_type = None }
+              typeAnn = None
+              optional = false };
+            { pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 8)
+                                                       stop = (Ln: 1, Col: 9) }
+                                              name = "y"
+                                              isMut = false }
+                          span = { start = (Ln: 1, Col: 8)
+                                   stop = (Ln: 1, Col: 9) }
+                          inferred_type = None }
+              typeAnn = None
+              optional = false }]
+          return_type = None
+          throws = None }
        body =
         Block { span = { start = (Ln: 1, Col: 11)
                          stop = (Ln: 1, Col: 16) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
@@ -1,0 +1,46 @@
+﻿input: fn <T: Foo = Bar>(x: T) -> T { x }
+output: Success: { kind =
+   Function
+     { sig' =
+        { type_params =
+           Some [{ span = { start = (Ln: 1, Col: 5)
+                            stop = (Ln: 1, Col: 17) }
+                   name = "T"
+                   constraint_ = Some { kind = TypeRef ("Foo", None)
+                                        span = { start = (Ln: 1, Col: 8)
+                                                 stop = (Ln: 1, Col: 12) }
+                                        inferred_type = None }
+                   default_ = Some { kind = TypeRef ("Bar", None)
+                                     span = { start = (Ln: 1, Col: 14)
+                                              stop = (Ln: 1, Col: 17) }
+                                     inferred_type = None } }]
+          param_list =
+           [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 19)
+                                                       stop = (Ln: 1, Col: 20) }
+                                              name = "x"
+                                              isMut = false }
+                          span = { start = (Ln: 1, Col: 19)
+                                   stop = (Ln: 1, Col: 20) }
+                          inferred_type = None }
+              typeAnn = Some { kind = TypeRef ("T", None)
+                               span = { start = (Ln: 1, Col: 22)
+                                        stop = (Ln: 1, Col: 23) }
+                               inferred_type = None }
+              optional = false }]
+          return_type = Some { kind = TypeRef ("T", None)
+                               span = { start = (Ln: 1, Col: 28)
+                                        stop = (Ln: 1, Col: 30) }
+                               inferred_type = None }
+          throws = None }
+       body =
+        Block { span = { start = (Ln: 1, Col: 30)
+                         stop = (Ln: 1, Col: 35) }
+                stmts = [{ span = { start = (Ln: 1, Col: 32)
+                                    stop = (Ln: 1, Col: 34) }
+                           kind = Expr { kind = Identifer "x"
+                                         span = { start = (Ln: 1, Col: 32)
+                                                  stop = (Ln: 1, Col: 34) }
+                                         inferred_type = None } }] } }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 35) }
+  inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypes.verified.txt
@@ -1,0 +1,38 @@
+﻿input: fn (x: number) -> number throws "RangeError" { x }
+output: Success: { kind =
+   Function
+     { sig' =
+        { type_params = None
+          param_list =
+           [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 5)
+                                                       stop = (Ln: 1, Col: 6) }
+                                              name = "x"
+                                              isMut = false }
+                          span = { start = (Ln: 1, Col: 5)
+                                   stop = (Ln: 1, Col: 6) }
+                          inferred_type = None }
+              typeAnn = Some { kind = Keyword Number
+                               span = { start = (Ln: 1, Col: 8)
+                                        stop = (Ln: 1, Col: 14) }
+                               inferred_type = None }
+              optional = false }]
+          return_type = Some { kind = Keyword Number
+                               span = { start = (Ln: 1, Col: 19)
+                                        stop = (Ln: 1, Col: 26) }
+                               inferred_type = None }
+          throws = Some { kind = Literal (String "RangeError")
+                          span = { start = (Ln: 1, Col: 33)
+                                   stop = (Ln: 1, Col: 45) }
+                          inferred_type = None } }
+       body =
+        Block { span = { start = (Ln: 1, Col: 46)
+                         stop = (Ln: 1, Col: 51) }
+                stmts = [{ span = { start = (Ln: 1, Col: 48)
+                                    stop = (Ln: 1, Col: 50) }
+                           kind = Expr { kind = Identifer "x"
+                                         span = { start = (Ln: 1, Col: 48)
+                                                  stop = (Ln: 1, Col: 50) }
+                                         inferred_type = None } }] } }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 51) }
+  inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
@@ -1,28 +1,39 @@
-﻿input: fn (x: number) -> number throws "RangeError"
+﻿input: fn <T: Foo = Bar>(x: T) -> T throws "RangeError"
 output: Success: { kind =
    Function
-     { type_params = None
+     { type_params =
+        Some [{ span = { start = (Ln: 1, Col: 5)
+                         stop = (Ln: 1, Col: 17) }
+                name = "T"
+                constraint_ = Some { kind = TypeRef ("Foo", None)
+                                     span = { start = (Ln: 1, Col: 8)
+                                              stop = (Ln: 1, Col: 12) }
+                                     inferred_type = None }
+                default_ = Some { kind = TypeRef ("Bar", None)
+                                  span = { start = (Ln: 1, Col: 14)
+                                           stop = (Ln: 1, Col: 17) }
+                                  inferred_type = None } }]
        param_list =
-        [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 5)
-                                                    stop = (Ln: 1, Col: 6) }
+        [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 19)
+                                                    stop = (Ln: 1, Col: 20) }
                                            name = "x"
                                            isMut = false }
-                       span = { start = (Ln: 1, Col: 5)
-                                stop = (Ln: 1, Col: 6) }
+                       span = { start = (Ln: 1, Col: 19)
+                                stop = (Ln: 1, Col: 20) }
                        inferred_type = None }
-           typeAnn = { kind = Keyword Number
-                       span = { start = (Ln: 1, Col: 8)
-                                stop = (Ln: 1, Col: 14) }
+           typeAnn = { kind = TypeRef ("T", None)
+                       span = { start = (Ln: 1, Col: 22)
+                                stop = (Ln: 1, Col: 23) }
                        inferred_type = None }
            optional = false }]
-       return_type = { kind = Keyword Number
-                       span = { start = (Ln: 1, Col: 19)
-                                stop = (Ln: 1, Col: 26) }
+       return_type = { kind = TypeRef ("T", None)
+                       span = { start = (Ln: 1, Col: 28)
+                                stop = (Ln: 1, Col: 30) }
                        inferred_type = None }
        throws = Some { kind = Literal (String "RangeError")
-                       span = { start = (Ln: 1, Col: 33)
-                                stop = (Ln: 1, Col: 45) }
+                       span = { start = (Ln: 1, Col: 37)
+                                stop = (Ln: 1, Col: 49) }
                        inferred_type = None } }
   span = { start = (Ln: 1, Col: 1)
-           stop = (Ln: 1, Col: 45) }
+           stop = (Ln: 1, Col: 49) }
   inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
@@ -1,0 +1,28 @@
+﻿input: fn (x: number) -> number throws "RangeError"
+output: Success: { kind =
+   Function
+     { type_params = None
+       param_list =
+        [{ pattern = { kind = Identifier { span = { start = (Ln: 1, Col: 5)
+                                                    stop = (Ln: 1, Col: 6) }
+                                           name = "x"
+                                           isMut = false }
+                       span = { start = (Ln: 1, Col: 5)
+                                stop = (Ln: 1, Col: 6) }
+                       inferred_type = None }
+           typeAnn = { kind = Keyword Number
+                       span = { start = (Ln: 1, Col: 8)
+                                stop = (Ln: 1, Col: 14) }
+                       inferred_type = None }
+           optional = false }]
+       return_type = { kind = Keyword Number
+                       span = { start = (Ln: 1, Col: 19)
+                                stop = (Ln: 1, Col: 26) }
+                       inferred_type = None }
+       throws = Some { kind = Literal (String "RangeError")
+                       span = { start = (Ln: 1, Col: 33)
+                                stop = (Ln: 1, Col: 45) }
+                       inferred_type = None } }
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 45) }
+  inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTuple.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTuple.verified.txt
@@ -1,0 +1,17 @@
+﻿input: [1, 2, 3]
+output: Success: { kind =
+   Tuple
+     [{ kind = Literal (Number "1")
+        span = { start = (Ln: 1, Col: 2)
+                 stop = (Ln: 1, Col: 3) }
+        inferred_type = None }; { kind = Literal (Number "2")
+                                  span = { start = (Ln: 1, Col: 5)
+                                           stop = (Ln: 1, Col: 6) }
+                                  inferred_type = None };
+      { kind = Literal (Number "3")
+        span = { start = (Ln: 1, Col: 8)
+                 stop = (Ln: 1, Col: 9) }
+        inferred_type = None }]
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 10) }
+  inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionTypeWithLiterals.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionTypeWithLiterals.verified.txt
@@ -1,0 +1,11 @@
+﻿input: 5 | "hello"
+output: Success: { kind = Union [{ kind = Literal (Number "5")
+                  span = { start = (Ln: 1, Col: 1)
+                           stop = (Ln: 1, Col: 2) }
+                  inferred_type = None }; { kind = Literal (String "hello")
+                                            span = { start = (Ln: 1, Col: 5)
+                                                     stop = (Ln: 1, Col: 12) }
+                                            inferred_type = None }]
+  span = { start = (Ln: 1, Col: 1)
+           stop = (Ln: 1, Col: 12) }
+  inferred_type = None }

--- a/src/Escalier.Parser/Escalier.Parser.fsproj
+++ b/src/Escalier.Parser/Escalier.Parser.fsproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="ParserRefs.fs"/>
+        <Compile Include="Shared.fs"/>
         <Compile Include="Literals.fs"/>
         <Compile Include="Expressions.fs"/>
         <Compile Include="Statements.fs"/>

--- a/src/Escalier.Parser/Expressions.fs
+++ b/src/Escalier.Parser/Expressions.fs
@@ -3,17 +3,16 @@ namespace Escalier.Parser
 open FParsec
 open Escalier.Data.Syntax
 open System.Text
+open Shared
 
 exception ParseError of string
 
 module private Expressions =
+  let lit = ParserRefs.lit
   let expr = ParserRefs.expr
   let stmt = ParserRefs.stmt
   let typeAnn = ParserRefs.typeAnn
   let pattern = ParserRefs.pattern
-
-  let ws = spaces
-  let str_ws s = pstring s .>> ws
 
   let mergeSpans (x: Span) (y: Span) = { start = x.start; stop = y.stop }
 
@@ -26,10 +25,10 @@ module private Expressions =
     many1Satisfy2L isIdentifierFirstChar isIdentifierChar "identifier" .>> ws // skips trailing whitespace
 
   let identExpr: Parser<Expr, unit> =
-    pipe3 getPosition ident getPosition
-    <| fun start sl stop ->
+    withSpan ident
+    |>> fun (sl, span) ->
       { kind = Identifer(sl)
-        span = { start = start; stop = stop }
+        span = span
         inferred_type = None }
 
   let templateStringLiteral: Parser<Expr, unit> =
@@ -90,23 +89,16 @@ module private Expressions =
       }
 
   let block: Parser<BlockOrExpr, unit> =
-    pipe3
-      getPosition
-      (between (str_ws "{") (str_ws "}") (many stmt))
-      getPosition
-    <| fun start stmts stop ->
-      BlockOrExpr.Block(
-        { span = { start = start; stop = stop }
-          stmts = stmts }
-      )
+    withSpan (between (str_ws "{") (str_ws "}") (many stmt))
+    |>> fun (stmts, span) -> BlockOrExpr.Block({ span = span; stmts = stmts })
 
   let type_param: Parser<TypeParam, unit> =
-    pipe3 getPosition ident getPosition
-    <| fun start name stop ->
+    withSpan ident
+    |>> fun (name, span) ->
       { name = name
         bound = None // TODO: parse type bounds
         default_ = None // TODO: parse default type
-        span = { start = start; stop = stop } }
+        span = span }
 
   let type_params: Parser<list<TypeParam>, unit> =
     between (str_ws "<") (str_ws ">") (sepBy type_param (str_ws ","))
@@ -123,12 +115,18 @@ module private Expressions =
         throws = None // TODO: parse `throws` clause
         body = body }
 
-  let func_expr: Parser<Expr, unit> =
-    pipe3 getPosition func getPosition
-    <| fun start f stop ->
-
+  let funcExpr: Parser<Expr, unit> =
+    withSpan func
+    |>> fun (f, span) ->
       { kind = ExprKind.Function f
-        span = { start = start; stop = stop }
+        span = span
+        inferred_type = None }
+
+  let tupleExpr: Parser<Expr, unit> =
+    tuple expr |> withSpan
+    |>> fun (exprs, span) ->
+      { kind = ExprKind.Tuple(exprs)
+        span = span
         inferred_type = None }
 
   let ifElse, ifElseRef = createParserForwardedToRef<Expr, unit> ()
@@ -149,14 +147,20 @@ module private Expressions =
         inferred_type = None }
 
   let literalExpr: Parser<Expr, unit> =
-    pipe3 getPosition Literals.literal getPosition
-    <| fun start lit stop ->
+    withSpan lit
+    |>> fun (lit, span) ->
       { kind = ExprKind.Literal(lit)
-        span = { start = start; stop = stop }
+        span = span
         inferred_type = None }
 
   let atom =
-    choice [ literalExpr; func_expr; ifElse; templateStringLiteral; identExpr ]
+    choice
+      [ literalExpr
+        funcExpr
+        ifElse
+        tupleExpr
+        templateStringLiteral
+        identExpr ]
 
   let term = (atom .>> ws) <|> between (str_ws "(") (str_ws ")") expr
 

--- a/src/Escalier.Parser/Expressions.fs
+++ b/src/Escalier.Parser/Expressions.fs
@@ -5,8 +5,6 @@ open Escalier.Data.Syntax
 open System.Text
 open Shared
 
-exception ParseError of string
-
 module private Expressions =
   let lit = ParserRefs.lit
   let expr = ParserRefs.expr

--- a/src/Escalier.Parser/Literals.fs
+++ b/src/Escalier.Parser/Literals.fs
@@ -4,6 +4,8 @@ open FParsec
 open Escalier.Data.Syntax
 
 module Literals =
+  let lit = ParserRefs.lit
+
   let number: Parser<Literal, unit> =
     pfloat |>> fun nl -> Literal.Number(nl |> string)
 
@@ -29,4 +31,4 @@ module Literals =
     (pstring "true" |>> fun _ -> Literal.Boolean true)
     <|> (pstring "false" |>> fun _ -> Literal.Boolean false)
 
-  let literal = number <|> string <|> boolean
+  ParserRefs.litRef.Value <- number <|> string <|> boolean

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -2,6 +2,8 @@ namespace Escalier.Parser
 
 open FParsec
 
+exception ParseError of string
+
 module Parser =
   let lit = run Literals.lit
   let expr = run Expressions.expr

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -3,6 +3,7 @@ namespace Escalier.Parser
 open FParsec
 
 module Parser =
+  let lit = run Literals.lit
   let expr = run Expressions.expr
   let pattern = run Patterns.pattern
   let stmt = run Statements.stmt

--- a/src/Escalier.Parser/ParserRefs.fs
+++ b/src/Escalier.Parser/ParserRefs.fs
@@ -4,6 +4,7 @@ open FParsec
 open Escalier.Data.Syntax
 
 module private ParserRefs =
+  let lit, litRef = createParserForwardedToRef<Literal, unit> ()
   let expr, exprRef = createParserForwardedToRef<Expr, unit> ()
   let stmt, stmtRef = createParserForwardedToRef<Stmt, unit> ()
   let pattern, patternRef = createParserForwardedToRef<Pattern, unit> ()

--- a/src/Escalier.Parser/Patterns.fs
+++ b/src/Escalier.Parser/Patterns.fs
@@ -2,8 +2,10 @@ namespace Escalier.Parser
 
 open FParsec
 open Escalier.Data.Syntax
+open Shared
 
 module private Patterns =
+  let lit = ParserRefs.lit
   let expr = ParserRefs.expr
   let stmt = ParserRefs.stmt
   let typeAnn = ParserRefs.typeAnn
@@ -35,14 +37,14 @@ module private Patterns =
         inferred_type = None }
 
   let private literalPattern =
-    withSpan Literals.literal
+    withSpan lit
     |>> fun (lit, span) ->
       { Pattern.kind = PatternKind.Literal(span = span, value = lit)
         span = span
         inferred_type = None }
 
   let private tuplePattern =
-    withSpan (between (str_ws "[") (str_ws "]") (sepBy pattern (str_ws ",")))
+    tuple pattern |> withSpan
     |>> fun (patterns, span) ->
       { Pattern.kind = PatternKind.Tuple(patterns)
         span = span

--- a/src/Escalier.Parser/Shared.fs
+++ b/src/Escalier.Parser/Shared.fs
@@ -57,12 +57,12 @@ module Shared =
     (opt_or_id: Parser<TypeAnn, unit> -> Parser<'a, unit>)
     : Parser<FuncSig<'a>, unit> =
     pipe4
-      (opt typeParams)
-      (str_ws "fn" >>. (param_list opt_or_id))
+      (str_ws "fn" >>. (opt typeParams))
+      (param_list opt_or_id)
       (opt_or_id (str_ws "->" >>. typeAnn))
       (opt (ws .>> str_ws "throws" >>. typeAnn))
     <| fun type_params param_list return_type throws ->
-      { param_list = param_list
+      { type_params = type_params
+        param_list = param_list
         return_type = return_type
-        type_params = type_params
         throws = throws }

--- a/src/Escalier.Parser/Shared.fs
+++ b/src/Escalier.Parser/Shared.fs
@@ -1,0 +1,15 @@
+namespace Escalier.Parser
+
+open FParsec
+open Escalier.Data.Syntax
+
+module Shared =
+  let ws = spaces
+  let str_ws s = pstring s .>> ws
+
+  let withSpan p =
+    pipe3 getPosition p getPosition
+    <| fun start value stop -> (value, { start = start; stop = stop })
+
+  let tuple<'a> (parser: Parser<'a, unit>) =
+    between (str_ws "[") (str_ws "]") (sepBy parser (str_ws ","))

--- a/src/Escalier.Parser/Shared.fs
+++ b/src/Escalier.Parser/Shared.fs
@@ -4,6 +4,9 @@ open FParsec
 open Escalier.Data.Syntax
 
 module Shared =
+  let typeAnn = ParserRefs.typeAnn
+  let pattern = ParserRefs.pattern
+
   let ws = spaces
   let str_ws s = pstring s .>> ws
 
@@ -11,5 +14,51 @@ module Shared =
     pipe3 getPosition p getPosition
     <| fun start value stop -> (value, { start = start; stop = stop })
 
+  let ident =
+    let isIdentifierFirstChar c = isLetter c || c = '_'
+    let isIdentifierChar c = isLetter c || isDigit c || c = '_'
+
+    many1Satisfy2L isIdentifierFirstChar isIdentifierChar "identifier" .>> ws // skips trailing whitespace
+
   let tuple<'a> (parser: Parser<'a, unit>) =
     between (str_ws "[") (str_ws "]") (sepBy parser (str_ws ","))
+
+  let type_param: Parser<TypeParam, unit> =
+    withSpan ident
+    |>> fun (name, span) ->
+      { name = name
+        bound = None // TODO: parse type bounds
+        default_ = None // TODO: parse default type
+        span = span }
+
+  let type_params: Parser<list<TypeParam>, unit> =
+    between (str_ws "<") (str_ws ">") (sepBy type_param (str_ws ","))
+
+  let funcParam<'a>
+    (opt_or_id: Parser<TypeAnn, unit> -> Parser<'a, unit>)
+    : Parser<FuncParam<'a>, unit> =
+    pipe2 pattern (opt_or_id (str_ws ":" >>. typeAnn))
+    <| fun pattern typeAnn ->
+      { pattern = pattern
+        typeAnn = typeAnn
+        optional = false // TODO: parse `?` in func params
+      }
+
+  let param_list<'a>
+    (opt_or_id: Parser<TypeAnn, unit> -> Parser<'a, unit>)
+    : Parser<list<FuncParam<'a>>, unit> =
+    between (str_ws "(") (str_ws ")") (sepBy (funcParam opt_or_id) (str_ws ","))
+
+  let func_sig<'a>
+    (opt_or_id: Parser<TypeAnn, unit> -> Parser<'a, unit>)
+    : Parser<FuncSig<'a>, unit> =
+    pipe4
+      (opt type_params)
+      (str_ws "fn" >>. (param_list opt_or_id))
+      (opt_or_id (str_ws "->" >>. typeAnn))
+      (opt (ws .>> str_ws "throws" >>. typeAnn))
+    <| fun type_params param_list return_type throws ->
+      { param_list = param_list
+        return_type = return_type
+        type_params = type_params
+        throws = throws }

--- a/src/Escalier.Parser/TypeAnnotations.fs
+++ b/src/Escalier.Parser/TypeAnnotations.fs
@@ -53,6 +53,13 @@ module private TypeAnnotations =
         span = span
         inferred_type = None }
 
+  let private funcTypeAnn =
+    func_sig id |> withSpan
+    |>> fun (f, span) ->
+      { TypeAnn.kind = TypeAnnKind.Function(f)
+        span = span
+        inferred_type = None }
+
   let private keyofTypeAnn =
     withSpan (str_ws "keyof" >>. typeAnn)
     |>> fun (typeAnn, span) ->
@@ -116,6 +123,7 @@ module private TypeAnnotations =
         keywordTypeAnn // aka PredefinedType
         // TODO: objectTypeAnn
         tupleTypeAnn
+        funcTypeAnn
         typeofTypeAnn // aka TypeQuery
         keyofTypeAnn
         restTypeAnn

--- a/src/Escalier.Parser/TypeAnnotations.fs
+++ b/src/Escalier.Parser/TypeAnnotations.fs
@@ -121,12 +121,12 @@ module private TypeAnnotations =
       [ litTypeAnn
         parenthesizedTypeAnn
         keywordTypeAnn // aka PredefinedType
-        // TODO: objectTypeAnn
         tupleTypeAnn
         funcTypeAnn
         typeofTypeAnn // aka TypeQuery
         keyofTypeAnn
         restTypeAnn
+        // TODO: objectTypeAnn
         // TODO: thisTypeAnn
         // NOTE: should come last since any identifier can be a type reference
         typeRef ]
@@ -156,5 +156,4 @@ module private TypeAnnotations =
           span = span
           inferred_type = None }
 
-  // TODO: handle function types
   ParserRefs.typeAnnRef.Value <- unionOrIntersectionOrPrimaryType

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -249,8 +249,8 @@ let InferTypeDecls () =
           type A = number
           type B = [string, boolean]
           type C = 5 | "hello"
+          type D = fn (x: number) -> number
           """
-      // type D = fn (x: number) -> number
 
       let! env = infer_script src
 
@@ -260,8 +260,8 @@ let InferTypeDecls () =
       Assert.Equal("[string, boolean]", b.type_.ToString())
       let c = Map.find "C" env.schemes
       Assert.Equal("5 | \"hello\"", c.type_.ToString())
-    // let d = Map.find "D" env.schemes
-    // Assert.Equal("fn (x: number) -> number", d.type_.ToString())
+      let d = Map.find "D" env.schemes
+      Assert.Equal("fn (x: number) -> number", d.type_.ToString())
     }
 
   Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -185,7 +185,7 @@ module rec Infer =
                   optional = false }
             })
 
-          f.param_list
+          f.sig'.param_list
 
       // NOTE: infer_block returns a value to help with other uses
       // such as if-else and match expressions.
@@ -309,7 +309,7 @@ module rec Infer =
                       type_ = t
                       optional = false }
                 })
-              functionType.params_
+              functionType.param_list
 
           let f =
             { param_list = param_list

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -28,11 +28,18 @@ module TypeVariable =
 
 module rec Infer =
   type Binding = Type * bool
-  type Assump = Map<string, Binding>
+  type BindingAssump = Map<string, Binding>
+  type SchemeAssump = (string * Scheme)
 
   type Env =
-    { types: Map<string, Type>
-      values: Map<string, Binding> }
+    { schemes: Map<string, Scheme>
+      values: Map<string, Binding>
+      isAsync: bool
+      nonGeneric: Set<Type> }
+
+  // type Env =
+  //   { types: Map<string, Type>
+  //     values: Map<string, Binding> }
 
   let infer_expr (env: Env) (e: Expr) : Result<Type, TypeError> =
     let provenance = Some(Provenance.Expr(e))
@@ -225,12 +232,7 @@ module rec Infer =
         | TypeAnnKind.Array elem ->
           let! elem = infer_type_ann env elem
           return TypeKind.Array(elem)
-        | TypeAnnKind.BooleanLiteral value ->
-          return TypeKind.Literal(Literal.Boolean value)
-        | TypeAnnKind.NumberLiteral value ->
-          return TypeKind.Literal(Literal.Number value)
-        | TypeAnnKind.StringLiteral value ->
-          return TypeKind.Literal(Literal.String value)
+        | TypeAnnKind.Literal lit -> return TypeKind.Literal(lit)
         | TypeAnnKind.Keyword keyword ->
           match keyword with
           | KeywordTypeAnn.Boolean ->
@@ -358,13 +360,17 @@ module rec Infer =
       result {
         for stmt in block.stmts do
           match! infer_stmt env' stmt with
-          | Some(assump) ->
+          | Some(StmtResult.Bindings(assump)) ->
             let mutable values = env'.values
 
             for KeyValue(name, binding) in assump do
               values <- values.Add(name, binding)
 
             env' <- { env' with values = values }
+          | Some(StmtResult.Scheme(name, scheme)) ->
+            env' <-
+              { env' with
+                  schemes = env'.schemes.Add(name, scheme) }
           | None -> ()
 
         let last = List.last block.stmts
@@ -381,7 +387,11 @@ module rec Infer =
       }
     | BlockOrExpr.Expr e -> infer_expr env e
 
-  let infer_stmt (env: Env) (s: Stmt) : Result<option<Assump>, TypeError> =
+  type StmtResult =
+    | Bindings of BindingAssump
+    | Scheme of SchemeAssump
+
+  let infer_stmt (env: Env) (s: Stmt) : Result<option<StmtResult>, TypeError> =
     result {
       match s.kind with
       | StmtKind.Expr e ->
@@ -389,7 +399,15 @@ module rec Infer =
         return None
       | StmtKind.Decl(decl) ->
         match decl.kind with
-        | DeclKind.TypeDecl(name, type_ann, type_params) -> return None
+        | DeclKind.TypeDecl(name, type_ann, type_params) ->
+          let! t = infer_type_ann env type_ann
+
+          let scheme: Scheme =
+            { type_params = []
+              type_ = t
+              is_type_param = false }
+
+          return Some(StmtResult.Scheme(name, scheme))
         | DeclKind.VarDecl(pattern, init, type_ann, is_declare) ->
           let! pat_bindings, pat_type = infer_pattern env pattern
 
@@ -401,7 +419,7 @@ module rec Infer =
             | Some(type_ann) -> return! Error(NotImplemented)
             | None ->
               do! unify init_type pat_type
-              return Some(pat_bindings)
+              return Some(StmtResult.Bindings(pat_bindings))
           | None -> return! Error(NotImplemented)
       | StmtKind.Return e ->
         match e with
@@ -414,12 +432,11 @@ module rec Infer =
 
   let infer_pattern
     (env: Env)
-    (pat: Escalier.Data.Syntax.Pattern)
-    : Result<(Assump * Type), TypeError> =
-    let mutable assump = Assump([])
-    let rec foo x = x
+    (pat: Syntax.Pattern)
+    : Result<(BindingAssump * Type), TypeError> =
+    let mutable assump = BindingAssump([])
 
-    let rec infer_pattern_rec (pat: Escalier.Data.Syntax.Pattern) : Type =
+    let rec infer_pattern_rec (pat: Syntax.Pattern) : Type =
       match pat.kind with
       | PatternKind.Identifier({ name = name; isMut = isMut }) ->
         let t =
@@ -449,10 +466,10 @@ module rec Infer =
         { Type.kind = TypeKind.Wildcard
           provenance = None }
       | PatternKind.Is(span, binding, isName, isMut) ->
-        match Map.tryFind isName env.types with
-        | Some(t) ->
-          assump <- assump.Add(binding.name, (t, binding.isMut))
-          t
+        match Map.tryFind isName env.schemes with
+        | Some(scheme) ->
+          assump <- assump.Add(binding.name, (scheme.type_, binding.isMut))
+          scheme.type_
         | None -> failwith "todo"
 
     let t = infer_pattern_rec pat
@@ -464,19 +481,23 @@ module rec Infer =
     result {
       for stmt in script do
         match! infer_stmt env' stmt with
-        | Some(assump) ->
+        | Some(StmtResult.Bindings(assump)) ->
           let mutable values = env'.values
 
           for KeyValue(name, binding) in assump do
             values <- values.Add(name, binding)
 
           env' <- { env' with values = values }
+        | Some(StmtResult.Scheme(name, scheme)) ->
+          env' <-
+            { env' with
+                schemes = env'.schemes.Add(name, scheme) }
         | None -> ()
 
       return env'
     }
 
-  let rec pattern_to_pattern (pat: Escalier.Data.Syntax.Pattern) : Pattern =
+  let rec pattern_to_pattern (pat: Syntax.Pattern) : Pattern =
     match pat.kind with
     | PatternKind.Identifier({ name = name; isMut = isMut }) ->
       Pattern.Identifier(name)


### PR DESCRIPTION
- Parse and infer type decls
- Extract 'tuple' parser
- Rework TypeAnnKind to have a single literal variant
- Factor out FuncSig from Function and FunctionType in syntax tree
- make funcSig and associated combinators generic
- parse throws clause and type params