### PR TITLE
Replace uses of chainl1 in the Parser

### DIFF
--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -91,6 +91,14 @@ let ParseIndexer () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseMultipleIndexers () =
+  let src = "array[0][1]"
+  let expr = expr src
+  let result = $"input: %s{src}\noutput: %A{expr}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
 let ParseIndexerThenCall () =
   let src = "array[0]()"
   let expr = expr src

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
@@ -8,11 +8,11 @@ output: Success: { Kind = Index ({ Kind = Call { Callee = { Kind = Identifier "f
                                 OptChain = false
                                 Throws = None }
                   Span = { Start = (Ln: 1, Col: 1)
-                           Stop = (Ln: 1, Col: 5) }
+                           Stop = (Ln: 1, Col: 6) }
                   InferredType = None }, { Kind = Literal (Number "0")
                                            Span = { Start = (Ln: 1, Col: 7)
                                                     Stop = (Ln: 1, Col: 8) }
                                            InferredType = None }, false)
   Span = { Start = (Ln: 1, Col: 1)
-           Stop = (Ln: 1, Col: 7) }
+           Stop = (Ln: 1, Col: 9) }
   InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
@@ -8,5 +8,5 @@ output: Success: { Kind = Call { Callee = { Kind = Identifier "add"
                 OptChain = false
                 Throws = None }
   Span = { Start = (Ln: 1, Col: 1)
-           Stop = (Ln: 1, Col: 5) }
+           Stop = (Ln: 1, Col: 6) }
   InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
@@ -15,5 +15,5 @@ output: Success: { Kind =
           OptChain = false
           Throws = None }
   Span = { Start = (Ln: 1, Col: 1)
-           Stop = (Ln: 1, Col: 5) }
+           Stop = (Ln: 1, Col: 10) }
   InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
@@ -15,5 +15,5 @@ output: Success: { Kind =
           OptChain = false
           Throws = None }
   Span = { Start = (Ln: 1, Col: 1)
-           Stop = (Ln: 1, Col: 5) }
+           Stop = (Ln: 1, Col: 13) }
   InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
@@ -7,5 +7,5 @@ output: Success: { Kind = Index ({ Kind = Identifier "array"
                                                     Stop = (Ln: 1, Col: 8) }
                                            InferredType = None }, false)
   Span = { Start = (Ln: 1, Col: 1)
-           Stop = (Ln: 1, Col: 7) }
+           Stop = (Ln: 1, Col: 9) }
   InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
@@ -11,12 +11,12 @@ output: Success: { Kind =
                                                       Stop = (Ln: 1, Col: 8) }
                                              InferredType = None }, false)
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 7) }
+                   Stop = (Ln: 1, Col: 9) }
           InferredType = None }
        TypeArgs = None
        Args = []
        OptChain = false
        Throws = None }
   Span = { Start = (Ln: 1, Col: 1)
-           Stop = (Ln: 1, Col: 10) }
+           Stop = (Ln: 1, Col: 11) }
   InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMultipleIndexers.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMultipleIndexers.verified.txt
@@ -1,0 +1,20 @@
+﻿input: array[0][1]
+output: Success: { Kind =
+   Index
+     ({ Kind =
+         Index ({ Kind = Identifier "array"
+                  Span = { Start = (Ln: 1, Col: 1)
+                           Stop = (Ln: 1, Col: 6) }
+                  InferredType = None }, { Kind = Literal (Number "0")
+                                           Span = { Start = (Ln: 1, Col: 7)
+                                                    Stop = (Ln: 1, Col: 8) }
+                                           InferredType = None }, false)
+        Span = { Start = (Ln: 1, Col: 1)
+                 Stop = (Ln: 1, Col: 9) }
+        InferredType = None }, { Kind = Literal (Number "1")
+                                 Span = { Start = (Ln: 1, Col: 10)
+                                          Stop = (Ln: 1, Col: 11) }
+                                 InferredType = None }, false)
+  Span = { Start = (Ln: 1, Col: 1)
+           Stop = (Ln: 1, Col: 12) }
+  InferredType = None }


### PR DESCRIPTION
`chainl1` only works for left recursion that looks like `p (op p)*`, but function calls and array indexing don't look like.  This PR replaces `chainl1` with a simple `pipe2` that checks for zero or more suffixes.  Each suffix parser produces a function `Expr -> Expr` that is used to wrap the preceding expression in a new expression depending on the suffix that was detected.