### PR TITLE
Refactor ExpandScheme/ExpandType to be functions instead of methods

### DIFF
--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -80,17 +80,17 @@ let InferSimpleConditionalType () =
       let! ctx, env = inferScript src
 
       let a =
-        env.ExpandScheme (unify ctx) (Map.find "A" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "A" env.Schemes) Map.empty None
 
       Assert.Equal("\"string\"", a.ToString())
 
       let b =
-        env.ExpandScheme (unify ctx) (Map.find "B" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "B" env.Schemes) Map.empty None
 
       Assert.Equal("\"number\"", b.ToString())
 
       let c =
-        env.ExpandScheme (unify ctx) (Map.find "C" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "C" env.Schemes) Map.empty None
 
       Assert.Equal("\"other\"", c.ToString())
     }
@@ -121,17 +121,17 @@ let InferNestedConditionalTypes () =
       let! ctx, env = inferScript src
 
       let a =
-        env.ExpandScheme (unify ctx) (Map.find "A" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "A" env.Schemes) Map.empty None
 
       Assert.Equal("\"string\"", a.ToString())
 
       let b =
-        env.ExpandScheme (unify ctx) (Map.find "B" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "B" env.Schemes) Map.empty None
 
       Assert.Equal("\"number\"", b.ToString())
 
       let c =
-        env.ExpandScheme (unify ctx) (Map.find "C" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "C" env.Schemes) Map.empty None
 
       Assert.Equal("\"other\"", c.ToString())
     }
@@ -152,7 +152,8 @@ let InferExclude () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme
+        expandScheme
+          env
           (unify ctx)
           (Map.find "Result" env.Schemes)
           Map.empty
@@ -177,7 +178,8 @@ let InferExtract () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme
+        expandScheme
+          env
           (unify ctx)
           (Map.find "Result" env.Schemes)
           Map.empty
@@ -210,7 +212,8 @@ let InferCartesianProdType () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme
+        expandScheme
+          env
           (unify ctx)
           (Map.find "Cells" env.Schemes)
           Map.empty
@@ -241,7 +244,7 @@ let InfersPick () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
 
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }
@@ -268,7 +271,7 @@ let InfersOmit () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
 
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }
@@ -310,7 +313,7 @@ let InfersNestedConditionals () =
       let! ctx, env = inferScript src
 
       let result =
-        env.ExpandScheme (unify ctx) (Map.find "Foo" env.Schemes) Map.empty None
+        expandScheme env (unify ctx) (Map.find "Foo" env.Schemes) Map.empty None
 
       Assert.Equal("5 | 3", result.ToString())
     }

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -490,7 +490,7 @@ module rec Infer =
         getPropType
           ctx
           env
-          (env.ExpandScheme (unify ctx) scheme Map.empty typeArgs)
+          (expandScheme env (unify ctx) scheme Map.empty typeArgs)
           key
           optChain
       | None ->
@@ -499,7 +499,7 @@ module rec Infer =
           getPropType
             ctx
             env
-            (env.ExpandScheme (unify ctx) scheme Map.empty typeArgs)
+            (expandScheme env (unify ctx) scheme Map.empty typeArgs)
             key
             optChain
         | None -> failwithf $"{key} not in scope"
@@ -1101,7 +1101,7 @@ module rec Infer =
 
         // TODO: add a variant of `ExpandType` that allows us to specify a
         // predicate that can stop the expansion early.
-        let expandedRightType = env.ExpandType (unify ctx) Map.empty rightType
+        let expandedRightType = expandType env (unify ctx) Map.empty rightType
 
         let elemType =
           match expandedRightType.Kind with

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -362,8 +362,8 @@ module rec Unify =
         ->
         return ()
       | _, _ ->
-        let t1' = env.ExpandType (unify ctx) Map.empty t1
-        let t2' = env.ExpandType (unify ctx) Map.empty t2
+        let t1' = expandType env (unify ctx) Map.empty t1
+        let t2' = expandType env (unify ctx) Map.empty t2
 
         if t1' <> t1 || t2' <> t2 then
           return! unify ctx env t1' t2'


### PR DESCRIPTION
This will allow us to get rid of the `mapping` param we're passing to these functions.  I'll do that in a separate PR.