### PR TITLE
switch from ':' to '=' for object property values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,84 @@
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.3.2"
+      },
+      "devDependencies": {
+        "sloc": "^0.3.1"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/sloc": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sloc/-/sloc-0.3.1.tgz",
+      "integrity": "sha512-ImBLf1q0R7OHUqAVVjUkW8q1qqGL3hI4ThWbKd8EMe1l1gGmxu062zSHyD/kz8B0Wii5boVYJ3/ZnFatpikBkw==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.4",
+        "cli-table": "^0.3.11",
+        "commander": "^11.0.0",
+        "readdirp": "^3.3.0"
+      },
+      "bin": {
+        "sloc": "bin/sloc"
       }
     },
     "node_modules/typescript": {
@@ -26,6 +104,60 @@
     }
   },
   "dependencies": {
+    "async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "sloc": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sloc/-/sloc-0.3.1.tgz",
+      "integrity": "sha512-ImBLf1q0R7OHUqAVVjUkW8q1qqGL3hI4ThWbKd8EMe1l1gGmxu062zSHyD/kz8B0Wii5boVYJ3/ZnFatpikBkw==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.4",
+        "cli-table": "^0.3.11",
+        "commander": "^11.0.0",
+        "readdirp": "^3.3.0"
+      }
+    },
     "typescript": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "homepage": "https://github.com/escalier-lang/escalier-next#readme",
   "dependencies": {
     "typescript": "^5.3.2"
+  },
+  "devDependencies": {
+    "sloc": "^0.3.1"
   }
 }

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.esc
@@ -2,6 +2,6 @@ import "~/imports1/math" {add}
 import "./point" {makePoint, Point}
 
 let p = makePoint(5, 10)
-let q: Point = {x: 20, y: 30}
+let q: Point = {x = 20, y = 30}
 let x = add(p.x, q.x)
 let y = add(p.y, q.y)

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/point.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/point.esc
@@ -1,5 +1,5 @@
 type Point = {x: number, y: number}
 
 let makePoint = fn (x: number, y: number) -> Point {
-    return {x: x, y: y}
+    return {x, y}
 }

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -217,7 +217,7 @@ let ParseObjLitAndObjPat () =
   let src =
     """
     type Point = {x: number, y: number}
-    let {x, y}: Point = {x: 5, y: 10}
+    let {x, y}: Point = {x = 5, y = 10}
     let p: Point = {x, y}
     let foo = fn ({x, y}: Point) => x + y
     """
@@ -231,7 +231,7 @@ let ParseObjLitAndObjPat () =
 let ParseObjRestSpread () =
   let src =
     """
-    let obj = {a: 5, b: "hello", c: true}
+    let obj = {a = 5, b = "hello", c = true}
     let {a, ...rest} = obj
   """
 

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
     type Point = {x: number, y: number}
-    let {x, y}: Point = {x: 5, y: 10}
+    let {x, y}: Point = {x = 5, y = 10}
     let p: Point = {x, y}
     let foo = fn ({x, y}: Point) => x + y
     
@@ -57,17 +57,17 @@ output: Ok
                       Object
                         [Property
                            ({ Start = (Ln: 3, Col: 26)
-                              Stop = (Ln: 3, Col: 30) }, String "x",
+                              Stop = (Ln: 3, Col: 31) }, String "x",
                             { Kind = Literal (Number (Int 5))
-                              Span = { Start = (Ln: 3, Col: 29)
-                                       Stop = (Ln: 3, Col: 30) }
+                              Span = { Start = (Ln: 3, Col: 30)
+                                       Stop = (Ln: 3, Col: 31) }
                               InferredType = None });
                          Property
-                           ({ Start = (Ln: 3, Col: 32)
-                              Stop = (Ln: 3, Col: 37) }, String "y",
+                           ({ Start = (Ln: 3, Col: 33)
+                              Stop = (Ln: 3, Col: 39) }, String "y",
                             { Kind = Literal (Number (Int 10))
-                              Span = { Start = (Ln: 3, Col: 35)
-                                       Stop = (Ln: 3, Col: 37) }
+                              Span = { Start = (Ln: 3, Col: 37)
+                                       Stop = (Ln: 3, Col: 39) }
                               InferredType = None })]
                      Span = { Start = (Ln: 3, Col: 25)
                               Stop = (Ln: 4, Col: 5) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    let obj = {a: 5, b: "hello", c: true}
+    let obj = {a = 5, b = "hello", c = true}
     let {a, ...rest} = obj
   
 output: Ok
@@ -20,24 +20,24 @@ output: Ok
                       Object
                         [Property
                            ({ Start = (Ln: 2, Col: 16)
-                              Stop = (Ln: 2, Col: 20) }, String "a",
+                              Stop = (Ln: 2, Col: 21) }, String "a",
                             { Kind = Literal (Number (Int 5))
-                              Span = { Start = (Ln: 2, Col: 19)
-                                       Stop = (Ln: 2, Col: 20) }
+                              Span = { Start = (Ln: 2, Col: 20)
+                                       Stop = (Ln: 2, Col: 21) }
                               InferredType = None });
                          Property
-                           ({ Start = (Ln: 2, Col: 22)
-                              Stop = (Ln: 2, Col: 32) }, String "b",
+                           ({ Start = (Ln: 2, Col: 23)
+                              Stop = (Ln: 2, Col: 34) }, String "b",
                             { Kind = Literal (String "hello")
-                              Span = { Start = (Ln: 2, Col: 25)
-                                       Stop = (Ln: 2, Col: 32) }
+                              Span = { Start = (Ln: 2, Col: 27)
+                                       Stop = (Ln: 2, Col: 34) }
                               InferredType = None });
                          Property
-                           ({ Start = (Ln: 2, Col: 34)
-                              Stop = (Ln: 2, Col: 41) }, String "c",
+                           ({ Start = (Ln: 2, Col: 36)
+                              Stop = (Ln: 2, Col: 44) }, String "c",
                             { Kind = Literal (Boolean true)
-                              Span = { Start = (Ln: 2, Col: 37)
-                                       Stop = (Ln: 2, Col: 41) }
+                              Span = { Start = (Ln: 2, Col: 40)
+                                       Stop = (Ln: 2, Col: 44) }
                               InferredType = None })]
                      Span = { Start = (Ln: 2, Col: 15)
                               Stop = (Ln: 3, Col: 5) }

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -228,7 +228,7 @@ module Parser =
         InferredType = None }
 
   let objElemProperty: Parser<ObjElem, unit> =
-    pipe4 getPosition ident (opt (strWs ":" >>. expr)) getPosition
+    pipe4 getPosition ident (opt (strWs "=" >>. expr)) getPosition
     <| fun start name value stop ->
       let span = { Start = start; Stop = stop }
 
@@ -642,7 +642,7 @@ module Parser =
         InferredType = None }
 
   let private objPatKeyValueOrShorthand =
-    pipe4 getPosition ident (opt (strWs ":" >>. (ws >>. pattern))) getPosition
+    pipe4 getPosition ident (opt (strWs "=" >>. (ws >>. pattern))) getPosition
     <| fun start name value stop ->
       let span = { Start = start; Stop = stop }
 


### PR DESCRIPTION
This is part of the work that's necessary for #86.  Since patterns can include both type assertions and we need an easy way to differentiate between types as values.

TODO:
 - [ ] switch to `as` for renaming bindings in patterns
 - [ ] if `=` is for default values then `:` should be used for restructuring nested patterns 