### PR TITLE
Infer comparison expressions as binary types

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -59,6 +59,34 @@ module Common =
       | Int a, Float b -> Float(float a ** b)
       | Int a, Int b -> Int(int ((float a) ** (float b)))
 
+    member this.GreaterThan(other: Number) =
+      match this, other with
+      | Float a, Float b -> Boolean(a > b)
+      | Float a, Int b -> Boolean(a > float b)
+      | Int a, Float b -> Boolean(float a > b)
+      | Int a, Int b -> Boolean(a > b)
+
+    member this.GreaterThanOrEqual(other: Number) =
+      match this, other with
+      | Float a, Float b -> Boolean(a >= b)
+      | Float a, Int b -> Boolean(a >= float b)
+      | Int a, Float b -> Boolean(float a >= b)
+      | Int a, Int b -> Boolean(a >= b)
+
+    member this.LessThan(other: Number) =
+      match this, other with
+      | Float a, Float b -> Boolean(a < b)
+      | Float a, Int b -> Boolean(a < float b)
+      | Int a, Float b -> Boolean(float a < b)
+      | Int a, Int b -> Boolean(a < b)
+
+    member this.LessThanOrEqual(other: Number) =
+      match this, other with
+      | Float a, Float b -> Boolean(a <= b)
+      | Float a, Int b -> Boolean(a <= float b)
+      | Int a, Float b -> Boolean(float a <= b)
+      | Int a, Int b -> Boolean(a <= b)
+
   type Literal =
     | Number of Number
     | String of string

--- a/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
+++ b/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
@@ -73,7 +73,7 @@ let InfersAsyncError () =
       Assert.Value(
         env,
         "foo",
-        "fn (x: number) -> Promise<number, \"RangeError\">"
+        "fn <A: number>(x: A) -> Promise<A, \"RangeError\">"
       )
     }
 
@@ -97,7 +97,7 @@ let InfersPropagateAsyncError () =
       Assert.Value(
         env,
         "foo",
-        "fn (x: number) -> Promise<number, \"RangeError\">"
+        "fn <A: number>(x: A) -> Promise<A, \"RangeError\">"
       )
 
       Assert.Value(
@@ -130,7 +130,7 @@ let InfersTryCatchAsync () =
       Assert.Value(
         env,
         "foo",
-        "fn (x: number) -> Promise<number, \"RangeError\">"
+        "fn <A: number>(x: A) -> Promise<A, \"RangeError\">"
       )
 
       Assert.Value(env, "bar", "fn (x: number) -> Promise<number, never>")

--- a/src/Escalier.TypeChecker.Tests/Exceptions.fs
+++ b/src/Escalier.TypeChecker.Tests/Exceptions.fs
@@ -106,7 +106,7 @@ let InfersThrowingMultipleExpressions () =
     result {
       let src =
         """
-        let foo = fn (x) =>
+        let foo = fn <A: number>(x: A) =>
           if x < 0 { throw "RangeError" } else { throw "BoundsError" }
         """
 
@@ -180,7 +180,7 @@ let InferCatchesMultipleExceptions () =
     result {
       let src =
         """
-        let foo = fn (x) =>
+        let foo = fn <A: number>(x: A) =>
           if x < 0 { throw "RangeError" } else { throw "BoundsError" }
           
         let bar = fn (x) =>
@@ -206,7 +206,7 @@ let InferCatchesOneOfManyExceptions () =
     result {
       let src =
         """
-        let foo = fn (x) =>
+        let foo = fn <A: number>(x: A) =>
           if x < 0 { throw "RangeError" } else { throw "BoundsError" }
           
         let bar = fn (x) =>

--- a/src/Escalier.TypeChecker.Tests/Exceptions.fs
+++ b/src/Escalier.TypeChecker.Tests/Exceptions.fs
@@ -53,7 +53,11 @@ let InfersExplicitThrow () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "foo", "fn (x: number) -> number throws \"RangeError\"")
+      Assert.Value(
+        env,
+        "foo",
+        "fn <A: number>(x: A) -> A throws \"RangeError\""
+      )
     }
 
   printfn "res = %A" res
@@ -71,7 +75,11 @@ let InfersThrowExpression () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "foo", "fn (x: number) -> number throws \"RangeError\"")
+      Assert.Value(
+        env,
+        "foo",
+        "fn <A: number>(x: A) -> A throws \"RangeError\""
+      )
     }
 
   Assert.False(Result.isError res)
@@ -98,7 +106,7 @@ let InfersThrowingMultipleExpressions () =
     result {
       let src =
         """
-        let foo = fn (x: number) =>
+        let foo = fn (x) =>
           if x < 0 { throw "RangeError" } else { throw "BoundsError" }
         """
 
@@ -107,7 +115,7 @@ let InfersThrowingMultipleExpressions () =
       Assert.Value(
         env,
         "foo",
-        "fn (x: number) -> never throws \"BoundsError\" | \"RangeError\""
+        "fn <A: number>(x: A) -> never throws \"BoundsError\" | \"RangeError\""
       )
     }
 
@@ -127,8 +135,17 @@ let InfersThrowsFromCall () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "foo", "fn (x: number) -> number throws \"RangeError\"")
-      Assert.Value(env, "bar", "fn (x: number) -> number throws \"RangeError\"")
+      Assert.Value(
+        env,
+        "foo",
+        "fn <A: number>(x: A) -> A throws \"RangeError\""
+      )
+
+      Assert.Value(
+        env,
+        "bar",
+        "fn <A: number>(x: A) -> A throws \"RangeError\""
+      )
     }
 
   Assert.False(Result.isError res)
@@ -152,7 +169,7 @@ let InferCatchesException () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "bar", "fn (x: number) -> number")
+      Assert.Value(env, "bar", "fn <A: number>(x: A) -> A | 0")
     }
 
   Assert.False(Result.isError res)
@@ -163,7 +180,7 @@ let InferCatchesMultipleExceptions () =
     result {
       let src =
         """
-        let foo = fn (x: number) =>
+        let foo = fn (x) =>
           if x < 0 { throw "RangeError" } else { throw "BoundsError" }
           
         let bar = fn (x) =>
@@ -177,7 +194,7 @@ let InferCatchesMultipleExceptions () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "bar", "fn (x: number) -> 0")
+      Assert.Value(env, "bar", "fn <A: number>(x: A) -> 0")
     }
 
   printfn "res = %A" res
@@ -189,7 +206,7 @@ let InferCatchesOneOfManyExceptions () =
     result {
       let src =
         """
-        let foo = fn (x: number) =>
+        let foo = fn (x) =>
           if x < 0 { throw "RangeError" } else { throw "BoundsError" }
           
         let bar = fn (x) =>
@@ -202,7 +219,11 @@ let InferCatchesOneOfManyExceptions () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "bar", "fn (x: number) -> 0 throws \"BoundsError\"")
+      Assert.Value(
+        env,
+        "bar",
+        "fn <A: number>(x: A) -> 0 throws \"BoundsError\""
+      )
     }
 
   printfn "res = %A" res
@@ -228,7 +249,11 @@ let InferTryFinally () =
 
       let! ctx, env = inferScript src
 
-      Assert.Value(env, "bar", "fn (x: number) -> number throws \"RangeError\"")
+      Assert.Value(
+        env,
+        "bar",
+        "fn <A: number>(x: A) -> A throws \"RangeError\""
+      )
     }
 
   Assert.False(Result.isError res)
@@ -255,7 +280,7 @@ let InferTryCatchFinally () =
 
       let! ctx, env = inferScript src
 
-      Assert.Value(env, "bar", "fn (x: number) -> number")
+      Assert.Value(env, "bar", "fn <A: number>(x: A) -> A | 0")
     }
 
   printfn "res = %A" res

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -344,7 +344,7 @@ let InferFuncWithMultipleReturns () =
     result {
       let src =
         """
-          let foo = fn (x, y: string) {
+          let foo = fn <A: number>(x: A, y: string) {
             if (x > 0) {
               return x
             }

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -149,7 +149,7 @@ let InferBinaryOperators () =
       Assert.Equal("\"Hello, world!\"", str.ToString())
 
       let! lt = infer "5 < 10"
-      Assert.Equal("boolean", lt.ToString())
+      Assert.Equal("true", lt.ToString())
 
       let! eq = infer "5 == 10"
       Assert.Equal("boolean", eq.ToString())
@@ -336,7 +336,6 @@ let InferFuncParamsWithTypeAnns () =
     }
 
   printfn "result = %A" result
-
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -345,7 +344,7 @@ let InferFuncWithMultipleReturns () =
     result {
       let src =
         """
-          let foo = fn (x: number, y: string) {
+          let foo = fn (x, y: string) {
             if (x > 0) {
               return x
             }
@@ -356,10 +355,11 @@ let InferFuncWithMultipleReturns () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "foo", "fn (x: number, y: string) -> string | number")
-      Assert.Value(env, "bar", "string | number")
+      Assert.Value(env, "foo", "fn <A: number>(x: A, y: string) -> string | A")
+      Assert.Value(env, "bar", "string | 5")
     }
 
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -894,7 +894,7 @@ let BasicPatternMatchingInferExpr () =
       Assert.Value(
         env,
         "foo",
-        "fn <A>(x: A | number) -> \"none\" | \"one\" | \"negative\" | \"other\""
+        "fn <B: number, A>(x: A | B | 1 | 0) -> \"none\" | \"one\" | \"negative\" | \"other\""
       )
     }
 

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -121,11 +121,12 @@ module Prelude =
         never,
        false)
 
-    let comparison =
+    let comparison (op: string) =
       (makeFunctionType
-        None
-        [ makeParam "left" numType; makeParam "right" numType ]
-        boolType
+        (Some [ tpA; tpB ])
+        [ makeParam "left" typeRefA; makeParam "right" typeRefB ]
+        { Kind = TypeKind.Binary(typeRefA, op, typeRefB)
+          Provenance = None }
         never,
        false)
 
@@ -217,10 +218,10 @@ module Prelude =
                 ("/", arithemtic "/")
                 ("%", arithemtic "%")
                 ("**", arithemtic "**")
-                ("<", comparison)
-                ("<=", comparison)
-                (">", comparison)
-                (">=", comparison)
+                ("<", comparison "<")
+                ("<=", comparison "<=")
+                (">", comparison ">")
+                (">=", comparison ">=")
                 ("==", equality)
                 ("!=", equality)
                 ("||", logical)

--- a/src/Escalier.TypeChecker/Prune.fs
+++ b/src/Escalier.TypeChecker/Prune.fs
@@ -43,15 +43,19 @@ module rec Prune =
       | TypeKind.Literal(Literal.Number n1), TypeKind.Literal(Literal.Number n2) ->
         let result =
           match op with
-          | "+" -> n1.Add(n2)
-          | "-" -> n1.Sub(n2)
-          | "*" -> n1.Mul(n2)
-          | "/" -> n1.Div(n2)
-          | "%" -> n1.Mod(n2)
-          | "**" -> n1.Exp(n2)
+          | "+" -> n1.Add(n2) |> Literal.Number
+          | "-" -> n1.Sub(n2) |> Literal.Number
+          | "*" -> n1.Mul(n2) |> Literal.Number
+          | "/" -> n1.Div(n2) |> Literal.Number
+          | "%" -> n1.Mod(n2) |> Literal.Number
+          | "**" -> n1.Exp(n2) |> Literal.Number
+          | ">" -> n1.GreaterThan(n2)
+          | ">=" -> n1.GreaterThanOrEqual(n2)
+          | "<" -> n1.LessThan(n2)
+          | "<=" -> n1.LessThanOrEqual(n2)
           | _ -> failwith "TODO: simplify binary"
 
-        { Kind = TypeKind.Literal(Literal.Number result)
+        { Kind = TypeKind.Literal result
           Provenance = None }
       // TODO: Check `op` when collapsing binary expressions involving numbers
       | _, TypeKind.Primitive Primitive.Number -> right

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -273,6 +273,10 @@ module rec Unify =
         op = "+" || op = "-" || op = "*" || op = "/" || op = "%" || op = "**"
         ->
         return ()
+      | TypeKind.Binary(left, op, right), TypeKind.Primitive Primitive.Boolean when
+        op = "<" || op = "<=" || op = ">" || op = ">="
+        ->
+        return ()
       | TypeKind.Binary(left, op, right), TypeKind.Primitive Primitive.String when
         op = "++"
         ->


### PR DESCRIPTION
We were already doing this for arithmetic operators.

This change identified an issue with the interaction between `number` primitives and binary types.  To fix the failing tests I changed the explicit `number` type annotations to be generic with `number` as the constraint, i.e. `T: number`.

It also further underscores an existing with binary types: inferred function signatures are overly complicated with additional type params.

In a future PR I'll try to address these issues inferring `number` annotations as `T: number` everywhere while hiding the type params.  This will require some thoughtful planning before I can begin implementation.