### PR TITLE
Type check `infers` types

### DIFF
--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -508,7 +508,8 @@ let ParseTemplateLiteralType () =
 
 [<Fact>]
 let ParseInferType () =
-  let src = "type ReturnType<T> = if T: fn () -> infer R { R } else { never }"
+  let src =
+    "type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never }"
 
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -505,3 +505,12 @@ let ParseTemplateLiteralType () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseInferType () =
+  let src = "type ReturnType<T> = if T: fn () -> infer R { R } else { never }"
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -1,0 +1,50 @@
+﻿input: type ReturnType<T> = if T: fn () -> infer R { R } else { never }
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                TypeDecl
+                  ("ReturnType",
+                   { Kind =
+                      Condition
+                        { Check = { Kind = TypeRef ("T", None)
+                                    Span = { Start = (Ln: 1, Col: 25)
+                                             Stop = (Ln: 1, Col: 26) }
+                                    InferredType = None }
+                          Extends =
+                           { Kind =
+                              Function
+                                { TypeParams = None
+                                  ParamList = []
+                                  ReturnType =
+                                   { Kind = Infer "R"
+                                     Span = { Start = (Ln: 1, Col: 37)
+                                              Stop = (Ln: 1, Col: 45) }
+                                     InferredType = None }
+                                  Throws = None
+                                  IsAsync = false }
+                             Span = { Start = (Ln: 1, Col: 28)
+                                      Stop = (Ln: 1, Col: 45) }
+                             InferredType = None }
+                          TrueType = { Kind = TypeRef ("R", None)
+                                       Span = { Start = (Ln: 1, Col: 47)
+                                                Stop = (Ln: 1, Col: 49) }
+                                       InferredType = None }
+                          FalseType = { Kind = Keyword Never
+                                        Span = { Start = (Ln: 1, Col: 58)
+                                                 Stop = (Ln: 1, Col: 64) }
+                                        InferredType = None } }
+                     Span = { Start = (Ln: 1, Col: 22)
+                              Stop = (Ln: 1, Col: 65) }
+                     InferredType = None },
+                   Some [{ Span = { Start = (Ln: 1, Col: 17)
+                                    Stop = (Ln: 1, Col: 18) }
+                           Name = "T"
+                           Constraint = None
+                           Default = None }])
+               Span = { Start = (Ln: 1, Col: 1)
+                        Stop = (Ln: 1, Col: 65) } }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 65) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -1,4 +1,4 @@
-﻿input: type ReturnType<T> = if T: fn () -> infer R { R } else { never }
+﻿input: type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never }
 output: Ok
   { Items =
      [Stmt
@@ -17,27 +17,45 @@ output: Ok
                            { Kind =
                               Function
                                 { TypeParams = None
-                                  ParamList = []
+                                  ParamList =
+                                   [{ Pattern =
+                                       { Kind =
+                                          Rest
+                                            { Kind = Ident { Name = "args"
+                                                             IsMut = false
+                                                             Assertion = None }
+                                              Span = { Start = (Ln: 1, Col: 35)
+                                                       Stop = (Ln: 1, Col: 39) }
+                                              InferredType = None }
+                                         Span = { Start = (Ln: 1, Col: 32)
+                                                  Stop = (Ln: 1, Col: 39) }
+                                         InferredType = None }
+                                      TypeAnn =
+                                       { Kind = TypeRef ("_", None)
+                                         Span = { Start = (Ln: 1, Col: 41)
+                                                  Stop = (Ln: 1, Col: 42) }
+                                         InferredType = None }
+                                      Optional = false }]
                                   ReturnType =
                                    { Kind = Infer "R"
-                                     Span = { Start = (Ln: 1, Col: 37)
-                                              Stop = (Ln: 1, Col: 45) }
+                                     Span = { Start = (Ln: 1, Col: 47)
+                                              Stop = (Ln: 1, Col: 55) }
                                      InferredType = None }
                                   Throws = None
                                   IsAsync = false }
                              Span = { Start = (Ln: 1, Col: 28)
-                                      Stop = (Ln: 1, Col: 45) }
+                                      Stop = (Ln: 1, Col: 55) }
                              InferredType = None }
                           TrueType = { Kind = TypeRef ("R", None)
-                                       Span = { Start = (Ln: 1, Col: 47)
-                                                Stop = (Ln: 1, Col: 49) }
+                                       Span = { Start = (Ln: 1, Col: 57)
+                                                Stop = (Ln: 1, Col: 59) }
                                        InferredType = None }
                           FalseType = { Kind = Keyword Never
-                                        Span = { Start = (Ln: 1, Col: 58)
-                                                 Stop = (Ln: 1, Col: 64) }
+                                        Span = { Start = (Ln: 1, Col: 68)
+                                                 Stop = (Ln: 1, Col: 74) }
                                         InferredType = None } }
                      Span = { Start = (Ln: 1, Col: 22)
-                              Stop = (Ln: 1, Col: 65) }
+                              Stop = (Ln: 1, Col: 75) }
                      InferredType = None },
                    Some [{ Span = { Start = (Ln: 1, Col: 17)
                                     Stop = (Ln: 1, Col: 18) }
@@ -45,6 +63,6 @@ output: Ok
                            Constraint = None
                            Default = None }])
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 65) } }
+                        Stop = (Ln: 1, Col: 75) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 65) } }] }
+                   Stop = (Ln: 1, Col: 75) } }] }

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -966,6 +966,14 @@ module Parser =
       else
         Reply(Error, messageError "Expected '`'")
 
+  // TODO: add support for type constraints on the inferred type
+  let private inferType =
+    withSpan (strWs "infer" >>. ident)
+    |>> fun (name, span) ->
+      { TypeAnn.Kind = TypeAnnKind.Infer(name)
+        Span = span
+        InferredType = None }
+
   let primaryType =
     choice
       [ litTypeAnn
@@ -976,6 +984,7 @@ module Parser =
         funcTypeAnn
         typeofTypeAnn // aka TypeQuery
         keyofTypeAnn
+        inferType
         restTypeAnn
         objectTypeAnn
         condTypeAnn

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -80,17 +80,35 @@ let InferSimpleConditionalType () =
       let! ctx, env = inferScript src
 
       let a =
-        expandScheme env (unify ctx) (Map.find "A" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "A" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"string\"", a.ToString())
 
       let b =
-        expandScheme env (unify ctx) (Map.find "B" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "B" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"number\"", b.ToString())
 
       let c =
-        expandScheme env (unify ctx) (Map.find "C" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "C" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"other\"", c.ToString())
     }
@@ -121,17 +139,35 @@ let InferNestedConditionalTypes () =
       let! ctx, env = inferScript src
 
       let a =
-        expandScheme env (unify ctx) (Map.find "A" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "A" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"string\"", a.ToString())
 
       let b =
-        expandScheme env (unify ctx) (Map.find "B" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "B" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"number\"", b.ToString())
 
       let c =
-        expandScheme env (unify ctx) (Map.find "C" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "C" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("\"other\"", c.ToString())
     }
@@ -153,6 +189,7 @@ let InferExclude () =
 
       let result =
         expandScheme
+          ctx
           env
           (unify ctx)
           (Map.find "Result" env.Schemes)
@@ -179,6 +216,7 @@ let InferExtract () =
 
       let result =
         expandScheme
+          ctx
           env
           (unify ctx)
           (Map.find "Result" env.Schemes)
@@ -213,6 +251,7 @@ let InferCartesianProdType () =
 
       let result =
         expandScheme
+          ctx
           env
           (unify ctx)
           (Map.find "Cells" env.Schemes)
@@ -244,7 +283,13 @@ let InfersPick () =
       let! ctx, env = inferScript src
 
       let result =
-        expandScheme env (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "Bar" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }
@@ -271,7 +316,13 @@ let InfersOmit () =
       let! ctx, env = inferScript src
 
       let result =
-        expandScheme env (unify ctx) (Map.find "Bar" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "Bar" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }
@@ -313,7 +364,13 @@ let InfersNestedConditionals () =
       let! ctx, env = inferScript src
 
       let result =
-        expandScheme env (unify ctx) (Map.find "Foo" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "Foo" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("5 | 3", result.ToString())
     }
@@ -321,7 +378,7 @@ let InfersNestedConditionals () =
   printfn "res = %A" res
   Assert.False(Result.isError res)
 
-[<Fact(Skip = "Add inferred types to scope in `expandType`")>]
+[<Fact>]
 let InfersReturnType () =
   let res =
     result {
@@ -334,7 +391,13 @@ let InfersReturnType () =
       let! ctx, env = inferScript src
 
       let result =
-        expandScheme env (unify ctx) (Map.find "Foo" env.Schemes) Map.empty None
+        expandScheme
+          ctx
+          env
+          (unify ctx)
+          (Map.find "Foo" env.Schemes)
+          Map.empty
+          None
 
       Assert.Equal("number", result.ToString())
     }

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -174,7 +174,7 @@ let InferCartesianProdType () =
     result {
       let src =
         """
-        type CartesianProduce<X, Y> =
+        type CartesianProduct<X, Y> =
           if X : unknown {
             if Y : unknown {
               [X, Y]
@@ -184,7 +184,7 @@ let InferCartesianProdType () =
           } else {
             never
           }
-        type Cells = CartesianProduce<"A" | "B", 1 | 2>
+        type Cells = CartesianProduct<"A" | "B", 1 | 2>
         """
 
       let! ctx, env = inferScript src
@@ -268,6 +268,27 @@ let InfersRecord () =
       let! _, env = inferScript src
 
       Assert.Value(env, "p", "Point")
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let InfersInferType () =
+  let res =
+    result {
+      let src =
+        """
+        type ReturnType<T> = if T: fn () -> infer R { R } else { never }
+        type Foo = ReturnType<fn () -> number>
+        """
+
+      let! ctx, env = inferScript src
+
+      let result =
+        env.ExpandScheme (unify ctx) (Map.find "Foo" env.Schemes) None
+
+      Assert.Equal("number", result.ToString())
     }
 
   printfn "res = %A" res

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -46,6 +46,7 @@ module rec Infer =
       Pattern.Tuple(List.map (patternToPattern >> Some) elems)
     | PatternKind.Wildcard { Assertion = assertion } -> Pattern.Wildcard
     | PatternKind.Literal lit -> Pattern.Literal lit
+    | PatternKind.Rest rest -> Pattern.Rest(patternToPattern rest)
 
   let inferPropName
     (ctx: Ctx)
@@ -736,7 +737,10 @@ module rec Infer =
                   Scheme = scheme }
                 |> TypeKind.TypeRef
           | None ->
-            return! Error(TypeError.SemanticError $"{name} is not in scope")
+            if name = "_" then
+              return TypeKind.Wildcard
+            else
+              return! Error(TypeError.SemanticError $"{name} is not in scope")
         | TypeAnnKind.Function functionType ->
           let! f = inferFunctionType ctx env functionType
           return TypeKind.Function(f)

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -362,8 +362,8 @@ module rec Unify =
         ->
         return ()
       | _, _ ->
-        let t1' = expandType env (unify ctx) Map.empty t1
-        let t2' = expandType env (unify ctx) Map.empty t2
+        let t1' = expandType ctx env (unify ctx) Map.empty t1
+        let t2' = expandType ctx env (unify ctx) Map.empty t2
 
         if t1' <> t1 || t2' <> t2 then
           return! unify ctx env t1' t2'

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -27,6 +27,8 @@ module rec Unify =
       | TypeKind.TypeVar _, _ -> do! bind ctx env unify t1 t2
       | _, TypeKind.TypeVar _ -> do! unify ctx env t2 t1
       | TypeKind.Primitive p1, TypeKind.Primitive p2 when p1 = p2 -> ()
+      | TypeKind.Wildcard, _ -> ()
+      | _, TypeKind.Wildcard -> ()
       | _, TypeKind.Keyword Keyword.Unknown -> () // All types are assignable to `unknown`
       | TypeKind.Keyword Keyword.Never, _ -> () // `never` is assignable to all types
       | TypeKind.Tuple elems1, TypeKind.Tuple elems2 ->
@@ -119,23 +121,46 @@ module rec Unify =
           return! Error(TypeError.SemanticError("Too many rest elements!"))
       | TypeKind.Function(f1), TypeKind.Function(f2) ->
         // TODO: check if `f1` and `f2` have the same type params
+        // TODO: check if the type params have the same variance
         let! f1 = instantiateFunc ctx f1 None
         let! f2 = instantiateFunc ctx f2 None
 
-        let paramList1 =
-          List.map (fun (param: FuncParam) -> param.Type) f1.ParamList
+        let nonRestParams2, restParams2 =
+          List.partition
+            (fun param ->
+              match param.Pattern with
+              | Pattern.Rest _ -> false
+              | _ -> true)
+            f2.ParamList
 
-        let paramList2 =
-          List.map (fun (param: FuncParam) -> param.Type) f2.ParamList
+        match restParams2 with
+        | [] ->
+          if f1.ParamList.Length > f2.ParamList.Length then
+            // t1 needs to have at least as many params as t2
+            return! Error(TypeError.TypeMismatch(t1, t2))
 
-        if paramList1.Length > paramList2.Length then
-          // t1 needs to have at least as many params as t2
-          return! Error(TypeError.TypeMismatch(t1, t2))
+          for i in 0 .. f1.ParamList.Length - 1 do
+            let param1 = f1.ParamList[i]
+            let param2 = f2.ParamList[i]
 
-        for i in 0 .. paramList1.Length - 1 do
-          let param1 = paramList1[i]
-          let param2 = paramList2[i]
-          do! unify ctx env param2 param1 // params are contravariant
+            do! unify ctx env param2.Type param1.Type // params are contravariant
+        | [ restParam2 ] ->
+          for i in 0 .. nonRestParams2.Length - 1 do
+            let param1 = f1.ParamList[i]
+            let param2 = f2.ParamList[i]
+            do! unify ctx env param2.Type param1.Type // params are contravariant
+
+          let restParam1 =
+            { Kind =
+                TypeKind.Tuple(
+                  List.map
+                    (fun (param: FuncParam) -> param.Type)
+                    (List.skip nonRestParams2.Length f1.ParamList)
+                )
+              Provenance = None }
+
+          do! unify ctx env restParam2.Type restParam1
+        | _ -> return! Error(TypeError.SemanticError("Too many rest params!"))
 
         do! unify ctx env f1.Return f2.Return // returns are covariant
         do! unify ctx env f1.Throws f2.Throws // throws are covariant


### PR DESCRIPTION
This is used in utility types such as `ReturnType` and `Parameters`.

TODO:
- [x] make `ReturnType` work on any function
- [x] make `Parameters` work
