### PR TITLE
Initial support for template literal types

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -112,6 +112,9 @@ module Common =
     | Add
     | Remove
 
+  type TemplateLiteral<'T> =
+    { Parts: list<string>; Exprs: list<'T> }
+
 
 module Syntax =
   type Span = { Start: Position; Stop: Position }
@@ -151,10 +154,6 @@ module Syntax =
       Pattern: Pattern
       Guard: option<Expr>
       Body: BlockOrExpr }
-
-  type TemplateLiteral =
-    { Parts: list<string>
-      Exprs: list<Expr> }
 
   type PropName =
     | Ident of string
@@ -219,10 +218,10 @@ module Syntax =
     | Do of body: Block
     | Await of Await
     | Throw of value: Expr
-    | TemplateLiteral of TemplateLiteral
+    | TemplateLiteral of Common.TemplateLiteral<Expr>
     | TaggedTemplateLiteral of
       tag: Expr *
-      template: TemplateLiteral *
+      template: Common.TemplateLiteral<Expr> *
       throws: option<Type.Type>
 
   [<CustomEquality; NoComparison>]
@@ -386,6 +385,7 @@ module Syntax =
     | Infer of name: string
     | Wildcard
     | Binary of left: TypeAnn * op: string * right: TypeAnn // TODO: BinaryOp
+    | TemplateLiteral of Common.TemplateLiteral<TypeAnn>
 
   type TypeAnn =
     { Kind: TypeAnnKind
@@ -698,6 +698,7 @@ module Type =
     | Infer of name: string
     | Binary of left: Type * op: string * right: Type // use TypeRef? - const folding is probably a better approach
     | Wildcard
+    | TemplateLiteral of Common.TemplateLiteral<Type>
 
   [<CustomEquality; NoComparison>]
   type Type =

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -493,3 +493,15 @@ let ParseRangeIteratorType () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseTemplateLiteralType () =
+  let src =
+    """
+      type TemplateLiteral = `foo${number}`
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
@@ -1,0 +1,25 @@
+﻿input: 
+      type TemplateLiteral = `foo${number}`
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                TypeDecl
+                  ("TemplateLiteral",
+                   { Kind =
+                      TemplateLiteral
+                        { Parts = ["foo"; ""]
+                          Exprs = [{ Kind = Keyword Number
+                                     Span = { Start = (Ln: 2, Col: 36)
+                                              Stop = (Ln: 2, Col: 42) }
+                                     InferredType = None }] }
+                     Span = { Start = (Ln: 2, Col: 30)
+                              Stop = (Ln: 2, Col: 44) }
+                     InferredType = None }, None)
+               Span = { Start = (Ln: 2, Col: 7)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 7)
+                   Stop = (Ln: 3, Col: 5) } }] }

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -861,3 +861,62 @@ let InferDeclare () =
   printfn "result = %A" result
 
   Assert.False(Result.isError result)
+
+[<Fact>]
+let InferTemplateLiteralType () =
+  let result =
+    result {
+
+      let src =
+        """
+        type Foo = `foo${number}`
+        let x: Foo = "foo123"
+        type Bar = `A${string}B`
+        let y: Bar = "A1B"
+        type Baz = `A${string}B${string}C`
+        let z: Baz = "A1B2C"
+        let w: Baz = "ABCBC"
+        """
+
+      let! _, env = inferScript src
+      Assert.Value(env, "x", "Foo")
+      Assert.Value(env, "y", "Bar")
+      Assert.Value(env, "z", "Baz")
+      Assert.Value(env, "w", "Baz")
+    }
+
+  printfn "result = %A" result
+
+  Assert.False(Result.isError result)
+
+[<Fact>]
+let ParseTemplateLiteralType () =
+  let mutable parser: Parser<unit, unit> = eof
+  parser <- (pstring "C" |>> ignore) .>> parser
+  parser <- many (notFollowedBy parser >>. anyChar) |>> ignore
+  parser <- (pstring "B" |>> ignore) .>> parser
+  parser <- many (notFollowedBy parser >>. anyChar) |>> ignore
+  parser <- (pstring "A" |>> ignore) .>> parser
+
+  let result = run parser "ABCBC"
+
+  match result with
+  | Success(value, _, _) -> printfn "value = %A" value
+  | Failure(s, _, _) -> printfn "s = %A" s
+
+
+[<Fact>]
+let InferTemplateLiteralTypeError () =
+  let result =
+    result {
+      let src =
+        """
+        type Foo = `foo${number}`
+        let x: Foo = "foo123abc"
+        """
+
+      let! _, _ = inferScript src
+      ()
+    }
+
+  Assert.True(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -890,6 +890,31 @@ let InferTemplateLiteralType () =
   Assert.False(Result.isError result)
 
 [<Fact>]
+let InferTemplateLiteralTypeWithUnions () =
+  let result =
+    result {
+
+      let src =
+        """
+        type Dir = `${"top" | "bottom"}-${"left" | "right"}`
+        let a: Dir = "top-left"
+        let b: Dir = "top-right"
+        let c: Dir = "bottom-right"
+        let d: Dir = "bottom-left"
+        """
+
+      let! _, env = inferScript src
+      Assert.Value(env, "a", "Dir")
+      Assert.Value(env, "b", "Dir")
+      Assert.Value(env, "c", "Dir")
+      Assert.Value(env, "d", "Dir")
+    }
+
+  printfn "result = %A" result
+
+  Assert.False(Result.isError result)
+
+[<Fact>]
 let ParseTemplateLiteralType () =
   let mutable parser: Parser<unit, unit> = eof
   parser <- (pstring "C" |>> ignore) .>> parser
@@ -904,6 +929,18 @@ let ParseTemplateLiteralType () =
   | Success(value, _, _) -> printfn "value = %A" value
   | Failure(s, _, _) -> printfn "s = %A" s
 
+[<Fact>]
+let ParseTemplateLiteralTypeWithUnions () =
+  let mutable parser: Parser<unit, unit> = eof
+  parser <- (pstring "right" <|> pstring "left" |>> ignore) .>> parser
+  parser <- (pstring "-" |>> ignore) .>> parser
+  parser <- (pstring "top" <|> pstring "bottom" |>> ignore) .>> parser
+
+  let result = run parser "top-left"
+
+  match result with
+  | Success(value, _, _) -> printfn "value = %A" value
+  | Failure(s, _, _) -> printfn "s = %A" s
 
 [<Fact>]
 let InferTemplateLiteralTypeError () =

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -957,3 +957,19 @@ let InferTemplateLiteralTypeError () =
     }
 
   Assert.True(Result.isError result)
+
+[<Fact>]
+let InferTemplateLiteralTypeErrorWithUnion () =
+  let result =
+    result {
+      let src =
+        """
+        type Dir = `${"top" | "bottom"}-${"left" | "right"}`
+        let x: Dir = "top-bottom"
+        """
+
+      let! _, _ = inferScript src
+      ()
+    }
+
+  Assert.True(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -250,3 +250,25 @@ let InfersOmit () =
     }
 
   Assert.False(Result.isError res)
+
+[<Fact>]
+let InfersRecord () =
+  let res =
+    result {
+      let src =
+        """
+        type AnyKey = string | number | symbol
+        type Record<K: AnyKey, T> = {
+          [P]: T for P in K
+        }
+        type Point = Record<"x" | "y", number>
+        let p: Point = {x: 5, y: 10}
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "p", "Point")
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
+++ b/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
@@ -10,6 +10,7 @@
         <Compile Include="Folder.fs"/>
         <Compile Include="Env.fs"/>
         <Compile Include="Poly.fs"/>
+        <Compile Include="TemplateLiteral.fs"/>
         <Compile Include="Unify.fs"/>
         <Compile Include="Infer.fs"/>
         <Compile Include="Prelude.fs"/>

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -771,6 +771,9 @@ module rec Infer =
           let! min = inferTypeAnn ctx env range.Min
           let! max = inferTypeAnn ctx env range.Max
           return TypeKind.Range { Min = min; Max = max }
+        | TypeAnnKind.TemplateLiteral { Parts = parts; Exprs = exprs } ->
+          let! exprs = List.traverseResultM (inferTypeAnn ctx env) exprs
+          return TypeKind.TemplateLiteral { Parts = parts; Exprs = exprs }
       }
 
     let t: Result<Type, TypeError> =

--- a/src/Escalier.TypeChecker/TemplateLiteral.fs
+++ b/src/Escalier.TypeChecker/TemplateLiteral.fs
@@ -1,0 +1,62 @@
+namespace Escalier.TypeChecker
+
+open FParsec
+
+open Escalier.Data.Common
+open Escalier.Data.Type
+
+module TemplateLiteral =
+  let number: Parser<Number, unit> =
+    fun stream ->
+      let intReply = many1Satisfy isDigit stream
+
+      match intReply.Status with
+      | Ok ->
+        if stream.PeekString(2) = ".." then
+          Reply(Number.Int(int intReply.Result))
+        else if stream.PeekString(1) = "." then
+          let index = stream.Index
+          stream.Skip(1)
+          let decReply = many1Satisfy isDigit stream
+
+          match decReply.Status with
+          | Ok ->
+            let number = intReply.Result + "." + decReply.Result
+            Reply(Number.Float(float number))
+          | Error ->
+            stream.Seek(index)
+            Reply(Number.Int(int intReply.Result))
+          | _ -> Reply(decReply.Status, decReply.Error)
+        else
+          Reply(Number.Int(int intReply.Result))
+      | _ -> Reply(intReply.Status, intReply.Error)
+
+  let check (s: string) (tl: TemplateLiteral<Type>) : bool =
+    let { Parts = parts; Exprs = exprs } = tl
+
+    let firstPart, restParts = List.head parts, List.tail parts
+    let pairs = List.zip exprs restParts
+
+    let mutable parser: Parser<unit, unit> = eof
+
+    for expr, part in List.rev pairs do
+      if part.Length > 0 then
+        parser <- (pstring part |>> ignore) .>> parser
+
+      match expr.Kind with
+      | TypeKind.Primitive Primitive.Number ->
+        parser <- (number |>> ignore) .>> parser
+      | TypeKind.Primitive Primitive.Boolean ->
+        parser <- ((pstring "true" <|> pstring "false") |>> ignore) .>> parser
+      | TypeKind.Primitive Primitive.String ->
+        // This produces the same behaviour as `*.?` would in a regex
+        parser <- many (notFollowedBy parser >>. anyChar) |>> ignore
+
+    if firstPart.Length > 0 then
+      parser <- (pstring firstPart |>> ignore) .>> parser
+
+    match run parser s with
+    | Success((), _, pos) ->
+      printfn "pos = %A" pos
+      true
+    | Failure _ -> false

--- a/src/Escalier.TypeChecker/TemplateLiteral.fs
+++ b/src/Escalier.TypeChecker/TemplateLiteral.fs
@@ -31,6 +31,31 @@ module TemplateLiteral =
           Reply(Number.Int(int intReply.Result))
       | _ -> Reply(intReply.Status, intReply.Error)
 
+  let parserForType
+    (parser: Parser<unit, unit>)
+    (t: Type)
+    : Parser<unit, unit> =
+
+    let rec fold (t: Type) : Parser<unit, unit> =
+      match t.Kind with
+      | TypeKind.Literal lit ->
+        match lit with
+        | Literal.String s -> pstring s
+        | Literal.Boolean b -> pstring (string b)
+        | Literal.Number n -> pstring (string n)
+        | _ -> failwith $"TODO: parserForType - lit = ${lit}"
+        |>> ignore
+      | TypeKind.Primitive Primitive.Number -> number |>> ignore
+      | TypeKind.Primitive Primitive.Boolean ->
+        (pstring "true" <|> pstring "false") |>> ignore
+      | TypeKind.Primitive Primitive.String ->
+        // This produces the same behaviour as `*.?` would in a regex
+        many (notFollowedBy parser >>. anyChar) |>> ignore
+      | TypeKind.Union elems -> choice (List.map fold elems)
+      | _ -> failwith $"TODO: parserForType - t = {t}"
+
+    fold t .>> parser
+
   let check (s: string) (tl: TemplateLiteral<Type>) : bool =
     let { Parts = parts; Exprs = exprs } = tl
 
@@ -43,14 +68,18 @@ module TemplateLiteral =
       if part.Length > 0 then
         parser <- (pstring part |>> ignore) .>> parser
 
-      match expr.Kind with
-      | TypeKind.Primitive Primitive.Number ->
-        parser <- (number |>> ignore) .>> parser
-      | TypeKind.Primitive Primitive.Boolean ->
-        parser <- ((pstring "true" <|> pstring "false") |>> ignore) .>> parser
-      | TypeKind.Primitive Primitive.String ->
-        // This produces the same behaviour as `*.?` would in a regex
-        parser <- many (notFollowedBy parser >>. anyChar) |>> ignore
+      parser <- parserForType parser expr
+    // match expr.Kind with
+    // | TypeKind.Primitive Primitive.Number ->
+    //   parser <- (number |>> ignore) .>> parser
+    // | TypeKind.Primitive Primitive.Boolean ->
+    //   parser <- ((pstring "true" <|> pstring "false") |>> ignore) .>> parser
+    // | TypeKind.Primitive Primitive.String ->
+    //   // This produces the same behaviour as `*.?` would in a regex
+    //   parser <- many (notFollowedBy parser >>. anyChar) |>> ignore
+    // | TypeKind.Union elems ->
+    //   printfn $"union = ${expr}"
+    //   failwith "TODO: generate parser for union of types"
 
     if firstPart.Length > 0 then
       parser <- (pstring firstPart |>> ignore) .>> parser

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -200,6 +200,11 @@ module rec Unify =
         | Literal.Null, Literal.Null -> ()
         | Literal.Undefined, Literal.Undefined -> ()
         | _, _ -> return! Error(TypeError.TypeMismatch(t1, t2))
+      | TypeKind.Literal(Literal.String s), TypeKind.TemplateLiteral tl ->
+        if TemplateLiteral.check s tl then
+          ()
+        else
+          return! Error(TypeError.TypeMismatch(t1, t2))
       | TypeKind.UniqueSymbol id1, TypeKind.UniqueSymbol id2 when id1 = id2 ->
         ()
       | TypeKind.UniqueNumber id1, TypeKind.UniqueNumber id2 when id1 = id2 ->


### PR DESCRIPTION
I was going to try to get `${infer T}` inside of template literal types, but it appears `infer T` is not even working (or maybe just not tested) for outside of template literal types.  I'll work on that in a separate PR.

TODO:
- [x] handle union types inside `${}`