### PR TITLE
SKK test case

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -143,7 +143,7 @@ module Syntax =
       mutable throws: option<Type.Type> }
 
   type ExprKind =
-    | Identifer of string
+    | Identifier of string
     | Literal of Literal
     | Object of elems: list<ObjElem>
     | Tuple of elems: list<Expr>

--- a/src/Escalier.Data/Visitor.fs
+++ b/src/Escalier.Data/Visitor.fs
@@ -85,7 +85,7 @@ module Visitor =
       | ExprKind.Assign(left, _op, right) ->
         this.VisitExpr left
         this.VisitExpr right
-      | ExprKind.Identifer _ -> ()
+      | ExprKind.Identifier _ -> ()
       | ExprKind.Literal _ -> ()
       | ExprKind.Object elems ->
         List.iter

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: foo()[0]
-output: Success: { kind = Index ({ kind = Call { callee = { kind = Identifer "foo"
+output: Success: { kind = Index ({ kind = Call { callee = { kind = Identifier "foo"
                                            span = { start = (Ln: 1, Col: 1)
                                                     stop = (Ln: 1, Col: 4) }
                                            inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: add()
-output: Success: { kind = Call { callee = { kind = Identifer "add"
+output: Success: { kind = Call { callee = { kind = Identifier "add"
                            span = { start = (Ln: 1, Col: 1)
                                     stop = (Ln: 1, Col: 4) }
                            inferred_type = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
@@ -29,7 +29,7 @@ output: Success: { kind =
                          stop = (Ln: 1, Col: 16) }
                 stmts = [{ span = { start = (Ln: 1, Col: 13)
                                     stop = (Ln: 1, Col: 15) }
-                           kind = Expr { kind = Identifer "x"
+                           kind = Expr { kind = Identifier "x"
                                          span = { start = (Ln: 1, Col: 13)
                                                   stop = (Ln: 1, Col: 15) }
                                          inferred_type = None } }] } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
@@ -37,7 +37,7 @@ output: Success: { kind =
                          stop = (Ln: 1, Col: 35) }
                 stmts = [{ span = { start = (Ln: 1, Col: 32)
                                     stop = (Ln: 1, Col: 34) }
-                           kind = Expr { kind = Identifer "x"
+                           kind = Expr { kind = Identifier "x"
                                          span = { start = (Ln: 1, Col: 32)
                                                   stop = (Ln: 1, Col: 34) }
                                          inferred_type = None } }] } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypes.verified.txt
@@ -29,7 +29,7 @@ output: Success: { kind =
                          stop = (Ln: 1, Col: 51) }
                 stmts = [{ span = { start = (Ln: 1, Col: 48)
                                     stop = (Ln: 1, Col: 50) }
-                           kind = Expr { kind = Identifer "x"
+                           kind = Expr { kind = Identifier "x"
                                          span = { start = (Ln: 1, Col: 48)
                                                   stop = (Ln: 1, Col: 50) }
                                          inferred_type = None } }] } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
@@ -1,14 +1,14 @@
 ﻿input: add(x, y)
 output: Success: { kind =
-   Call { callee = { kind = Identifer "add"
+   Call { callee = { kind = Identifier "add"
                      span = { start = (Ln: 1, Col: 1)
                               stop = (Ln: 1, Col: 4) }
                      inferred_type = None }
           typeArgs = None
-          args = [{ kind = Identifer "x"
+          args = [{ kind = Identifier "x"
                     span = { start = (Ln: 1, Col: 5)
                              stop = (Ln: 1, Col: 6) }
-                    inferred_type = None }; { kind = Identifer "y"
+                    inferred_type = None }; { kind = Identifier "y"
                                               span = { start = (Ln: 1, Col: 8)
                                                        stop = (Ln: 1, Col: 9) }
                                               inferred_type = None }]

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
@@ -1,14 +1,14 @@
 ﻿input: add( x , y )
 output: Success: { kind =
-   Call { callee = { kind = Identifer "add"
+   Call { callee = { kind = Identifier "add"
                      span = { start = (Ln: 1, Col: 1)
                               stop = (Ln: 1, Col: 4) }
                      inferred_type = None }
           typeArgs = None
-          args = [{ kind = Identifer "x"
+          args = [{ kind = Identifier "x"
                     span = { start = (Ln: 1, Col: 6)
                              stop = (Ln: 1, Col: 8) }
-                    inferred_type = None }; { kind = Identifer "y"
+                    inferred_type = None }; { kind = Identifier "y"
                                               span = { start = (Ln: 1, Col: 10)
                                                        stop = (Ln: 1, Col: 12) }
                                               inferred_type = None }]

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: array[0]
-output: Success: { kind = Index ({ kind = Identifer "array"
+output: Success: { kind = Index ({ kind = Identifier "array"
                   span = { start = (Ln: 1, Col: 1)
                            stop = (Ln: 1, Col: 6) }
                   inferred_type = None }, { kind = Literal (Number "0")

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
@@ -3,7 +3,7 @@ output: Success: { kind =
    Call
      { callee =
         { kind =
-           Index ({ kind = Identifer "array"
+           Index ({ kind = Identifier "array"
                     span = { start = (Ln: 1, Col: 1)
                              stop = (Ln: 1, Col: 6) }
                     inferred_type = None }, { kind = Literal (Number "0")

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: msg = "Hello,\n\t\"world!\"" 
 output: Success: { kind =
    Assign
-     ({ kind = Identifer "msg"
+     ({ kind = Identifier "msg"
         span = { start = (Ln: 1, Col: 1)
                  stop = (Ln: 1, Col: 5) }
         inferred_type = None }, Assign,

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: msg = `foo ${`bar ${baz}`}`
 output: Success: { kind =
    Assign
-     ({ kind = Identifer "msg"
+     ({ kind = Identifier "msg"
         span = { start = (Ln: 1, Col: 1)
                  stop = (Ln: 1, Col: 5) }
         inferred_type = None }, Assign,
@@ -12,7 +12,7 @@ output: Success: { kind =
               [{ kind =
                   TemplateLiteral
                     { parts = ["bar "; ""]
-                      exprs = [{ kind = Identifer "baz"
+                      exprs = [{ kind = Identifier "baz"
                                  span = { start = (Ln: 1, Col: 21)
                                           stop = (Ln: 1, Col: 24) }
                                  inferred_type = None }] }

--- a/src/Escalier.Parser/Expressions.fs
+++ b/src/Escalier.Parser/Expressions.fs
@@ -25,7 +25,7 @@ module private Expressions =
   let identExpr: Parser<Expr, unit> =
     withSpan ident
     |>> fun (sl, span) ->
-      { kind = Identifer(sl)
+      { kind = Identifier(sl)
         span = span
         inferred_type = None }
 
@@ -83,7 +83,10 @@ module private Expressions =
     |>> fun (stmts, span) -> BlockOrExpr.Block({ span = span; stmts = stmts })
 
   let func: Parser<Function, unit> =
-    pipe2 (func_sig opt) block <| fun sig' body -> { sig' = sig'; body = body }
+    pipe2
+      (func_sig opt)
+      (block <|> (str_ws "=>" >>. expr |>> fun e -> BlockOrExpr.Expr(e)))
+    <| fun sig' body -> { sig' = sig'; body = body }
 
   let funcExpr: Parser<Expr, unit> =
     withSpan func

--- a/src/Escalier.Parser/Library.fs
+++ b/src/Escalier.Parser/Library.fs
@@ -22,7 +22,7 @@ module Say =
   let stop = Position("source.esc", 5, 0, 5)
 
   let expr: Expr =
-    { kind = Identifer("foo")
+    { kind = Identifier("foo")
       span = { start = start; stop = stop }
       inferred_type = Some(t) }
 

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -327,6 +327,7 @@ let InferLambda () =
 
   Assert.False(Result.isError result)
 
+// TODO: fix this test
 [<Fact>]
 let InferSKK () =
   let result =
@@ -340,7 +341,6 @@ let InferSKK () =
 
       let! env = infer_script src
 
-      // TODO: fix this
       Assert.Value(
         env,
         "S",
@@ -348,7 +348,7 @@ let InferSKK () =
       )
 
       Assert.Value(env, "K", "fn <A, B>(x: A) -> fn (y: B) -> A")
-      // TODO: fix this
+      // This should be `fn <A>(x: A) -> A`
       Assert.Value(env, "I", "fn <A, B>(x: A) -> B")
     }
 

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -1,0 +1,14 @@
+namespace Escalier.TypeChecker
+
+open Escalier.Data.Type
+
+module Env =
+  type Binding = Type * bool
+  type BindingAssump = Map<string, Binding>
+  type SchemeAssump = (string * Scheme)
+
+  type Env =
+    { schemes: Map<string, Scheme>
+      values: Map<string, Binding>
+      isAsync: bool
+      nonGeneric: Set<int> }

--- a/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
+++ b/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="Errors.fs"/>
+        <Compile Include="Env.fs"/>
         <Compile Include="TypeVariable.fs"/>
         <Compile Include="Unify.fs"/>
         <Compile Include="Infer.fs"/>

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -4,29 +4,22 @@ open FsToolkit.ErrorHandling
 open Escalier.Data.Syntax
 open Escalier.Data.Type
 open Escalier.Data
-open Escalier.TypeChecker.Errors
-open Escalier.TypeChecker.Unify
+
+open Env
+open Errors
+open Unify
 
 module rec Infer =
-  type Binding = Type * bool
-  type BindingAssump = Map<string, Binding>
-  type SchemeAssump = (string * Scheme)
-
-  type Env =
-    { schemes: Map<string, Scheme>
-      values: Map<string, Binding>
-      isAsync: bool
-      nonGeneric: Set<Type> }
-
   let infer_expr (env: Env) (e: Expr) : Result<Type, TypeError> =
     let provenance = Some(Provenance.Expr(e))
 
     let kind =
       result {
         match e.kind with
-        | ExprKind.Identifer name ->
+        | ExprKind.Identifier name ->
           match Map.tryFind name env.values with
-          | Some((t, _)) -> return t.kind // How do we link back to the variable declaration?
+          | Some((t, _)) ->
+            return (fresh env t).kind // How do we link back to the variable declaration?
           | None -> return! Error(NotImplemented)
         | ExprKind.Literal lit -> return TypeKind.Literal(lit)
         | ExprKind.Object elems -> return! Error(NotImplemented)
@@ -156,16 +149,21 @@ module rec Infer =
               let! type_ann_t =
                 match p.typeAnn with
                 | Some(typeAnn) -> infer_type_ann env typeAnn
-                | None -> Result.Ok(TypeVariable.fresh None)
+                | None -> Result.Ok(TypeVariable.new_type_var None)
 
               let! assumps, param_t = infer_pattern env p.pattern
 
               do! unify param_t type_ann_t
 
               for KeyValue(name, binding) in assumps do
+                let nonGeneric =
+                  match fst(binding).kind with
+                  | TypeVar { id = id } -> env.nonGeneric.Add(id)
+                  | _ -> env.nonGeneric
+
                 env <-
                   { env with
-                      nonGeneric = env.nonGeneric.Add(fst (binding))
+                      nonGeneric = nonGeneric
                       values = env.values.Add(name, binding) }
 
               return
@@ -180,22 +178,27 @@ module rec Infer =
       // such as if-else and match expressions.
       let! _ = infer_block env f.body
 
-      let returns = findReturns f.body
-
       let return_type =
-        match returns with
-        | [] ->
-          { kind = TypeKind.Keyword(KeywordType.Never)
-            provenance = None }
-        | [ ret ] ->
-          match ret.inferred_type with
+        match f.body with
+        | BlockOrExpr.Block(block) ->
+          match findReturns block with
+          | [] ->
+            { kind = TypeKind.Keyword(KeywordType.Never)
+              provenance = None }
+          | [ ret ] ->
+            match ret.inferred_type with
+            | Some(t) -> t
+            | None -> failwith "todo"
+          | many ->
+            let types = many |> List.choose (fun (r: Expr) -> r.inferred_type)
+
+            { kind = TypeKind.Union(types)
+              provenance = None }
+        | BlockOrExpr.Expr(expr) ->
+          match expr.inferred_type with
           | Some(t) -> t
           | None -> failwith "todo"
-        | many ->
-          let types = many |> List.choose (fun (r: Expr) -> r.inferred_type)
 
-          { kind = TypeKind.Union(types)
-            provenance = None }
 
       let never =
         { kind = TypeKind.Keyword(KeywordType.Never)
@@ -567,12 +570,10 @@ module rec Infer =
         | None -> ()
       | _ -> base.VisitStmt(stmt)
 
-  let findReturns (block: BlockOrExpr) : Expr list =
+  let findReturns (block: Block) : Expr list =
     let visitor = ReturnVisitor()
 
-    match block with
-    | BlockOrExpr.Block b -> visitor.VisitBlock(b)
-    | BlockOrExpr.Expr e -> visitor.VisitExpr(e)
+    visitor.VisitBlock(block)
 
     visitor.ReturnValues
 
@@ -589,8 +590,8 @@ module rec Infer =
           match Map.tryFind id mapping with
           | Some(name) -> name
           | None ->
-            let name = 65 + mapping.Count |> char |> string
-            mapping <- Map.add id name mapping
+            let name = 65 + mapping.Count |> char |> stringmapping <-
+              Map.add id name mapping
             name
 
         { Type.kind =
@@ -633,6 +634,29 @@ module rec Infer =
         type_params = if type_params.IsEmpty then None else Some(type_params)
         param_list = param_list
         return_type = return_type }
+
+  let fresh (env: Env) (t: Type) =
+    let mutable mapping: Map<int, Type> = Map.empty
+
+    let foldFn (t: Type) : Type =
+      match (prune t).kind with
+      | TypeVar { id = id } ->
+        if env.nonGeneric.Contains(id) then
+          t
+        else
+          match Map.tryFind id mapping with
+          | None ->
+            let new_var = TypeVariable.new_type_var None
+            mapping <- Map.add id new_var mapping
+            new_var
+          | Some(var) -> var
+      | _ -> t
+
+    // TODO: Fix TypeFolder so that we don't get new type variables
+    // let folder = Folder.TypeFolder(foldFn)
+    // folder.FoldType(t)
+
+    t
 
 // TODO: infer_module
 // These will allow us to more thoroughly test infer_stmt and infer_pattern

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -18,8 +18,7 @@ module rec Infer =
         match e.kind with
         | ExprKind.Identifier name ->
           match Map.tryFind name env.values with
-          | Some((t, _)) ->
-            return (fresh env t).kind // How do we link back to the variable declaration?
+          | Some((t, _)) -> return (fresh env t).kind // How do we link back to the variable declaration?
           | None -> return! Error(NotImplemented)
         | ExprKind.Literal lit -> return TypeKind.Literal(lit)
         | ExprKind.Object elems -> return! Error(NotImplemented)
@@ -590,8 +589,8 @@ module rec Infer =
           match Map.tryFind id mapping with
           | Some(name) -> name
           | None ->
-            let name = 65 + mapping.Count |> char |> stringmapping <-
-              Map.add id name mapping
+            let name = 65 + mapping.Count |> char |> string
+            mapping <- Map.add id name mapping
             name
 
         { Type.kind =

--- a/src/Escalier.TypeChecker/TypeVariable.fs
+++ b/src/Escalier.TypeChecker/TypeVariable.fs
@@ -7,7 +7,8 @@ module TypeVariable =
 
   let reset () = next_id <- 0
 
-  let fresh (bound: option<Type>) =
+  // TODO: remove `env` as a param
+  let new_type_var (bound: option<Type>) =
     let t =
       { Type.kind =
           TypeKind.TypeVar(

--- a/src/Escalier/Program.fs
+++ b/src/Escalier/Program.fs
@@ -129,3 +129,5 @@ if (true) {
 """
 
 test' Parser.script src
+
+test' Parser.expr "fn (x, y) => x + y"


### PR DESCRIPTION
I = S(K)(K) is a common test case used to verify that type inference is working correctly.  We need to get this working before proceding further.  The test is currently broken but I'm not sure what's causing the issue.  I'm going to merge this and then take a detour to port an existing OCaml implementation of Hindley-Milner to F# and see if that sheds any light on the issue.