### PR TITLE
Lookup Schemes when inferring TypeRefs

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -553,6 +553,7 @@ module Type =
         printfn "this.Kind = %A" this.Kind
         failwith "TODO: finish implementing Type.ToString"
 
+  // TODO: add `IsTypeParam` field
   type Scheme =
     { TypeParams: option<list<string>>
       Type: Type }

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -370,6 +370,7 @@ let InferFuncGenericFuncWithExplicitTypeParams () =
       Assert.Value(env, "baz", "\"hello\"")
     }
 
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -394,7 +395,37 @@ let InferTypeDecls () =
       Assert.Type(env, "Nullable", "<T>(T | undefined)")
     }
 
+  printfn "result = %A" result
+
   Assert.False(Result.isError result)
+
+
+[<Fact>]
+let InferPrivateDecl () =
+  let result =
+    result {
+      let src =
+        """
+          let makePoint = fn (x, y) {
+            type Point = {x: number, y: number}
+            let point: Point = {x, y}
+            return point
+          }
+          let p = makePoint(5, 10)
+          let {x, y} = p
+          """
+
+      let! env = inferScript src
+
+      Assert.Value(env, "makePoint", "fn (x: number, y: number) -> Point")
+      Assert.Value(env, "p", "Point")
+      Assert.Value(env, "x", "number")
+      Assert.Value(env, "y", "number")
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)
+
 
 [<Fact>]
 let InferLambda () =

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -426,6 +426,23 @@ let InferPrivateDecl () =
   printfn "result = %A" result
   Assert.False(Result.isError result)
 
+[<Fact(Skip = "TODO: add primitive types to fix this")>]
+let InferTypeAliasOfPrimtiveType () =
+  let result =
+    result {
+      let src =
+        """
+        type Bar = number
+        let x: Bar = 5
+        """
+
+      let! env = inferScript src
+
+      Assert.Value(env, "foo", "")
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)
 
 [<Fact>]
 let InferLambda () =

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -309,7 +309,7 @@ module rec Unify =
     (retType: Type)
     (throwsType: Type)
     (callee: Function)
-    : Result<(Type * Type), TypeError> =
+    : Result<Type * Type, TypeError> =
 
     result {
       let! callee =

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -72,6 +72,10 @@ module rec Unify =
         | Literal.Number _, "number" -> ()
         | Literal.String _, "string" -> ()
         | Literal.Boolean _, "boolean" -> ()
+        // TODO: expand the type ref
+        // TODO: making `number`, `string`, `boolean`, primitives
+        // instead of type refs so that we don't have to have exceptions
+        // those types everywhere
         | _, _ -> return! Error(TypeError.TypeMismatch(t1, t2))
       | TypeKind.Literal l1, TypeKind.Literal l2 ->
         match l1, l2 with

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -16,6 +16,7 @@ module rec Visitor =
         | ExprKind.Identifier _ -> ()
         | ExprKind.Literal _ -> ()
         | ExprKind.Function f ->
+          // TODO: walk type annotations
           match f.Body with
           | BlockOrExpr.Block block -> List.iter (walkStmt visitor) block.Stmts
           | BlockOrExpr.Expr expr -> walk expr
@@ -55,7 +56,10 @@ module rec Visitor =
           walk left
           walk right
         | ExprKind.Unary(_op, value) -> walk value
-        | ExprKind.Object elems -> failwith "todo"
+        | ExprKind.Object elems ->
+          // TODO:
+          // failwith "todo"
+          ()
         | ExprKind.Try(body, catch, fin) ->
           List.iter (walkStmt visitor) body.Stmts
 
@@ -87,8 +91,9 @@ module rec Visitor =
         | StmtKind.Decl({ Kind = DeclKind.VarDecl(_name, init, typeAnn) }) ->
           // TODO: walk typeAnn
           walkExpr visitor init
-        | StmtKind.Decl({ Kind = DeclKind.TypeDecl _ }) ->
-          failwith "TODO: walkStmt - TypeDecl"
+        | StmtKind.Decl({ Kind = DeclKind.TypeDecl(name, typeAnn, typeParams) }) ->
+          // TODO: walk type params
+          walkTypeAnn visitor typeAnn
         | StmtKind.Return exprOption ->
           Option.iter (walkExpr visitor) exprOption
 


### PR DESCRIPTION
If the Scheme exists we assign it to the .Scheme field on the TypeRef.  This is so that a value whose type is the TypeRef can be used outside of the scope where the TypeRef was defined.  This PR also makes sure that type alias decls and function decls add schemes for type variables to the curent environment so they can be referenced.