### PR TITLE
Support partial object matches and more

### DIFF
--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -434,28 +434,6 @@ let PartialDestructuring () =
   Assert.False(Result.isError res)
 
 [<Fact>]
-let PatternMatchingImmutableTypes () =
-  let res =
-    result {
-      let src =
-        """
-        declare let value: #[number, string] | #{a: number, b: string}
-        let result = match value {
-          | #[a, b] => a
-          | #{a, b} => a
-        }
-        """
-
-      let! _, env = inferScript src
-
-      Assert.Value(env, "result", "number")
-    }
-
-  printfn "res = %A" res
-  Assert.False(Result.isError res)
-
-
-[<Fact>]
 let ImmutableTuplesAreIncompatibleWithRegularTuples () =
   let res =
     result {
@@ -485,6 +463,24 @@ let ImmutableObjectsAreIncompatibleWithRegularObjects () =
       let! ctx, env = inferScript src
 
       Assert.Equal(ctx.Diagnostics.Length, 1)
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let DescructuringArray () =
+  let res =
+    result {
+      let src =
+        """
+        declare let array: number[]
+        let [a, b] = array
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "a", "number | undefined")
     }
 
   printfn "res = %A" res

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -37,7 +37,8 @@ let getEnv () =
 
   { Values = values
     Schemes = Map.empty
-    IsAsync = false }
+    IsAsync = false
+    IsPatternMatching = false }
 
 let dummySpan =
   { Start = Position("", 0, 0, 0)

--- a/src/Escalier.TypeChecker.Tests/PatternMatching.fs
+++ b/src/Escalier.TypeChecker.Tests/PatternMatching.fs
@@ -89,7 +89,7 @@ let BasicPatternMatchingInferExpr () =
   printfn "result = %A" result
   Assert.False(Result.isError result)
 
-[<Fact(Skip = "TODO: simplify union newExprTypes before unifying with exprType")>]
+[<Fact>]
 let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
   let result =
     result {
@@ -102,6 +102,14 @@ let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
             | {x: 0, y is number} => "y-axis"
             | _ => "other"
           }
+          
+        let bar = fn (x, y) =>
+          match {x, y} {
+            | {x: 0, y: 0} => "origin"
+            | {x is number, y: 0} => "x-axis"
+            | {x: 0, y is number} => "y-axis"
+            | {x is number, y is number} => "other"
+          }
         """
 
       let! _, env = inferScript src
@@ -109,11 +117,16 @@ let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
       Assert.Value(
         env,
         "foo",
-        "fn (x: 0, y: 0) -> \"origin\" | \"x-axis\" | \"y-axis\" | \"other\""
+        "fn <A, B>(x: A | number, y: B | number) -> \"origin\" | \"x-axis\" | \"y-axis\" | \"other\""
+      )
+
+      Assert.Value(
+        env,
+        "bar",
+        "fn (x: number, y: number) -> \"origin\" | \"x-axis\" | \"y-axis\" | \"other\""
       )
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker.Tests/PatternMatching.fs
+++ b/src/Escalier.TypeChecker.Tests/PatternMatching.fs
@@ -59,6 +59,7 @@ let BasicPatternMatching () =
       )
     }
 
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -81,7 +82,34 @@ let BasicPatternMatchingInferExpr () =
       Assert.Value(
         env,
         "foo",
-        "fn <A, B: number>(x: A | B | 1 | 0) -> \"none\" | \"one\" | \"negative\" | \"other\""
+        "fn <B, A: number>(x: 0 | 1 | A | B) -> \"none\" | \"one\" | \"negative\" | \"other\""
+      )
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact(Skip = "TODO: simplify union newExprTypes before unifying with exprType")>]
+let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
+  let result =
+    result {
+      let src =
+        """
+        let foo = fn (x, y) =>
+          match {x, y} {
+            | {x: 0, y: 0} => "origin"
+            | {x is number, y: 0} => "x-axis"
+            | {x: 0, y is number} => "y-axis"
+            | _ => "other"
+          }
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(
+        env,
+        "foo",
+        "fn (x: 0, y: 0) -> \"origin\" | \"x-axis\" | \"y-axis\" | \"other\""
       )
     }
 
@@ -192,6 +220,7 @@ let PatternMatchingArrays () =
       Assert.Value(env, "sum", "fn (arg0: number[]) -> number")
     }
 
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -217,17 +246,40 @@ let PatternMatchingPrimitiveAssertions () =
 
   Assert.False(Result.isError result)
 
-
-[<Fact(Skip = "TODO: allow partial matches")>]
-let PartialPatternMatching () =
+[<Fact>]
+let PartialPatternMatchingObject () =
   let res =
     result {
       let src =
         """
-        declare let value: [number, string] | {a: number, b: string}
+        declare let value: {a: number, b: string} | [number, string]
         let result = match value {
-          | [a] => a
-          | {a} => a
+          | [a, _] => a
+          | {b} => b
+        }
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "result", "number | string")
+    }
+
+  match res with
+  | Ok resultValue -> printfn $"res = Ok({resultValue})"
+  | Error errorValue -> printfn $"res = Error({errorValue})"
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let PatternMatchingImmutableTypes () =
+  let res =
+    result {
+      let src =
+        """
+        declare let value: #[number, string] | #{a: number, b: string}
+        let result = match value {
+          | #[a, b] => a
+          | #{a, b} => a
         }
         """
 
@@ -236,8 +288,52 @@ let PartialPatternMatching () =
       Assert.Value(env, "result", "number")
     }
 
+  printfn "res = %A" res
+  Assert.False(Result.isError res)
+
+
+[<Fact>]
+let PatternMatchingDisallowsExtraProperties () =
+  let res =
+    result {
+      let src =
+        """
+        declare let value: {a: number, b: string}
+        let result = match value {
+          | {a, b: _, c: _} => a
+        }
+        """
+
+      let! _ = inferScript src
+
+      ()
+    }
+
   match res with
   | Ok resultValue -> printfn $"res = Ok({resultValue})"
   | Error errorValue -> printfn $"res = Error({errorValue})"
 
-  Assert.False(Result.isError res)
+  Assert.True(Result.isError res)
+
+[<Fact>]
+let PatternMatchingDisallowsPartialMappingOfTuples () =
+  let res =
+    result {
+      let src =
+        """
+        declare let value: [number, string]
+        let result = match value {
+          | [a] => a
+        }
+        """
+
+      let! _ = inferScript src
+
+      ()
+    }
+
+  match res with
+  | Ok resultValue -> printfn $"res = Ok({resultValue})"
+  | Error errorValue -> printfn $"res = Error({errorValue})"
+
+  Assert.True(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -201,7 +201,8 @@ let InferIdentifier () =
   let env =
     { Env.Values = Map([ ("foo", (t, false)) ])
       Env.Schemes = Map([])
-      Env.IsAsync = false }
+      Env.IsAsync = false
+      Env.IsPatternMatching = false }
 
   let result =
     result {

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -172,12 +172,14 @@ module rec Env =
   type Env =
     { Values: Map<string, Binding>
       Schemes: Map<string, Scheme>
-      IsAsync: bool }
+      IsAsync: bool
+      IsPatternMatching: bool }
 
     static member empty =
       { Values = Map.empty
         Schemes = Map.empty
-        IsAsync = false }
+        IsAsync = false
+        IsPatternMatching = false }
 
     // TODO: Rename to AddBinding
     // TODO: don't curry this function

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -233,7 +233,8 @@ module Prelude =
                 ("&&", logical) ]
 
           Env.Schemes = Map([ ("Promise", promise) ])
-          Env.IsAsync = false }
+          Env.IsAsync = false
+          Env.IsPatternMatching = false }
 
       let ctx =
         Ctx(

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -238,6 +238,8 @@ module rec TypeVisitor =
       | TypeKind.Range { Min = min; Max = max } ->
         walk min
         walk max
+      | TypeKind.UniqueNumber _ -> ()
+      | TypeKind.TemplateLiteral { Exprs = exprs } -> List.iter walk exprs
 
       f t
 


### PR DESCRIPTION
In additional to partial object matches, this PR also simplifies union types of multiple objects when the matched expression contains type variables.

Fixes #120.