### PR TITLE
Distribute unions across conditional types inside of ExpandType instead of ExpandScheme

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -495,7 +495,10 @@ module rec Codegen =
           ObjType = buildType ctx target
           IndexType = buildType ctx index
           Loc = None }
-    | TypeKind.Condition(check, extends, trueType, falseType) ->
+    | TypeKind.Condition { Check = check
+                           Extends = extends
+                           TrueType = trueType
+                           FalseType = falseType } ->
       TsType.TsConditionalType
         { CheckType = buildType ctx check
           ExtendsType = buildType ctx extends

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -671,6 +671,12 @@ module Type =
 
     override this.ToString() = $"{this.Elem}[]"
 
+  type Condition =
+    { Check: Type
+      Extends: Type
+      TrueType: Type
+      FalseType: Type }
+
   [<RequireQualifiedAccess>]
   type TypeKind =
     | TypeVar of TypeVar
@@ -690,11 +696,7 @@ module Type =
     | Array of Array
     | KeyOf of Type
     | Index of target: Type * index: Type
-    | Condition of
-      check: Type *
-      extends: Type *
-      trueType: Type *
-      falseType: Type
+    | Condition of Condition
     | Infer of name: string
     | Binary of left: Type * op: string * right: Type // use TypeRef? - const folding is probably a better approach
     | Wildcard
@@ -769,7 +771,10 @@ module Type =
         $"{{{elems}}}"
       | TypeKind.Rest t -> $"...{t}"
       | TypeKind.Index(target, index) -> $"{target}[{index}]"
-      | TypeKind.Condition(check, extends, trueType, falseType) ->
+      | TypeKind.Condition { Check = check
+                             Extends = extends
+                             TrueType = trueType
+                             FalseType = falseType } ->
         $"{check} extends {extends} ? {trueType} : {falseType}"
       | TypeKind.KeyOf t -> $"keyof {t}"
       // TODO: handle operator precedence

--- a/src/Escalier.Interop/Infer.fs
+++ b/src/Escalier.Interop/Infer.fs
@@ -323,7 +323,12 @@ module rec Infer =
         let extendsType = inferTsType ctx env tsConditionalType.ExtendsType
         let trueType = inferTsType ctx env tsConditionalType.TrueType
         let falseType = inferTsType ctx env tsConditionalType.FalseType
-        TypeKind.Condition(checkType, extendsType, trueType, falseType)
+
+        TypeKind.Condition
+          { Check = checkType
+            Extends = extendsType
+            TrueType = trueType
+            FalseType = falseType }
       | TsType.TsInferType tsInferType ->
         TypeKind.Infer tsInferType.TypeParam.Name.Name
       | TsType.TsParenthesizedType tsParenthesizedType ->

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -79,13 +79,19 @@ let InferSimpleConditionalType () =
 
       let! ctx, env = inferScript src
 
-      let a = env.ExpandScheme (unify ctx) (Map.find "A" env.Schemes) None
+      let a =
+        env.ExpandScheme (unify ctx) (Map.find "A" env.Schemes) Map.empty None
+
       Assert.Equal("\"string\"", a.ToString())
 
-      let b = env.ExpandScheme (unify ctx) (Map.find "B" env.Schemes) None
+      let b =
+        env.ExpandScheme (unify ctx) (Map.find "B" env.Schemes) Map.empty None
+
       Assert.Equal("\"number\"", b.ToString())
 
-      let c = env.ExpandScheme (unify ctx) (Map.find "C" env.Schemes) None
+      let c =
+        env.ExpandScheme (unify ctx) (Map.find "C" env.Schemes) Map.empty None
+
       Assert.Equal("\"other\"", c.ToString())
     }
 
@@ -114,13 +120,19 @@ let InferNestedConditionalTypes () =
 
       let! ctx, env = inferScript src
 
-      let a = env.ExpandScheme (unify ctx) (Map.find "A" env.Schemes) None
+      let a =
+        env.ExpandScheme (unify ctx) (Map.find "A" env.Schemes) Map.empty None
+
       Assert.Equal("\"string\"", a.ToString())
 
-      let b = env.ExpandScheme (unify ctx) (Map.find "B" env.Schemes) None
+      let b =
+        env.ExpandScheme (unify ctx) (Map.find "B" env.Schemes) Map.empty None
+
       Assert.Equal("\"number\"", b.ToString())
 
-      let c = env.ExpandScheme (unify ctx) (Map.find "C" env.Schemes) None
+      let c =
+        env.ExpandScheme (unify ctx) (Map.find "C" env.Schemes) Map.empty None
+
       Assert.Equal("\"other\"", c.ToString())
     }
 
@@ -140,7 +152,11 @@ let InferExclude () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Result" env.Schemes) None
+        env.ExpandScheme
+          (unify ctx)
+          (Map.find "Result" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"b\" | \"c\" | \"d\"", result.ToString())
     }
@@ -161,7 +177,11 @@ let InferExtract () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Result" env.Schemes) None
+        env.ExpandScheme
+          (unify ctx)
+          (Map.find "Result" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("{x: 5, y: 10}", result.ToString())
     }
@@ -190,7 +210,11 @@ let InferCartesianProdType () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Cells" env.Schemes) None
+        env.ExpandScheme
+          (unify ctx)
+          (Map.find "Cells" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal(
         """["A", 1] | ["A", 2] | ["B", 1] | ["B", 2]""",
@@ -217,7 +241,7 @@ let InfersPick () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Bar" env.Schemes) None
+        env.ExpandScheme (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
 
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }
@@ -244,7 +268,7 @@ let InfersOmit () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Bar" env.Schemes) None
+        env.ExpandScheme (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
 
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -296,3 +296,24 @@ let InfersRecord () =
 
   printfn "res = %A" res
   Assert.False(Result.isError res)
+
+[<Fact>]
+let InfersNestedConditionals () =
+  let res =
+    result {
+      let src =
+        """
+        type Extends<X, Y, Z> = if X : Y { X } else { if Y : Z { Y } else { never } }
+        type Foo = Extends<5 | 10, 2 | 3 | 5 | 7, 3 | 6 | 9>
+        """
+
+      let! ctx, env = inferScript src
+
+      let result =
+        env.ExpandScheme (unify ctx) (Map.find "Foo" env.Schemes) Map.empty None
+
+      Assert.Equal("5 | 3", result.ToString())
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -253,7 +253,7 @@ module rec Env =
         let findCond =
           fun t ->
             match t.Kind with
-            | TypeKind.Condition(check, _, _, _) ->
+            | TypeKind.Condition { Check = check } ->
               checkTypes <- check :: checkTypes
             | _ -> ()
 
@@ -381,7 +381,10 @@ module rec Env =
             // special function to expand the type
             // TODO: Handle different kinds of index types, e.g. number, symbol
             failwith "TODO: expand index"
-        | TypeKind.Condition(check, extends, trueType, falseType) ->
+        | TypeKind.Condition { Check = check
+                               Extends = extends
+                               TrueType = trueType
+                               FalseType = falseType } ->
           match check.Kind with
           | TypeKind.Union types -> failwith "TODO: distribute conditional"
           | _ ->

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -462,8 +462,10 @@ module rec Env =
                              TypeArgs = typeArgs
                              Scheme = scheme } ->
 
-          // TODO: lookup `name` in `mapping` first
 
+          // TODO: Take this a setep further and update ExpandType and ExpandScheme
+          // to be functions that accept an `env: Env` param.  We can then augment
+          // the `env` instead of using the `mapping` param.
           let t =
             match Map.tryFind name mapping with
             | Some t -> t

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -233,6 +233,7 @@ module rec Env =
     member this.ExpandScheme
       (unify: Env -> Type -> Type -> Result<unit, TypeError>)
       (scheme: Scheme)
+      (mapping: Map<string, Type>)
       (typeArgs: option<list<Type>>)
       : Type =
 
@@ -242,81 +243,37 @@ module rec Env =
       let typeArgs =
         typeArgs
         |> Option.map (fun typeArgs ->
-          typeArgs |> List.map (fun t -> this.ExpandType unify t))
+          typeArgs |> List.map (fun t -> this.ExpandType unify mapping t))
 
       match scheme.TypeParams, typeArgs with
-      | None, None -> this.ExpandType unify scheme.Type
+      | None, None -> this.ExpandType unify mapping scheme.Type
       | Some(typeParams), Some(typeArgs) ->
         let mapping = Map.ofList (List.zip typeParams typeArgs)
-        let mutable checkTypes: List<Type> = []
-
-        let findCond =
-          fun t ->
-            match t.Kind with
-            | TypeKind.Condition { Check = check } ->
-              checkTypes <- check :: checkTypes
-            | _ -> ()
-
-        TypeVisitor.walkType findCond scheme.Type
-
-        let checkTypeNames =
-          checkTypes
-          |> List.choose (fun t ->
-            match t.Kind with
-            | TypeKind.TypeRef { Name = name } ->
-              match Map.containsKey name mapping with
-              | true -> Some(name)
-              | false -> None
-            | _ -> None)
-
-        if checkTypeNames.IsEmpty then
-          instantiateScheme scheme mapping
-        else
-          let mutable unionMapping = Map.empty
-          let mutable unionNames = []
-
-          for name in checkTypeNames do
-            let unionType = Map.find name mapping
-
-            match unionType.Kind with
-            | TypeKind.Union types ->
-              unionMapping <- Map.add name types unionMapping
-              unionNames <- name :: unionNames
-            | _ -> ()
-
-          // The elements of each list in the cartesian product
-          // appearin the same order as the names in unionNames.
-          let product = cartesian (Seq.toList unionMapping.Values)
-
-          match product.IsEmpty with
-          | true -> instantiateScheme scheme mapping
-          | false ->
-            let types =
-              product
-              |> List.map (fun types ->
-
-                let mutable mapping = mapping
-
-                // Elements from each list in the cartesian product
-                // are used to update the mapping we use to instantiate
-                // the scheme below.
-                List.iter2
-                  (fun name t -> mapping <- Map.add name t mapping)
-                  unionNames
-                  (List.rev types)
-
-                let t = instantiateScheme scheme mapping
-                this.ExpandType unify t)
-
-            union types
+        this.ExpandType unify mapping scheme.Type
       | _ -> failwith "TODO: expandScheme with type params/args"
 
     member this.ExpandType
       (unify: Env -> Type -> Type -> Result<unit, TypeError>)
+      (mapping: Map<string, Type>)
       (t: Type)
       : Type =
 
-      let rec expand t =
+      let rec expand mapping t =
+        // TODO: only define `fold` when we actually need to use it
+        let fold =
+          fun t ->
+            let result =
+              match t.Kind with
+              | TypeKind.TypeRef { Name = name
+                                   TypeArgs = typeArgs
+                                   Scheme = scheme } ->
+                match Map.tryFind name mapping with
+                | Some typeArg -> typeArg
+                | None -> t
+              | _ -> t
+
+            Some(result)
+
         match t.Kind with
         | TypeKind.TypeRef { Name = "Promise" } -> printfn $"t = {t}"
         | _ -> ()
@@ -325,7 +282,7 @@ module rec Env =
 
         match t.Kind with
         | TypeKind.KeyOf t ->
-          let t = this.ExpandType unify t
+          let t = this.ExpandType unify mapping t
 
           match t.Kind with
           | TypeKind.Object elems ->
@@ -354,8 +311,8 @@ module rec Env =
             union keys
           | _ -> failwith "TODO: expand keyof"
         | TypeKind.Index(target, index) ->
-          let target = this.ExpandType unify target
-          let index = this.ExpandType unify index
+          let target = this.ExpandType unify mapping target
+          let index = this.ExpandType unify mapping index
 
           let key =
             match index.Kind with
@@ -386,11 +343,41 @@ module rec Env =
                                TrueType = trueType
                                FalseType = falseType } ->
           match check.Kind with
-          | TypeKind.Union types -> failwith "TODO: distribute conditional"
+          | TypeKind.TypeRef { Name = name } ->
+            match Map.tryFind name mapping with
+            | Some { Kind = TypeKind.Union types } ->
+              let extends = expand mapping extends
+
+              let types =
+                types
+                |> List.map (fun check ->
+                  let newMapping = Map.add name check mapping
+
+                  match unify this check extends with
+                  | Ok _ -> expand newMapping trueType
+                  | Error _ -> expand newMapping falseType)
+
+              union types
+            | Some check ->
+              let newMapping = Map.add name check mapping
+
+              match unify this check extends with
+              | Ok _ -> expand newMapping trueType
+              | Error _ -> expand newMapping falseType
+
+            // failwith "TODO: replace check type with the type argument"
+            | _ ->
+              failwith
+                "TODO: check if the TypeRef's scheme is defined and use it"
+
+              match unify this check extends with
+              | Ok _ -> expand mapping trueType
+              | Error _ -> expand mapping falseType
           | _ ->
             match unify this check extends with
-            | Ok _ -> expand trueType
-            | Error _ -> expand falseType
+            | Ok _ -> expand mapping trueType
+            | Error _ -> expand mapping falseType
+
         | TypeKind.Binary _ -> simplify t
         // TODO: instead of expanding object types, we should try to
         // look up properties on the object type without expanding it
@@ -401,7 +388,7 @@ module rec Env =
             |> List.collect (fun elem ->
               match elem with
               | Mapped m ->
-                let c = this.ExpandType unify m.TypeParam.Constraint
+                let c = this.ExpandType unify mapping m.TypeParam.Constraint
 
                 match c.Kind with
                 | TypeKind.Union types ->
@@ -433,7 +420,7 @@ module rec Env =
 
                         Property
                           { Name = PropName.String name
-                            Type = this.ExpandType unify typeAnn
+                            Type = this.ExpandType unify mapping typeAnn
                             Optional = false // TODO
                             Readonly = false // TODO
                           }
@@ -456,32 +443,45 @@ module rec Env =
 
                   [ Property
                       { Name = PropName.String key
-                        Type = this.ExpandType unify typeAnn
+                        Type = this.ExpandType unify mapping typeAnn
                         Optional = false // TODO
                         Readonly = false // TODO
                       } ]
                 | _ -> failwith "TODO: expand mapped type - constraint type"
               | _ -> [ elem ])
 
-          { Kind = TypeKind.Object(elems)
-            Provenance = None // TODO: set provenance
-          }
+          let t =
+            { Kind = TypeKind.Object(elems)
+              Provenance = None // TODO: set provenance
+            }
+
+          // Replaces type parameters with their corresponding type arguments
+          // TODO: do this more consistently
+          if mapping = Map.empty then t else foldType fold t
         | TypeKind.TypeRef { Name = name
                              TypeArgs = typeArgs
                              Scheme = scheme } ->
 
+          // TODO: lookup `name` in `mapping` first
+
           let t =
-            match scheme with
-            | Some scheme -> this.ExpandScheme unify scheme typeArgs
+            match Map.tryFind name mapping with
+            | Some t -> t
             | None ->
-              match this.Schemes.TryFind name with
-              | Some scheme -> this.ExpandScheme unify scheme typeArgs
-              | None -> failwith $"{name} is not in scope"
+              match scheme with
+              | Some scheme -> this.ExpandScheme unify scheme mapping typeArgs
+              | None ->
+                match this.Schemes.TryFind name with
+                | Some scheme -> this.ExpandScheme unify scheme mapping typeArgs
+                | None -> failwith $"{name} is not in scope"
 
-          expand t
-        | _ -> t
+          expand mapping t
+        | _ ->
+          // Replaces type parameters with their corresponding type arguments
+          // TODO: do this more consistently
+          if mapping = Map.empty then t else foldType fold t
 
-      expand t
+      expand mapping t
 
   let rec bind
     (ctx: Ctx)

--- a/src/Escalier.TypeChecker/Folder.fs
+++ b/src/Escalier.TypeChecker/Folder.fs
@@ -88,14 +88,16 @@ module rec Folder =
         | TypeKind.Index(target, index) ->
           { Kind = TypeKind.Index(fold target, fold index)
             Provenance = None }
-        | TypeKind.Condition(check, extends, trueType, falseType) ->
+        | TypeKind.Condition { Check = check
+                               Extends = extends
+                               TrueType = trueType
+                               FalseType = falseType } ->
           { Kind =
-              TypeKind.Condition(
-                fold check,
-                fold extends,
-                fold trueType,
-                fold falseType
-              )
+              TypeKind.Condition
+                { Check = fold check
+                  Extends = fold extends
+                  TrueType = fold trueType
+                  FalseType = fold falseType }
             Provenance = None }
         | TypeKind.Infer _ -> t
         | TypeKind.Binary(left, op, right) ->

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -758,7 +758,13 @@ module rec Infer =
           let! extends = inferTypeAnn ctx env conditionType.Extends
           let! trueType = inferTypeAnn ctx env conditionType.TrueType
           let! falseType = inferTypeAnn ctx env conditionType.FalseType
-          return TypeKind.Condition(check, extends, trueType, falseType)
+
+          return
+            TypeKind.Condition
+              { Check = check
+                Extends = extends
+                TrueType = trueType
+                FalseType = falseType }
         | TypeAnnKind.Match matchType ->
           return! Error(TypeError.NotImplemented "TODO: inferTypeAnn - Match") // TODO
         | TypeAnnKind.Infer name -> return TypeKind.Infer name

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -490,7 +490,7 @@ module rec Infer =
         getPropType
           ctx
           env
-          (env.ExpandScheme (unify ctx) scheme typeArgs)
+          (env.ExpandScheme (unify ctx) scheme Map.empty typeArgs)
           key
           optChain
       | None ->
@@ -499,7 +499,7 @@ module rec Infer =
           getPropType
             ctx
             env
-            (env.ExpandScheme (unify ctx) scheme typeArgs)
+            (env.ExpandScheme (unify ctx) scheme Map.empty typeArgs)
             key
             optChain
         | None -> failwithf $"{key} not in scope"
@@ -1101,7 +1101,7 @@ module rec Infer =
 
         // TODO: add a variant of `ExpandType` that allows us to specify a
         // predicate that can stop the expansion early.
-        let expandedRightType = env.ExpandType (unify ctx) rightType
+        let expandedRightType = env.ExpandType (unify ctx) Map.empty rightType
 
         let elemType =
           match expandedRightType.Kind with

--- a/src/Escalier.TypeChecker/Poly.fs
+++ b/src/Escalier.TypeChecker/Poly.fs
@@ -86,14 +86,16 @@ module Poly =
         | TypeKind.Index(target, index) ->
           { Kind = TypeKind.Index(fold target, fold index)
             Provenance = None }
-        | TypeKind.Condition(check, extends, trueType, falseType) ->
+        | TypeKind.Condition { Check = check
+                               Extends = extends
+                               TrueType = trueType
+                               FalseType = falseType } ->
           { Kind =
-              TypeKind.Condition(
-                fold check,
-                fold extends,
-                fold trueType,
-                fold falseType
-              )
+              TypeKind.Condition
+                { Check = fold check
+                  Extends = fold extends
+                  TrueType = fold trueType
+                  FalseType = fold falseType }
             Provenance = None }
         | TypeKind.Infer _ -> t
         | TypeKind.Binary(left, op, right) ->

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -164,6 +164,7 @@ module rec Unify =
           else
             return! Error(TypeError.TypeMismatch(t1, t2))
         | _ ->
+          printfn $"unify({t1}, {t2})"
           printfn "TODO: expand `min` and `max` before unifying with `n`"
           return! Error(TypeError.TypeMismatch(t1, t2))
 
@@ -361,8 +362,8 @@ module rec Unify =
         ->
         return ()
       | _, _ ->
-        let t1' = env.ExpandType (unify ctx) t1
-        let t2' = env.ExpandType (unify ctx) t2
+        let t1' = env.ExpandType (unify ctx) Map.empty t1
+        let t2' = env.ExpandType (unify ctx) Map.empty t2
 
         if t1' <> t1 || t2' <> t2 then
           return! unify ctx env t1' t2'

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -223,7 +223,10 @@ module rec TypeVisitor =
       | TypeKind.Index(target, index) ->
         walk target
         walk index
-      | TypeKind.Condition(check, extends, trueType, falseType) ->
+      | TypeKind.Condition { Check = check
+                             Extends = extends
+                             TrueType = trueType
+                             FalseType = falseType } ->
         walk check
         walk extends
         walk trueType


### PR DESCRIPTION
The reason for this refactoring is that we want to support `infer T` inside of the `extends` clause of conditionals.  In order to support this we need `ExpandType` to distribute each conditional as it's encountered.  