### PR TITLE
Implement constrained generics

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -547,6 +547,8 @@ module Type =
       | TypeKind.Condition(check, extends, trueType, falseType) ->
         $"{check} extends {extends} ? {trueType} : {falseType}"
       | TypeKind.KeyOf t -> $"keyof {t}"
+      // TODO: handle operator precedence
+      | TypeKind.Binary(left, op, right) -> $"{left} {op} {right}"
       | _ ->
         printfn "this.Kind = %A" this.Kind
         failwith "TODO: finish implementing Type.ToString"

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -345,6 +345,7 @@ module Parser =
   opp.AddOperator(InfixOperator("/", ws, 12, Assoc.Left, binary "/"))
   opp.AddOperator(InfixOperator("%", ws, 12, Assoc.Left, binary "%"))
   opp.AddOperator(InfixOperator("+", ws, 11, Assoc.Left, binary "+"))
+  opp.AddOperator(InfixOperator("++", ws, 11, Assoc.Left, binary "++"))
   opp.AddOperator(InfixOperator("-", ws, 11, Assoc.Left, binary "-"))
   opp.AddOperator(InfixOperator("<", ws, 9, Assoc.Left, binary "<"))
   opp.AddOperator(InfixOperator("<=", ws, 9, Assoc.Left, binary "<="))

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -245,9 +245,9 @@ module Parser =
   let atom =
     choice
       [ literalExpr
-        funcExpr
-        doExpr
-        ifElse
+        attempt funcExpr // conflicts with identExpr
+        attempt doExpr // conflicts with identExpr
+        attempt ifElse // conflicts with identExpr
         tupleExpr
         objectExpr
         templateStringLiteral

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -85,11 +85,31 @@ let InfersLiterals () =
   }
 
 [<Fact>]
+let InferSimpleTypeError () =
+  let result =
+    result {
+      let src =
+        """
+        let y: string = "hello"
+        let x: number = y
+        """
+
+      let! _ = inferScript src
+
+      ()
+    }
+
+  Assert.True(Result.isError result)
+
+[<Fact>]
 let InferBinaryOperators () =
   let result =
     result {
       let! sum = infer "5 + 10"
       Assert.Equal("number", sum.ToString())
+
+      let! str = infer "\"Hello, \" + \"world!\""
+      Assert.Equal("string", str.ToString())
 
       let! lt = infer "5 < 10"
       Assert.Equal("boolean", lt.ToString())
@@ -197,7 +217,11 @@ let InferFuncParams () =
 
       let! env = inferScript src
 
-      Assert.Value(env, "add", "fn (x: number, y: number) -> number")
+      Assert.Value(
+        env,
+        "add",
+        "fn <A: number, B: number>(x: A, y: B) -> number"
+      )
     }
 
   Assert.False(Result.isError result)
@@ -319,7 +343,11 @@ let InferLambda () =
 
       let! env = inferScript src
 
-      Assert.Value(env, "add", "fn (x: number, y: number) -> number")
+      Assert.Value(
+        env,
+        "add",
+        "fn <A: number, B: number>(x: A, y: B) -> number"
+      )
     }
 
   Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -217,6 +217,8 @@ let InferFuncParams () =
             return x ++ y
           }
           let msg = addStrs("Hello, ", "world!")
+          let greeting: string = "Bonjour, "
+          let frMsg = addStrs(greeting, "monde!")
           """
 
       let! env = inferScript src
@@ -234,6 +236,7 @@ let InferFuncParams () =
       )
 
       Assert.Value(env, "msg", "Hello, world!")
+      Assert.Value(env, "frMsg", "string")
     }
 
   Assert.False(Result.isError result)
@@ -254,6 +257,8 @@ let InferBinaryOpStressTest () =
             return x + 1
           }
           let bar = foo(double(1), inc(2), 3)
+          let baz: number = 5
+          let qux = double(baz)
           """
 
       let! env = inferScript src
@@ -267,6 +272,7 @@ let InferBinaryOpStressTest () =
       Assert.Value(env, "double", "fn <A: number>(x: A) -> 2 * A")
       Assert.Value(env, "inc", "fn <A: number>(x: A) -> A + 1")
       Assert.Value(env, "bar", "9")
+      Assert.Value(env, "qux", "number")
     }
 
   printfn "result = %A" result
@@ -539,7 +545,7 @@ let InferOptionalChaining () =
       Assert.Value(env, "x", "number")
     }
 
-  printf "result = %A" result
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -289,13 +289,10 @@ let InferFuncParamsWithTypeAnns () =
       let! env = inferScript src
 
       Assert.Value(env, "addNums", "fn (x: number, y: number) -> number")
-
-      Assert.Value(
-        env,
-        "addStrs",
-        "fn (x: string, y: string) -> string ++ string"
-      )
+      Assert.Value(env, "addStrs", "fn (x: string, y: string) -> string")
     }
+
+  printfn "result = %A" result
 
   Assert.False(Result.isError result)
 

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -108,7 +108,7 @@ let InferBinaryOperators () =
       let! sum = infer "5 + 10"
       Assert.Equal("number", sum.ToString())
 
-      let! str = infer "\"Hello, \" + \"world!\""
+      let! str = infer "\"Hello, \" ++ \"world!\""
       Assert.Equal("string", str.ToString())
 
       let! lt = infer "5 < 10"
@@ -210,8 +210,11 @@ let InferFuncParams () =
     result {
       let src =
         """
-          let add = fn (x, y) {
+          let addNums = fn (x, y) {
             return x + y
+          }
+          let addStrs = fn (x, y) {
+            return x ++ y
           }
           """
 
@@ -219,8 +222,14 @@ let InferFuncParams () =
 
       Assert.Value(
         env,
-        "add",
+        "addNums",
         "fn <A: number, B: number>(x: A, y: B) -> number"
+      )
+
+      Assert.Value(
+        env,
+        "addStrs",
+        "fn <A: string, B: string>(x: A, y: B) -> string"
       )
     }
 
@@ -232,14 +241,18 @@ let InferFuncParamsWithTypeAnns () =
     result {
       let src =
         """
-          let add = fn (x: number, y: number) -> number {
+          let addNums = fn (x: number, y: number) -> number {
             return x + y
+          }
+          let addStrs = fn (x: string, y: string) -> string {
+            return x ++ y
           }
           """
 
       let! env = inferScript src
 
-      Assert.Value(env, "add", "fn (x: number, y: number) -> number")
+      Assert.Value(env, "addNums", "fn (x: number, y: number) -> number")
+      Assert.Value(env, "addStrs", "fn (x: string, y: string) -> string")
     }
 
   Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -293,6 +293,7 @@ module rec Env =
 
         { Kind = TypeKind.Literal(Literal.Number(string result))
           Provenance = None }
+      // TODO: Check `op` when collapsing binary expressions involving numbers
       | _, TypeKind.TypeRef { Name = "number" } -> right
       | TypeKind.TypeRef { Name = "number" }, _ -> left
       | TypeKind.Literal(Literal.String s1), TypeKind.Literal(Literal.String s2) ->
@@ -304,6 +305,9 @@ module rec Env =
 
         { Kind = TypeKind.Literal(Literal.Number(string result))
           Provenance = None }
+      // TODO: Check `op` when collapsing binary expressions involving strings
+      | _, TypeKind.TypeRef { Name = "string" } -> right
+      | TypeKind.TypeRef { Name = "string" }, _ -> left
       | _ -> t
     | _ -> t
 

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -107,6 +107,8 @@ module rec Infer =
             { Kind = TypeKind.Literal(Literal.Undefined)
               Provenance = None }
 
+          // TODO: unify body return type with return type annotation
+          // if it exists
           let! retType =
             result {
               match retExprs with
@@ -127,6 +129,16 @@ module rec Infer =
                 return
                   { Kind = TypeKind.Union types
                     Provenance = None }
+            }
+
+          let! retType =
+            result {
+              match f.Sig.ReturnType with
+              | Some(sigRetType) ->
+                let! sigRetType = inferTypeAnn env sigRetType
+                do! unify env retType sigRetType
+                return sigRetType
+              | None -> return retType
             }
 
           // TODO: move this up so that we can reference any type params in the

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -116,11 +116,10 @@ module Prelude =
         strType,
        false)
 
-    let t = intersection [ fst arithemtic; fst stringConcat ]
-
     { Env.Values =
         Map.ofList
-          [ ("+", (t, false))
+          [ ("+", arithemtic)
+            ("++", stringConcat)
             ("-", arithemtic)
             ("*", arithemtic)
             ("/", arithemtic)

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -38,11 +38,12 @@ module Prelude =
           |> TypeKind.TypeRef
         Provenance = None }
 
-    let arithemtic =
+    let arithemtic (op: string) =
       (makeFunctionType
         (Some [ tpA; tpB ])
         [ makeParam "left" typeRefA; makeParam "right" typeRefB ]
-        numType,
+        { Kind = TypeKind.Binary(typeRefA, op, typeRefB)
+          Provenance = None },
        false)
 
     let comparison =
@@ -113,18 +114,19 @@ module Prelude =
       (makeFunctionType
         (Some [ tpA; tpB ])
         [ makeParam "left" typeRefA; makeParam "right" typeRefB ]
-        strType,
+        { Kind = TypeKind.Binary(typeRefA, "++", typeRefB)
+          Provenance = None },
        false)
 
     { Env.Values =
         Map.ofList
-          [ ("+", arithemtic)
+          [ ("+", arithemtic "+")
             ("++", stringConcat)
-            ("-", arithemtic)
-            ("*", arithemtic)
-            ("/", arithemtic)
-            ("%", arithemtic)
-            ("**", arithemtic)
+            ("-", arithemtic "-")
+            ("*", arithemtic "*")
+            ("/", arithemtic "/")
+            ("%", arithemtic "%")
+            ("**", arithemtic "**")
             ("<", comparison)
             ("<=", comparison)
             (">", comparison)

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -12,10 +12,36 @@ module Prelude =
       Optional = false }
 
   let getEnv () : Env =
+    let tpA =
+      { Name = "A"
+        Constraint = Some(numType)
+        Default = None }
+
+    let tpB =
+      { Name = "B"
+        Constraint = Some(numType)
+        Default = None }
+
+    let typeRefA =
+      { Kind =
+          { Name = "A"
+            TypeArgs = None
+            Scheme = None }
+          |> TypeKind.TypeRef
+        Provenance = None }
+
+    let typeRefB =
+      { Kind =
+          { Name = "B"
+            TypeArgs = None
+            Scheme = None }
+          |> TypeKind.TypeRef
+        Provenance = None }
+
     let arithemtic =
       (makeFunctionType
-        None
-        [ makeParam "left" numType; makeParam "right" numType ]
+        (Some [ tpA; tpB ])
+        [ makeParam "left" typeRefA; makeParam "right" typeRefB ]
         numType,
        false)
 
@@ -57,9 +83,44 @@ module Prelude =
         boolType,
        false)
 
+    let tpA =
+      { Name = "A"
+        Constraint = Some(strType)
+        Default = None }
+
+    let tpB =
+      { Name = "B"
+        Constraint = Some(strType)
+        Default = None }
+
+    let typeRefA =
+      { Kind =
+          { Name = "A"
+            TypeArgs = None
+            Scheme = None }
+          |> TypeKind.TypeRef
+        Provenance = None }
+
+    let typeRefB =
+      { Kind =
+          { Name = "B"
+            TypeArgs = None
+            Scheme = None }
+          |> TypeKind.TypeRef
+        Provenance = None }
+
+    let stringConcat =
+      (makeFunctionType
+        (Some [ tpA; tpB ])
+        [ makeParam "left" typeRefA; makeParam "right" typeRefB ]
+        strType,
+       false)
+
+    let t = intersection [ fst arithemtic; fst stringConcat ]
+
     { Env.Values =
         Map.ofList
-          [ ("+", arithemtic)
+          [ ("+", (t, false))
             ("-", arithemtic)
             ("*", arithemtic)
             ("/", arithemtic)

--- a/src/Escalier.TypeChecker/TypeVariable.fs
+++ b/src/Escalier.TypeChecker/TypeVariable.fs
@@ -1,10 +1,6 @@
 namespace Escalier.TypeChecker
 
-open FsToolkit.ErrorHandling
-
 open Escalier.Data.Type
-
-open Error
 
 module TypeVariable =
   let mutable nextVariableId = 0
@@ -19,45 +15,52 @@ module TypeVariable =
 
     { Kind = TypeKind.TypeVar(newVar)
       Provenance = None }
-
-  /// Returns the currently defining instance of t.
-  /// As a side effect, collapses the list of type instances. The function Prune
-  /// is used whenever a type expression has to be inspected: it will always
-  /// return a type expression which is either an uninstantiated type variable or
-  /// a type operator; i.e. it will skip instantiated variables, and will
-  /// prune them from expressions to remove long chains of instantiated variables.
-  let rec prune (t: Type) : Type =
-    match t.Kind with
-    | TypeKind.TypeVar({ Instance = Some(instance) } as v) ->
-      let newInstance = prune instance
-      v.Instance <- Some(newInstance)
-      newInstance
-    | _ -> t
-
-  let rec bind (t1: Type) (t2: Type) =
-    let t1 = prune t1
-    let t2 = prune t2
-
-    result {
-      if t1.Kind <> t2.Kind then
-        if occursInType t1 t2 then
-          return! Error(TypeError.RecursiveUnification)
-
-        match t1.Kind with
-        | TypeKind.TypeVar(v) ->
-          v.Instance <- Some(t2)
-          return ()
-        | _ -> return! Error(TypeError.NotImplemented "bind error")
-    }
-
-  and occursInType (v: Type) (t2: Type) : bool =
-    match (prune t2).Kind with
-    | pruned when pruned = v.Kind -> true
-    | TypeKind.TypeRef({ TypeArgs = typeArgs }) ->
-      match typeArgs with
-      | Some(typeArgs) -> occursIn v typeArgs
-      | None -> false
-    | _ -> false
-
-  and occursIn (t: Type) (types: list<Type>) : bool =
-    List.exists (occursInType t) types
+//
+// /// Returns the currently defining instance of t.
+// /// As a side effect, collapses the list of type instances. The function Prune
+// /// is used whenever a type expression has to be inspected: it will always
+// /// return a type expression which is either an uninstantiated type variable or
+// /// a type operator; i.e. it will skip instantiated variables, and will
+// /// prune them from expressions to remove long chains of instantiated variables.
+// let rec prune
+//   (unify: Env -> Type -> Type -> Result<unit, TypeError>)
+//   (t: Type)
+//   : Type =
+//   match t.Kind with
+//   | TypeKind.TypeVar({ Instance = Some(instance) } as v) ->
+//     let newInstance = prune instance
+//     v.Instance <- Some(newInstance)
+//     newInstance
+//   | _ -> t
+//
+// let rec bind (t1: Type) (t2: Type) =
+//   let t1 = prune t1
+//   let t2 = prune t2
+//
+//   result {
+//     if t1.Kind <> t2.Kind then
+//       if occursInType t1 t2 then
+//         return! Error(TypeError.RecursiveUnification)
+//
+//       match t1.Kind with
+//       | TypeKind.TypeVar(v) ->
+//         // printfn "Binding %A to %A" t1 t2
+//         if v.Bound <> None then
+//           do! unify v.Bound t2
+//         // return! Error(TypeError.TypeBoundMismatch(t1, t2))
+//         v.Instance <- Some(t2)
+//         return ()
+//       | _ -> return! Error(TypeError.NotImplemented "bind error")
+//   }
+//
+// and occursInType (v: Type) (t2: Type) : bool =
+//   match (prune t2).Kind with
+//   | pruned when pruned = v.Kind -> true
+//   | TypeKind.TypeRef({ TypeArgs = typeArgs }) ->
+//     match typeArgs with
+//     | Some(typeArgs) -> occursIn v typeArgs
+//     | None -> false
+//   | _ -> false
+//
+// and occursIn (t: Type) (types: list<Type>) : bool =
+//   List.exists (occursInType t) types

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -211,8 +211,15 @@ module rec Unify =
         | Some _ -> return ()
         | _ -> return! Error(TypeError.TypeMismatch(t1, t2))
 
-      | _, _ ->
+      | TypeKind.Binary(left, op, right), TypeKind.TypeRef { Name = "number" } ->
+        if
+          op = "+" || op = "-" || op = "*" || op = "/" || op = "%" || op = "**"
+        then
+          return ()
+        else
+          return! Error(TypeError.TypeMismatch(t1, t2))
 
+      | _, _ ->
         let t1' = env.ExpandType t1
         let t2' = env.ExpandType t2
 

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -247,7 +247,9 @@ module rec Unify =
           match t.Kind with
           | TypeKind.Function func ->
             match unifyCall env inferExpr args typeArgs t with
-            | Result.Ok value -> result <- Some(value)
+            | Result.Ok value ->
+              printfn $"unifyCall: {t} -> {value}"
+              result <- Some(value)
             | Result.Error _ -> ()
           | _ -> ()
 

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -9,17 +9,16 @@ open Escalier.Data.Type
 open Env
 open Error
 open Poly
-open TypeVariable
 
 module rec Unify =
 
   ///Unify the two types t1 and t2. Makes the types t1 and t2 the same.
   let unify (env: Env) (t1: Type) (t2: Type) : Result<unit, TypeError> =
-    // printfn "unify %A %A" t1 t2
+    // printfn $"unify({t1}, {t2})"
 
     result {
       match (prune t1).Kind, (prune t2).Kind with
-      | TypeKind.TypeVar _, _ -> do! bind t1 t2
+      | TypeKind.TypeVar _, _ -> do! bind env unify t1 t2
       | _, TypeKind.TypeVar _ -> do! unify env t2 t1
       | TypeKind.Tuple(elems1), TypeKind.Tuple(elems2) ->
         if List.length elems1 <> List.length elems2 then
@@ -241,6 +240,21 @@ module rec Unify =
       | TypeKind.Function func ->
         return!
           unifyFuncCall env inferExpr args typeArgs retType throwsType func
+      | TypeKind.Intersection types ->
+        let mutable result = None
+
+        for t in types do
+          match t.Kind with
+          | TypeKind.Function func ->
+            match unifyCall env inferExpr args typeArgs t with
+            | Result.Ok value -> result <- Some(value)
+            | Result.Error _ -> ()
+          | _ -> ()
+
+        match result with
+        | Some(value) -> return value
+        | None ->
+          return! Error(TypeError.NotImplemented $"kind = {callee.Kind}")
       | TypeKind.TypeVar _ ->
 
         // TODO: use a `result {}` CE here
@@ -265,7 +279,7 @@ module rec Unify =
                   TypeParams = None } // TODO
             Provenance = None }
 
-        match bind callee callType with
+        match bind env unify callee callType with
         | Ok _ -> return (prune retType, prune throwsType)
         | Error e -> return! Error e
       | kind -> return! Error(TypeError.NotImplemented $"kind = {kind}")


### PR DESCRIPTION
Update arithmetic operators to be generic functions where each param is constrained by `number`.  Make `+` an overloaded function so that it can be used with strings as well.  The string version also uses constrained generics.