### PR TITLE
Move Pat's TypeAnn field to the pattern's parent node

### DIFF
--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsBasics.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsBasics.verified.txt
@@ -7,4 +7,4 @@ export type Point = {
   x: number;
   y: number;
 };
-export declare const add: (a: number, b: number) => number;
+export declare const add;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsGeneric.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsGeneric.verified.txt
@@ -2,4 +2,4 @@
         let fst = fn (a, b) => a
         
 output:
-export declare const fst: <A, B>(a: A, b: B) => A;
+export declare const fst;

--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -92,9 +92,9 @@ module rec Codegen =
             [ { Id =
                   Pat.Ident
                     { Id = { Name = tempId; Loc = None }
-                      TypeAnn = None
                       Optional = false
                       Loc = None }
+                TypeAnn = None
                 Init = None } ]
           Declare = false
           Kind = VariableDeclarationKind.Var }
@@ -109,11 +109,14 @@ module rec Codegen =
     | ExprKind.Function { Sig = s; Body = body } ->
       match body with
       | BlockOrExpr.Block block ->
-        let ps =
+        let ps: list<Param> =
           s.ParamList
           |> List.map (fun (p: FuncParam<TypeAnn option>) ->
             let pat = buildPattern ctx p.Pattern
-            { Pat = pat; Loc = None })
+
+            { Pat = pat
+              TypeAnn = None
+              Loc = None })
 
         let body = buildBlock ctx block Finalizer.Empty
 
@@ -151,9 +154,9 @@ module rec Codegen =
             [ { Id =
                   Pat.Ident
                     { Id = { Name = tempId; Loc = None }
-                      TypeAnn = None
                       Optional = false
                       Loc = None }
+                TypeAnn = None
                 Init = None } ]
           Declare = false
           Kind = VariableDeclarationKind.Var }
@@ -210,7 +213,10 @@ module rec Codegen =
             let initExpr, initStmts = buildExpr ctx init
 
             let decl =
-              { Decls = [ { Id = pattern; Init = Some initExpr } ]
+              { Decls =
+                  [ { Id = pattern
+                      TypeAnn = None
+                      Init = Some initExpr } ]
                 Declare = false
                 Kind = VariableDeclarationKind.Var }
 
@@ -254,7 +260,6 @@ module rec Codegen =
     | PatternKind.Identifier id ->
       Pat.Ident
         { Id = { Name = id.Name; Loc = None }
-          TypeAnn = None
           Optional = false
           Loc = None }
     | _ -> failwith "TODO"
@@ -300,9 +305,9 @@ module rec Codegen =
               { Id =
                   Pat.Ident
                     { Id = { Name = n; Loc = None }
-                      TypeAnn = Some(buildTypeAnn ctx t)
                       Optional = false
                       Loc = None }
+                TypeAnn = Some(buildTypeAnn ctx t)
                 Init = None }
 
             let varDecl =
@@ -344,18 +349,22 @@ module rec Codegen =
           TypeParams = typeArgs
           Loc = None }
     | TypeKind.Function f ->
-      let ps =
+      let ps: list<TsFnParam> =
         f.ParamList
         |> List.map (fun p ->
           let t = buildTypeAnn ctx p.Type
 
           match p.Pattern with
           | Pattern.Identifier name ->
-            TsFnParam.Ident
-              { Id = { Name = name; Loc = None }
-                TypeAnn = Some(t)
-                Optional = false
-                Loc = None }
+            let pat =
+              TsFnParamPat.Ident
+                { Id = { Name = name; Loc = None }
+                  Optional = false
+                  Loc = None }
+
+            { Pat = pat
+              TypeAnn = Some(t)
+              Loc = None }
           | Pattern.Object _ -> failwith "TODO"
           | Pattern.Tuple _ -> failwith "TODO"
           | Pattern.Rest _ -> failwith "TODO"

--- a/src/Escalier.Codegen/Printer.fs
+++ b/src/Escalier.Codegen/Printer.fs
@@ -449,7 +449,7 @@ module rec Printer =
                    Kind = kind } ->
         let decls =
           List.map
-            (fun { Id = id; Init = init } ->
+            (fun { VarDeclarator.Id = id; Init = init } ->
               let id = printPattern ctx id
 
               match init with
@@ -471,12 +471,7 @@ module rec Printer =
   let printPattern (ctx: PrintCtx) (p: Pat) : string =
 
     match p with
-    | Pat.Ident { Id = id; TypeAnn = typeAnn } ->
-      match typeAnn with
-      | Some(typeAnn) ->
-        let t = printTypeAnn ctx typeAnn
-        $"{id.Name}: {t}"
-      | None -> id.Name
+    | Pat.Ident { Id = id } -> id.Name
     | _ -> failwith "TODO"
 
   let printBlock (ctx: PrintCtx) (block: BlockStmt) =
@@ -886,16 +881,18 @@ module rec Printer =
       | false, false -> $"[{ps}]: {typeAnn}"
 
   let printTsFnParam (ctx: PrintCtx) (param: TsFnParam) : string =
-    match param with
-    | TsFnParam.Ident { Id = { Name = name }
-                        TypeAnn = typeAnn } ->
-      match typeAnn with
-      | Some({ TypeAnn = t }) -> $"{name}: {printType ctx t}"
-      | None -> name
+    let pat =
+      match param.Pat with
+      | TsFnParamPat.Ident id -> id.Id.Name
+      | TsFnParamPat.Array arrayPat ->
+        failwith "TODO: printTsFnParam - arrayPat"
+      | TsFnParamPat.Rest restPat -> failwith "TODO: printTsFnParam - restPat"
+      | TsFnParamPat.Object objectPat ->
+        failwith "TODO: printTsFnParam - objectPat"
 
-    | TsFnParam.Array arrayPat -> failwith "TODO: printTsFnParam - arrayPat"
-    | TsFnParam.Rest restPat -> failwith "TODO: printTsFnParam - restPat"
-    | TsFnParam.Object objectPat -> failwith "TODO: printTsFnParam - objectPat"
+    match param.TypeAnn with
+    | Some(typeAnn) -> $"{pat}: {printTypeAnn ctx typeAnn}"
+    | None -> pat
 
   let printTsTypeParam (ctx: PrintCtx) (typeParam: TsTypeParam) : string =
     let c =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseBasicVarDecls.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseBasicVarDecls.verified.txt
@@ -9,62 +9,17 @@ output: Success: { Body =
       (Decl
          (Var
             { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "a"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsTypeRef { Loc = None
-                                         TypeName = Identifier { Name = "A"
-                                                                 Loc = None }
-                                         TypeParams = None }
-                            Loc = None }
-                       Optional = false
-                       Loc = None }
-                  Init = None }]
-              Declare = true
-              Kind = Var }));
-    Stmt
-      (Decl
-         (Var
-            { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "b"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsTypeRef
-                               { Loc = None
-                                 TypeName =
-                                  TsQualifiedName
-                                    { Left = Identifier { Name = "B"
-                                                          Loc = None }
-                                      Right = { Name = "C"
-                                                Loc = None } }
-                                 TypeParams = None }
-                            Loc = None }
-                       Optional = false
-                       Loc = None }
-                  Init = None }]
-              Declare = true
-              Kind = Var }));
-    Stmt
-      (Decl
-         (Var
-            { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "c"
-                              Loc = None }
-                       TypeAnn =
-                        Some { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
-                                                         Loc = None }
+               [{ Id = Ident { Id = { Name = "a"
+                                      Loc = None }
+                               Optional = false
                                Loc = None }
-                       Optional = false
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsTypeRef { Loc = None
+                                    TypeName = Identifier { Name = "A"
+                                                            Loc = None }
+                                    TypeParams = None }
                        Loc = None }
                   Init = None }]
               Declare = true
@@ -73,23 +28,59 @@ output: Success: { Body =
       (Decl
          (Var
             { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "d"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsUnionOrIntersectionType
-                               (TsUnionType
-                                  { Types =
-                                     [TsKeywordType { Kind = TsStringKeyword
-                                                      Loc = None };
-                                      TsKeywordType { Kind = TsBooleanKeyword
-                                                      Loc = None }]
-                                    Loc = None })
-                            Loc = None }
-                       Optional = false
+               [{ Id = Ident { Id = { Name = "b"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsTypeRef
+                          { Loc = None
+                            TypeName =
+                             TsQualifiedName { Left = Identifier { Name = "B"
+                                                                   Loc = None }
+                                               Right = { Name = "C"
+                                                         Loc = None } }
+                            TypeParams = None }
+                       Loc = None }
+                  Init = None }]
+              Declare = true
+              Kind = Var }));
+    Stmt
+      (Decl
+         (Var
+            { Decls =
+               [{ Id = Ident { Id = { Name = "c"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
+                                                    Loc = None }
+                          Loc = None }
+                  Init = None }]
+              Declare = true
+              Kind = Var }));
+    Stmt
+      (Decl
+         (Var
+            { Decls =
+               [{ Id = Ident { Id = { Name = "d"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsUnionOrIntersectionType
+                          (TsUnionType
+                             { Types =
+                                [TsKeywordType { Kind = TsStringKeyword
+                                                 Loc = None };
+                                 TsKeywordType { Kind = TsBooleanKeyword
+                                                 Loc = None }]
+                               Loc = None })
                        Loc = None }
                   Init = None }]
               Declare = true

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseBlockComments.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseBlockComments.verified.txt
@@ -10,19 +10,17 @@ output: Success: { Body =
       (Decl
          (Var
             { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "a"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsTypeRef { Loc = None
-                                         TypeName = Identifier { Name = "A"
-                                                                 Loc = None }
-                                         TypeParams = None }
-                            Loc = None }
-                       Optional = false
+               [{ Id = Ident { Id = { Name = "a"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsTypeRef { Loc = None
+                                    TypeName = Identifier { Name = "A"
+                                                            Loc = None }
+                                    TypeParams = None }
                        Loc = None }
                   Init = None }]
               Declare = true
@@ -31,19 +29,17 @@ output: Success: { Body =
       (Decl
          (Var
             { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "b"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsTypeRef { Loc = None
-                                         TypeName = Identifier { Name = "B"
-                                                                 Loc = None }
-                                         TypeParams = None }
-                            Loc = None }
-                       Optional = false
+               [{ Id = Ident { Id = { Name = "b"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsTypeRef { Loc = None
+                                    TypeName = Identifier { Name = "B"
+                                                            Loc = None }
+                                    TypeParams = None }
                        Loc = None }
                   Init = None }]
               Declare = true

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseComplexMethodSig.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseComplexMethodSig.verified.txt
@@ -22,68 +22,65 @@ output: Success: { Body =
                        Computed = false
                        Optional = false
                        Params =
-                        [Ident
-                           { Id = { Name = "value"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn = TsKeywordType { Kind = TsAnyKeyword
-                                                            Loc = None }
-                                  Loc = None }
-                             Optional = false
-                             Loc = None };
-                         Ident
-                           { Id = { Name = "replacer"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn =
-                                   TsUnionOrIntersectionType
-                                     (TsUnionType
-                                        { Types =
-                                           [TsArrayType
-                                              { ElemType =
-                                                 TsParenthesizedType
-                                                   { TypeAnn =
-                                                      TsUnionOrIntersectionType
-                                                        (TsUnionType
-                                                           { Types =
-                                                              [TsKeywordType
-                                                                 { Kind =
-                                                                    TsNumberKeyword
-                                                                   Loc = None };
-                                                               TsKeywordType
-                                                                 { Kind =
-                                                                    TsStringKeyword
-                                                                   Loc = None }]
-                                                             Loc = None })
-                                                     Loc = None }
-                                                Loc = None };
-                                            TsKeywordType { Kind = TsNullKeyword
-                                                            Loc = None }]
-                                          Loc = None })
-                                  Loc = None }
-                             Optional = true
-                             Loc = None };
-                         Ident
-                           { Id = { Name = "space"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn =
-                                   TsUnionOrIntersectionType
-                                     (TsUnionType
-                                        { Types =
-                                           [TsKeywordType
-                                              { Kind = TsStringKeyword
-                                                Loc = None };
-                                            TsKeywordType
-                                              { Kind = TsNumberKeyword
-                                                Loc = None }]
-                                          Loc = None })
-                                  Loc = None }
-                             Optional = true
-                             Loc = None }]
+                        [{ Pat = Ident { Id = { Name = "value"
+                                                Loc = None }
+                                         Optional = false
+                                         Loc = None }
+                           TypeAnn =
+                            Some { TypeAnn = TsKeywordType { Kind = TsAnyKeyword
+                                                             Loc = None }
+                                   Loc = None }
+                           Loc = None };
+                         { Pat = Ident { Id = { Name = "replacer"
+                                                Loc = None }
+                                         Optional = true
+                                         Loc = None }
+                           TypeAnn =
+                            Some
+                              { TypeAnn =
+                                 TsUnionOrIntersectionType
+                                   (TsUnionType
+                                      { Types =
+                                         [TsArrayType
+                                            { ElemType =
+                                               TsParenthesizedType
+                                                 { TypeAnn =
+                                                    TsUnionOrIntersectionType
+                                                      (TsUnionType
+                                                         { Types =
+                                                            [TsKeywordType
+                                                               { Kind =
+                                                                  TsNumberKeyword
+                                                                 Loc = None };
+                                                             TsKeywordType
+                                                               { Kind =
+                                                                  TsStringKeyword
+                                                                 Loc = None }]
+                                                           Loc = None })
+                                                   Loc = None }
+                                              Loc = None };
+                                          TsKeywordType { Kind = TsNullKeyword
+                                                          Loc = None }]
+                                        Loc = None })
+                                Loc = None }
+                           Loc = None };
+                         { Pat = Ident { Id = { Name = "space"
+                                                Loc = None }
+                                         Optional = true
+                                         Loc = None }
+                           TypeAnn =
+                            Some
+                              { TypeAnn =
+                                 TsUnionOrIntersectionType
+                                   (TsUnionType
+                                      { Types =
+                                         [TsKeywordType { Kind = TsStringKeyword
+                                                          Loc = None };
+                                          TsKeywordType { Kind = TsNumberKeyword
+                                                          Loc = None }]
+                                        Loc = None })
+                                Loc = None }
+                           Loc = None }]
                        TypeAnn =
                         Some { TypeAnn = TsKeywordType { Kind = TsStringKeyword
                                                          Loc = None }
@@ -96,104 +93,100 @@ output: Success: { Body =
                        Computed = false
                        Optional = false
                        Params =
-                        [Ident
-                           { Id = { Name = "predicate"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn =
-                                   TsFnOrConstructorType
-                                     (TsFnType
-                                        { Params =
-                                           [Ident
-                                              { Id = { Name = "value"
-                                                       Loc = None }
-                                                TypeAnn =
+                        [{ Pat = Ident { Id = { Name = "predicate"
+                                                Loc = None }
+                                         Optional = false
+                                         Loc = None }
+                           TypeAnn =
+                            Some
+                              { TypeAnn =
+                                 TsFnOrConstructorType
+                                   (TsFnType
+                                      { Params =
+                                         [{ Pat = Ident { Id = { Name = "value"
+                                                                 Loc = None }
+                                                          Optional = false
+                                                          Loc = None }
+                                            TypeAnn =
+                                             Some
+                                               { TypeAnn =
+                                                  TsTypeRef
+                                                    { Loc = None
+                                                      TypeName =
+                                                       Identifier { Name = "T"
+                                                                    Loc = None }
+                                                      TypeParams = None }
+                                                 Loc = None }
+                                            Loc = None };
+                                          { Pat = Ident { Id = { Name = "index"
+                                                                 Loc = None }
+                                                          Optional = false
+                                                          Loc = None }
+                                            TypeAnn =
+                                             Some
+                                               { TypeAnn =
+                                                  TsKeywordType
+                                                    { Kind = TsNumberKeyword
+                                                      Loc = None }
+                                                 Loc = None }
+                                            Loc = None };
+                                          { Pat = Ident { Id = { Name = "array"
+                                                                 Loc = None }
+                                                          Optional = false
+                                                          Loc = None }
+                                            TypeAnn =
+                                             Some
+                                               { TypeAnn =
+                                                  TsTypeOperator
+                                                    { Op = Readonly
+                                                      TypeAnn =
+                                                       TsArrayType
+                                                         { ElemType =
+                                                            TsTypeRef
+                                                              { Loc = None
+                                                                TypeName =
+                                                                 Identifier
+                                                                   { Name = "T"
+                                                                     Loc = None }
+                                                                TypeParams =
+                                                                 None }
+                                                           Loc = None }
+                                                      Loc = None }
+                                                 Loc = None }
+                                            Loc = None }]
+                                        TypeParams = None
+                                        TypeAnn =
+                                         { TypeAnn =
+                                            TsTypePredicate
+                                              { Asserts = false
+                                                ParamName =
+                                                 Ident { Name = "value"
+                                                         Loc = None }
+                                                Typeann =
                                                  Some
                                                    { TypeAnn =
                                                       TsTypeRef
                                                         { Loc = None
                                                           TypeName =
                                                            Identifier
-                                                             { Name = "T"
+                                                             { Name = "S"
                                                                Loc = None }
                                                           TypeParams = None }
                                                      Loc = None }
-                                                Optional = false
-                                                Loc = None };
-                                            Ident
-                                              { Id = { Name = "index"
-                                                       Loc = None }
-                                                TypeAnn =
-                                                 Some
-                                                   { TypeAnn =
-                                                      TsKeywordType
-                                                        { Kind = TsNumberKeyword
-                                                          Loc = None }
-                                                     Loc = None }
-                                                Optional = false
-                                                Loc = None };
-                                            Ident
-                                              { Id = { Name = "array"
-                                                       Loc = None }
-                                                TypeAnn =
-                                                 Some
-                                                   { TypeAnn =
-                                                      TsTypeOperator
-                                                        { Op = Readonly
-                                                          TypeAnn =
-                                                           TsArrayType
-                                                             { ElemType =
-                                                                TsTypeRef
-                                                                  { Loc = None
-                                                                    TypeName =
-                                                                     Identifier
-                                                                       { Name =
-                                                                          "T"
-                                                                         Loc =
-                                                                          None }
-                                                                    TypeParams =
-                                                                     None }
-                                                               Loc = None }
-                                                          Loc = None }
-                                                     Loc = None }
-                                                Optional = false
-                                                Loc = None }]
-                                          TypeParams = None
-                                          TypeAnn =
-                                           { TypeAnn =
-                                              TsTypePredicate
-                                                { Asserts = false
-                                                  ParamName =
-                                                   Ident { Name = "value"
-                                                           Loc = None }
-                                                  Typeann =
-                                                   Some
-                                                     { TypeAnn =
-                                                        TsTypeRef
-                                                          { Loc = None
-                                                            TypeName =
-                                                             Identifier
-                                                               { Name = "S"
-                                                                 Loc = None }
-                                                            TypeParams = None }
-                                                       Loc = None }
-                                                  Loc = None }
-                                             Loc = None }
-                                          Loc = None })
-                                  Loc = None }
-                             Optional = false
-                             Loc = None };
-                         Ident
-                           { Id = { Name = "thisArg"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn = TsKeywordType { Kind = TsAnyKeyword
-                                                            Loc = None }
-                                  Loc = None }
-                             Optional = true
-                             Loc = None }]
+                                                Loc = None }
+                                           Loc = None }
+                                        Loc = None })
+                                Loc = None }
+                           Loc = None };
+                         { Pat = Ident { Id = { Name = "thisArg"
+                                                Loc = None }
+                                         Optional = true
+                                         Loc = None }
+                           TypeAnn =
+                            Some { TypeAnn = TsKeywordType { Kind = TsAnyKeyword
+                                                             Loc = None }
+                                   Loc = None }
+                           Loc = None }]
                        TypeAnn =
                         Some
                           { TypeAnn =
@@ -240,17 +233,16 @@ output: Success: { Body =
                        Loc = None };
                    TsIndexSignature
                      { Params =
-                        [Ident
-                           { Id = { Name = "idx"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn =
-                                   TsKeywordType { Kind = TsStringKeyword
-                                                   Loc = None }
-                                  Loc = None }
-                             Optional = false
-                             Loc = None }]
+                        [{ Pat = Ident { Id = { Name = "idx"
+                                                Loc = None }
+                                         Optional = false
+                                         Loc = None }
+                           TypeAnn =
+                            Some
+                              { TypeAnn = TsKeywordType { Kind = TsStringKeyword
+                                                          Loc = None }
+                                Loc = None }
+                           Loc = None }]
                        TypeAnn =
                         { TypeAnn =
                            TsUnionOrIntersectionType

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseConditionalType.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseConditionalType.verified.txt
@@ -27,41 +27,37 @@ output: Success: { Body =
                     TsFnOrConstructorType
                       (TsFnType
                          { Params =
-                            [Ident
-                               { Id = { Name = "this"
-                                        Loc = None }
-                                 TypeAnn =
-                                  Some
-                                    { TypeAnn =
-                                       TsInferType
-                                         { TypeParam = { Name = { Name = "U"
-                                                                  Loc = None }
-                                                         IsIn = false
-                                                         IsOut = false
-                                                         IsConst = false
-                                                         Constraint = None
-                                                         Default = None
-                                                         Loc = None }
-                                           Loc = None }
-                                      Loc = None }
-                                 Optional = false
-                                 Loc = None };
-                             Rest
-                               { Arg =
-                                  Ident
-                                    { Id = { Name = "args"
+                            [{ Pat = Ident { Id = { Name = "this"
+                                                    Loc = None }
+                                             Optional = false
                                              Loc = None }
-                                      TypeAnn =
-                                       Some
-                                         { TypeAnn =
-                                            TsKeywordType
-                                              { Kind = TsNeverKeyword
-                                                Loc = None }
-                                           Loc = None }
-                                      Optional = false
-                                      Loc = None }
-                                 TypeAnn = None
-                                 Loc = None }]
+                               TypeAnn =
+                                Some
+                                  { TypeAnn =
+                                     TsInferType
+                                       { TypeParam = { Name = { Name = "U"
+                                                                Loc = None }
+                                                       IsIn = false
+                                                       IsOut = false
+                                                       IsConst = false
+                                                       Constraint = None
+                                                       Default = None
+                                                       Loc = None }
+                                         Loc = None }
+                                    Loc = None }
+                               Loc = None };
+                             { Pat = Rest { Arg = Ident { Id = { Name = "args"
+                                                                 Loc = None }
+                                                          Optional = false
+                                                          Loc = None }
+                                            Loc = None }
+                               TypeAnn =
+                                Some
+                                  { TypeAnn =
+                                     TsKeywordType { Kind = TsNeverKeyword
+                                                     Loc = None }
+                                    Loc = None }
+                               Loc = None }]
                            TypeParams = None
                            TypeAnn =
                             { TypeAnn = TsKeywordType { Kind = TsAnyKeyword

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithOptionalMethodAndProperty.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithOptionalMethodAndProperty.verified.txt
@@ -45,17 +45,16 @@ output: Success: { Body =
                        Computed = false
                        Optional = false
                        Params =
-                        [Ident
-                           { Id = { Name = "a"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn =
-                                   TsKeywordType { Kind = TsNumberKeyword
-                                                   Loc = None }
-                                  Loc = None }
-                             Optional = false
-                             Loc = None }]
+                        [{ Pat = Ident { Id = { Name = "a"
+                                                Loc = None }
+                                         Optional = false
+                                         Loc = None }
+                           TypeAnn =
+                            Some
+                              { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
+                                                          Loc = None }
+                                Loc = None }
+                           Loc = None }]
                        TypeAnn =
                         Some { TypeAnn = TsKeywordType { Kind = TsBooleanKeyword
                                                          Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaces.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaces.verified.txt
@@ -74,17 +74,16 @@ output: Success: { Body =
                        Loc = None };
                    TsIndexSignature
                      { Params =
-                        [Ident
-                           { Id = { Name = "index"
-                                    Loc = None }
-                             TypeAnn =
-                              Some
-                                { TypeAnn =
-                                   TsKeywordType { Kind = TsNumberKeyword
-                                                   Loc = None }
-                                  Loc = None }
-                             Optional = false
-                             Loc = None }]
+                        [{ Pat = Ident { Id = { Name = "index"
+                                                Loc = None }
+                                         Optional = false
+                                         Loc = None }
+                           TypeAnn =
+                            Some
+                              { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
+                                                          Loc = None }
+                                Loc = None }
+                           Loc = None }]
                        TypeAnn =
                         { TypeAnn =
                            TsTypeRef { Loc = None

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfacesWithGetterSetter.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfacesWithGetterSetter.verified.txt
@@ -31,17 +31,16 @@ output: Success: { Body =
                        Computed = false
                        Optional = false
                        Param =
-                        Ident
-                          { Id = { Name = "value"
-                                   Loc = None }
-                            TypeAnn =
-                             Some
-                               { TypeAnn =
-                                  TsKeywordType { Kind = TsNumberKeyword
-                                                  Loc = None }
-                                 Loc = None }
-                            Optional = false
-                            Loc = None }
+                        { Pat = Ident { Id = { Name = "value"
+                                               Loc = None }
+                                        Optional = false
+                                        Loc = None }
+                          TypeAnn =
+                           Some
+                             { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
+                                                         Loc = None }
+                               Loc = None }
+                          Loc = None }
                        Loc = None }]
                  Loc = None }
               Loc = None }))]

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseLineComments.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseLineComments.verified.txt
@@ -9,19 +9,17 @@ output: Success: { Body =
       (Decl
          (Var
             { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "a"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsTypeRef { Loc = None
-                                         TypeName = Identifier { Name = "A"
-                                                                 Loc = None }
-                                         TypeParams = None }
-                            Loc = None }
-                       Optional = false
+               [{ Id = Ident { Id = { Name = "a"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsTypeRef { Loc = None
+                                    TypeName = Identifier { Name = "A"
+                                                            Loc = None }
+                                    TypeParams = None }
                        Loc = None }
                   Init = None }]
               Declare = true
@@ -30,19 +28,17 @@ output: Success: { Body =
       (Decl
          (Var
             { Decls =
-               [{ Id =
-                   Ident
-                     { Id = { Name = "b"
-                              Loc = None }
-                       TypeAnn =
-                        Some
-                          { TypeAnn =
-                             TsTypeRef { Loc = None
-                                         TypeName = Identifier { Name = "B"
-                                                                 Loc = None }
-                                         TypeParams = None }
-                            Loc = None }
-                       Optional = false
+               [{ Id = Ident { Id = { Name = "b"
+                                      Loc = None }
+                               Optional = false
+                               Loc = None }
+                  TypeAnn =
+                   Some
+                     { TypeAnn =
+                        TsTypeRef { Loc = None
+                                    TypeName = Identifier { Name = "B"
+                                                            Loc = None }
+                                    TypeParams = None }
                        Loc = None }
                   Init = None }]
               Declare = true

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseMoreComplexFunctions.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseMoreComplexFunctions.verified.txt
@@ -10,29 +10,23 @@ output: Success: { Body =
               Declare = true
               Fn =
                { Params =
-                  [{ Pat =
-                      Ident
-                        { Id = { Name = "string"
-                                 Loc = None }
-                          TypeAnn =
-                           Some
-                             { TypeAnn = TsKeywordType { Kind = TsStringKeyword
-                                                         Loc = None }
-                               Loc = None }
-                          Optional = false
-                          Loc = None }
+                  [{ Pat = Ident { Id = { Name = "string"
+                                          Loc = None }
+                                   Optional = false
+                                   Loc = None }
+                     TypeAnn =
+                      Some { TypeAnn = TsKeywordType { Kind = TsStringKeyword
+                                                       Loc = None }
+                             Loc = None }
                      Loc = None };
-                   { Pat =
-                      Ident
-                        { Id = { Name = "radix"
-                                 Loc = None }
-                          TypeAnn =
-                           Some
-                             { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
-                                                         Loc = None }
-                               Loc = None }
-                          Optional = true
-                          Loc = None }
+                   { Pat = Ident { Id = { Name = "radix"
+                                          Loc = None }
+                                   Optional = true
+                                   Loc = None }
+                     TypeAnn =
+                      Some { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
+                                                       Loc = None }
+                             Loc = None }
                      Loc = None }]
                  Body = None
                  IsGenerator = false

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseSimpleFunctions.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseSimpleFunctions.verified.txt
@@ -12,17 +12,14 @@ output: Success: { Body =
               Declare = true
               Fn =
                { Params =
-                  [{ Pat =
-                      Ident
-                        { Id = { Name = "x"
-                                 Loc = None }
-                          TypeAnn =
-                           Some
-                             { TypeAnn = TsKeywordType { Kind = TsStringKeyword
-                                                         Loc = None }
-                               Loc = None }
-                          Optional = false
-                          Loc = None }
+                  [{ Pat = Ident { Id = { Name = "x"
+                                          Loc = None }
+                                   Optional = false
+                                   Loc = None }
+                     TypeAnn =
+                      Some { TypeAnn = TsKeywordType { Kind = TsStringKeyword
+                                                       Loc = None }
+                             Loc = None }
                      Loc = None }]
                  Body = None
                  IsGenerator = false
@@ -41,34 +38,30 @@ output: Success: { Body =
               Declare = true
               Fn =
                { Params =
-                  [{ Pat =
-                      Ident
-                        { Id = { Name = "a"
-                                 Loc = None }
-                          TypeAnn =
-                           Some
-                             { TypeAnn =
-                                TsTypeRef { Loc = None
-                                            TypeName = Identifier { Name = "A"
-                                                                    Loc = None }
-                                            TypeParams = None }
-                               Loc = None }
-                          Optional = false
+                  [{ Pat = Ident { Id = { Name = "a"
+                                          Loc = None }
+                                   Optional = false
+                                   Loc = None }
+                     TypeAnn =
+                      Some
+                        { TypeAnn =
+                           TsTypeRef { Loc = None
+                                       TypeName = Identifier { Name = "A"
+                                                               Loc = None }
+                                       TypeParams = None }
                           Loc = None }
                      Loc = None };
-                   { Pat =
-                      Ident
-                        { Id = { Name = "b"
-                                 Loc = None }
-                          TypeAnn =
-                           Some
-                             { TypeAnn =
-                                TsTypeRef { Loc = None
-                                            TypeName = Identifier { Name = "B"
-                                                                    Loc = None }
-                                            TypeParams = None }
-                               Loc = None }
-                          Optional = false
+                   { Pat = Ident { Id = { Name = "b"
+                                          Loc = None }
+                                   Optional = false
+                                   Loc = None }
+                     TypeAnn =
+                      Some
+                        { TypeAnn =
+                           TsTypeRef { Loc = None
+                                       TypeName = Identifier { Name = "B"
+                                                               Loc = None }
+                                       TypeParams = None }
                           Loc = None }
                      Loc = None }]
                  Body = None

--- a/src/Escalier.Interop/TypeScript.fs
+++ b/src/Escalier.Interop/TypeScript.fs
@@ -160,7 +160,10 @@ module rec TypeScript =
       Handler: option<CatchClause>
       Finalizer: option<BlockStmt> }
 
-  type CatchClause = { Param: Pat; Body: BlockStmt }
+  type CatchClause =
+    { Param: Pat
+      TypeAnn: option<TsTypeAnn>
+      Body: BlockStmt }
 
   type WhileStmt =
     { Test: Expr
@@ -237,7 +240,10 @@ module rec TypeScript =
       Declare: bool
       Kind: VariableDeclarationKind }
 
-  type VarDeclarator = { Id: Pat; Init: option<Expr> }
+  type VarDeclarator =
+    { Id: Pat
+      TypeAnn: option<TsTypeAnn>
+      Init: option<Expr> }
 
   type UsingDecl =
     { IsAwait: bool
@@ -630,25 +636,25 @@ module rec TypeScript =
 
   type BindingIdent =
     { Id: Ident
-      TypeAnn: option<TsTypeAnn>
+      // TypeAnn: option<TsTypeAnn>
       Optional: bool
       Loc: option<SourceLocation> }
 
   type ArrayPat =
     { Elems: list<option<Pat>>
       Optional: bool
-      TypeAnn: option<TsTypeAnn>
+      // TypeAnn: option<TsTypeAnn>
       Loc: option<SourceLocation> }
 
   type RestPat =
     { Arg: Pat
-      TypeAnn: option<TsTypeAnn>
+      // TypeAnn: option<TsTypeAnn>
       Loc: option<SourceLocation> }
 
   type ObjectPat =
     { Props: list<ObjectPatProp>
       Optional: bool
-      TypeAnn: option<TsTypeAnn>
+      // TypeAnn: option<TsTypeAnn>
       Loc: option<SourceLocation> }
 
   type AssignPat =
@@ -722,6 +728,7 @@ module rec TypeScript =
       // TODO: Decorators
       // decorators: list<Decorator>
       Pat: Pat
+      TypeAnn: option<TsTypeAnn>
       Loc: option<SourceLocation> }
 
   type TsParamProp =
@@ -732,6 +739,7 @@ module rec TypeScript =
       IsOverride: bool
       Readonly: bool
       Param: TsParamPropParam
+      TypeAnn: option<TsTypeAnn>
       Loc: option<SourceLocation> }
 
   type Accessibility =
@@ -1051,14 +1059,17 @@ module rec TypeScript =
       Default: option<TsType>
       Loc: option<SourceLocation> }
 
-  // TODO: Make BindingIdent, ArrayPat, RestPat, and ObjectPat
-  // parametric so that we can make `.TypeAnn` required
   [<RequireQualifiedAccess>]
-  type TsFnParam =
+  type TsFnParamPat =
     | Ident of BindingIdent
     | Array of ArrayPat
     | Rest of RestPat
     | Object of ObjectPat
+
+  type TsFnParam =
+    { Pat: TsFnParamPat
+      TypeAnn: option<TsTypeAnn>
+      Loc: option<SourceLocation> }
 
   type ObjectPatProp =
     | KeyValue of KeyValuePatProp


### PR DESCRIPTION
This brings the TypeScript AST closer inline with the Escalier AST.  Hopefully this will make it easier to share type inference code in the future.  At the very least it'll make the type inference code more similar than it would've been without this change.