### PR TITLE
Add support for `struct`

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -205,6 +205,11 @@ module Syntax =
       OptChain: bool
       mutable Throws: option<Type.Type> }
 
+  type Struct =
+    { Name: string
+      TypeArgs: option<list<TypeAnn>>
+      Elems: list<ObjElem> }
+
   type Try =
     { Body: Block
       Catch: option<list<MatchCase>>
@@ -222,6 +227,7 @@ module Syntax =
     | Function of Function
     | Call of Call
     | Object of Common.Object<ObjElem>
+    | Struct of Struct
     | Tuple of Common.Tuple<Expr>
     | Range of Common.Range<Expr>
     | Index of target: Expr * index: Expr * opt_chain: bool
@@ -320,7 +326,7 @@ module Syntax =
 
     override this.ToString() = this.Kind.ToString()
 
-  type Struct =
+  type StructDecl =
     { Name: string
       TypeParams: option<list<TypeParam>>
       Members: list<Property> }
@@ -336,7 +342,7 @@ module Syntax =
       name: string *
       typeAnn: TypeAnn *
       typeParams: option<list<TypeParam>>
-    | StructDecl of Struct
+    | StructDecl of StructDecl
 
   type Decl = { Kind: DeclKind; Span: Span }
 

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -149,9 +149,25 @@ module Syntax =
       Throws: option<TypeAnn>
       IsAsync: bool }
 
+  // TODO: include optional name
   type Function =
     { Sig: FuncSig<option<TypeAnn>>
       Body: BlockOrExpr }
+
+  type Method =
+    { Name: string
+      Sig: FuncSig<option<TypeAnn>>
+      Body: BlockOrExpr }
+
+  type Getter =
+    { Name: string
+      ReturnType: TypeAnn
+      Throws: TypeAnn }
+
+  type Setter =
+    { Name: string
+      Param: FuncParam<TypeAnn>
+      Throws: TypeAnn }
 
   type MatchCase =
     { Span: Span
@@ -300,12 +316,20 @@ module Syntax =
 
     override this.ToString() = this.Kind.ToString()
 
+  type Struct =
+    { Name: string
+      TypeParams: option<list<TypeParam>>
+      Members: list<Property> }
+
+  type Impl = { Name: string; Members: list<Method> }
+
   type DeclKind =
     | VarDecl of name: Pattern * init: Expr * typeAnn: option<TypeAnn>
     | TypeDecl of
       name: string *
       typeAnn: TypeAnn *
       typeParams: option<list<TypeParam>>
+    | StructDecl of Struct
 
   type Decl = { Kind: DeclKind; Span: Span }
 
@@ -314,6 +338,7 @@ module Syntax =
     | For of left: Pattern * right: Expr * body: Block
     | Return of option<Expr>
     | Decl of Decl
+    | Impl of Impl
 
   type Stmt = { Kind: StmtKind; Span: Span }
 
@@ -336,9 +361,9 @@ module Syntax =
   type ObjTypeAnnElem =
     | Callable of FunctionType
     | Constructor of FunctionType
-    | Method of name: string * is_mut: bool * type_: Function
-    | Getter of name: string * return_type: TypeAnn * throws: TypeAnn
-    | Setter of name: string * param: FuncParam<TypeAnn> * throws: TypeAnn
+    | Method of MethodType
+    | Getter of Getter
+    | Setter of Setter
     | Property of Property
     | Mapped of Mapped
 
@@ -356,6 +381,8 @@ module Syntax =
     | Object
 
   type FunctionType = FuncSig<TypeAnn>
+
+  type MethodType = { Name: PropName; Type: FunctionType }
 
   type ConditionType =
     { Check: TypeAnn

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -931,31 +931,11 @@ module Type =
     | false -> $"{{{elems}}}"
 
   let printStruct (ctx: PrintCtx) (s: Struct) : string =
-    let elems =
-      List.map
-        (fun (elem: ObjTypeElem) ->
-          match elem with
-          | Property { Name = name
-                       Optional = optional
-                       Readonly = readonly
-                       Type = t } ->
-            let ctx = { Precedence = 0 }
-            let optional = if optional then "?" else ""
-            let readonly = if readonly then "readonly " else ""
-            $"{readonly}{name}{optional}: {printType ctx t}"
-          | Mapped mapped -> printMapped ctx mapped
-          | _ -> failwith "TODO: Type.ToString - Object - Elem"
-
-        )
-        s.Elems
-
-    let elems = String.concat ", " elems
-
     match s.TypeArgs with
     | Some typeArgs ->
       let typeArgs = List.map (printType ctx) typeArgs |> String.concat ", "
-      $"{s.Name}<{typeArgs}> {{{elems}}}"
-    | None -> $"{s.Name} {{{elems}}}"
+      $"{s.Name}<{typeArgs}>"
+    | None -> $"{s.Name}"
 
   let printFunction (ctx: PrintCtx) (f: Function) : string =
     let ps =

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -263,6 +263,10 @@ module Syntax =
     | Ident of string
     | Member of left: QualifiedIdent * right: string
 
+  type TypeRef =
+    { Ident: string // TOOD: use QualifiedIdent
+      TypeArgs: option<list<TypeAnn>> }
+
   type KeyValuePat =
     { Span: Span
       Key: string
@@ -321,7 +325,10 @@ module Syntax =
       TypeParams: option<list<TypeParam>>
       Members: list<Property> }
 
-  type Impl = { Name: string; Members: list<Method> }
+  type Impl =
+    { TypeParams: option<list<TypeParam>>
+      SelfType: TypeRef
+      Elems: list<Method> }
 
   type DeclKind =
     | VarDecl of name: Pattern * init: Expr * typeAnn: option<TypeAnn>
@@ -405,7 +412,7 @@ module Syntax =
     | Range of Common.Range<TypeAnn>
     | Union of types: list<TypeAnn>
     | Intersection of types: list<TypeAnn>
-    | TypeRef of name: string * type_args: option<list<TypeAnn>>
+    | TypeRef of TypeRef
     | Function of FunctionType
     | Keyof of target: TypeAnn
     | Rest of target: TypeAnn

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -636,3 +636,16 @@ let ParseGenericImpl () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseStructExprs () =
+  let src =
+    """
+    let foo = Foo { a: 5, b: "hello" }
+    let bar = Bar<number> { a: 5, b: "hello" }
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -591,10 +591,41 @@ let ParseStruct () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseGenericStruct () =
+  let src =
+    """
+    struct Point<T> {
+      x: T,
+      y: T,
+    }
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
 let ParseImpl () =
   let src =
     """
     impl Point {
+      fn length(self) {
+        return Math.sqrt(self.x * self.x + self.y * self.y)
+      }
+    }
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseGenericImpl () =
+  let src =
+    """
+    impl<T> Point<T> {
       fn length(self) {
         return Math.sqrt(self.x * self.x + self.y * self.y)
       }

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -649,3 +649,27 @@ let ParseStructExprs () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseBasicStructPattern () =
+  let src =
+    """
+    let Point {x, y} = point
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseGenericStructPattern () =
+  let src =
+    """
+    let Point<number> {x, y} = point
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -574,3 +574,34 @@ let ParseTypeof () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseStruct () =
+  let src =
+    """
+    struct Point {
+      x: number,
+      y: number,
+    }
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseImpl () =
+  let src =
+    """
+    impl Point {
+      fn length(self) {
+        return Math.sqrt(self.x * self.x + self.y * self.y)
+      }
+    }
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
@@ -1,0 +1,37 @@
+﻿input: 
+    let Point {x, y} = point
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                VarDecl
+                  ({ Kind =
+                      Struct
+                        { Name = "Point"
+                          TypeArgs = None
+                          Elems =
+                           [ShorthandPat { Span = { Start = (Ln: 2, Col: 16)
+                                                    Stop = (Ln: 2, Col: 17) }
+                                           Name = "x"
+                                           IsMut = false
+                                           Default = None
+                                           Assertion = None };
+                            ShorthandPat { Span = { Start = (Ln: 2, Col: 19)
+                                                    Stop = (Ln: 2, Col: 20) }
+                                           Name = "y"
+                                           IsMut = false
+                                           Default = None
+                                           Assertion = None }] }
+                     Span = { Start = (Ln: 2, Col: 9)
+                              Stop = (Ln: 2, Col: 22) }
+                     InferredType = None }, { Kind = Identifier "point"
+                                              Span = { Start = (Ln: 2, Col: 24)
+                                                       Stop = (Ln: 3, Col: 5) }
+                                              InferredType = None }, None)
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 3, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
@@ -10,8 +10,8 @@ output: Ok
                 VarDecl
                   ({ Kind =
                       Struct
-                        { Name = "Point"
-                          TypeArgs = None
+                        { TypeRef = { Ident = "Point"
+                                      TypeArgs = None }
                           Elems =
                            [ShorthandPat { Span = { Start = (Ln: 2, Col: 16)
                                                     Stop = (Ln: 2, Col: 17) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
@@ -11,7 +11,8 @@ output: Ok
                   ("Foo",
                    { Kind =
                       Condition
-                        { Check = { Kind = TypeRef ("T", None)
+                        { Check = { Kind = TypeRef { Ident = "T"
+                                                     TypeArgs = None }
                                     Span = { Start = (Ln: 2, Col: 22)
                                              Stop = (Ln: 2, Col: 23) }
                                     InferredType = None }
@@ -26,7 +27,8 @@ output: Ok
                           FalseType =
                            { Kind =
                               Condition
-                                { Check = { Kind = TypeRef ("T", None)
+                                { Check = { Kind = TypeRef { Ident = "T"
+                                                             TypeArgs = None }
                                             Span = { Start = (Ln: 2, Col: 53)
                                                      Stop = (Ln: 2, Col: 54) }
                                             InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
@@ -11,11 +11,13 @@ output: Ok
                   ("Exclude",
                    { Kind =
                       Condition
-                        { Check = { Kind = TypeRef ("T", None)
+                        { Check = { Kind = TypeRef { Ident = "T"
+                                                     TypeArgs = None }
                                     Span = { Start = (Ln: 2, Col: 29)
                                              Stop = (Ln: 2, Col: 30) }
                                     InferredType = None }
-                          Extends = { Kind = TypeRef ("U", None)
+                          Extends = { Kind = TypeRef { Ident = "U"
+                                                       TypeArgs = None }
                                       Span = { Start = (Ln: 2, Col: 32)
                                                Stop = (Ln: 2, Col: 34) }
                                       InferredType = None }
@@ -23,7 +25,8 @@ output: Ok
                                        Span = { Start = (Ln: 2, Col: 36)
                                                 Stop = (Ln: 2, Col: 42) }
                                        InferredType = None }
-                          FalseType = { Kind = TypeRef ("T", None)
+                          FalseType = { Kind = TypeRef { Ident = "T"
+                                                         TypeArgs = None }
                                         Span = { Start = (Ln: 2, Col: 51)
                                                  Stop = (Ln: 2, Col: 53) }
                                         InferredType = None } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
@@ -13,11 +13,13 @@ output: Ok
                                       Stop = (Ln: 1, Col: 17) }
                              Name = "T"
                              Constraint =
-                              Some { Kind = TypeRef ("Foo", None)
+                              Some { Kind = TypeRef { Ident = "Foo"
+                                                      TypeArgs = None }
                                      Span = { Start = (Ln: 1, Col: 8)
                                               Stop = (Ln: 1, Col: 12) }
                                      InferredType = None }
-                             Default = Some { Kind = TypeRef ("Bar", None)
+                             Default = Some { Kind = TypeRef { Ident = "Bar"
+                                                               TypeArgs = None }
                                               Span = { Start = (Ln: 1, Col: 14)
                                                        Stop = (Ln: 1, Col: 17) }
                                               InferredType = None } }]
@@ -28,12 +30,14 @@ output: Ok
                                        Span = { Start = (Ln: 1, Col: 19)
                                                 Stop = (Ln: 1, Col: 20) }
                                        InferredType = None }
-                           TypeAnn = Some { Kind = TypeRef ("T", None)
+                           TypeAnn = Some { Kind = TypeRef { Ident = "T"
+                                                             TypeArgs = None }
                                             Span = { Start = (Ln: 1, Col: 22)
                                                      Stop = (Ln: 1, Col: 23) }
                                             InferredType = None }
                            Optional = false }]
-                       ReturnType = Some { Kind = TypeRef ("T", None)
+                       ReturnType = Some { Kind = TypeRef { Ident = "T"
+                                                            TypeArgs = None }
                                            Span = { Start = (Ln: 1, Col: 28)
                                                     Stop = (Ln: 1, Col: 30) }
                                            InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
@@ -5,11 +5,13 @@ output: Success: { Kind =
         Some [{ Span = { Start = (Ln: 1, Col: 5)
                          Stop = (Ln: 1, Col: 17) }
                 Name = "T"
-                Constraint = Some { Kind = TypeRef ("Foo", None)
+                Constraint = Some { Kind = TypeRef { Ident = "Foo"
+                                                     TypeArgs = None }
                                     Span = { Start = (Ln: 1, Col: 8)
                                              Stop = (Ln: 1, Col: 12) }
                                     InferredType = None }
-                Default = Some { Kind = TypeRef ("Bar", None)
+                Default = Some { Kind = TypeRef { Ident = "Bar"
+                                                  TypeArgs = None }
                                  Span = { Start = (Ln: 1, Col: 14)
                                           Stop = (Ln: 1, Col: 17) }
                                  InferredType = None } }]
@@ -19,12 +21,14 @@ output: Success: { Kind =
                                   Span = { Start = (Ln: 1, Col: 19)
                                            Stop = (Ln: 1, Col: 20) }
                                   InferredType = None }
-                      TypeAnn = { Kind = TypeRef ("T", None)
+                      TypeAnn = { Kind = TypeRef { Ident = "T"
+                                                   TypeArgs = None }
                                   Span = { Start = (Ln: 1, Col: 22)
                                            Stop = (Ln: 1, Col: 23) }
                                   InferredType = None }
                       Optional = false }]
-       ReturnType = { Kind = TypeRef ("T", None)
+       ReturnType = { Kind = TypeRef { Ident = "T"
+                                       TypeArgs = None }
                       Span = { Start = (Ln: 1, Col: 28)
                                Stop = (Ln: 1, Col: 30) }
                       InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericImpl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericImpl.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    impl Point {
+    impl<T> Point<T> {
       fn length(self) {
         return Math.sqrt(self.x * self.x + self.y * self.y)
       }
@@ -10,9 +10,18 @@ output: Ok
      [Stmt
         { Kind =
            Impl
-             { TypeParams = None
-               SelfType = { Ident = "Point"
-                            TypeArgs = None }
+             { TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 10)
+                                             Stop = (Ln: 2, Col: 11) }
+                                    Name = "T"
+                                    Constraint = None
+                                    Default = None }]
+               SelfType =
+                { Ident = "Point"
+                  TypeArgs = Some [{ Kind = TypeRef { Ident = "T"
+                                                      TypeArgs = None }
+                                     Span = { Start = (Ln: 2, Col: 19)
+                                              Stop = (Ln: 2, Col: 20) }
+                                     InferredType = None }] }
                Elems =
                 [{ Name = "length"
                    Sig =

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStruct.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStruct.verified.txt
@@ -17,7 +17,7 @@ output: Ok
                                          Name = "T"
                                          Constraint = None
                                          Default = None }]
-                    Members =
+                    Elems =
                      [{ Name = String "x"
                         TypeAnn = { Kind = TypeRef { Ident = "T"
                                                      TypeArgs = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStruct.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStruct.verified.txt
@@ -1,0 +1,40 @@
+﻿input: 
+    struct Point<T> {
+      x: T,
+      y: T,
+    }
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                StructDecl
+                  { Name = "Point"
+                    TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 18)
+                                                  Stop = (Ln: 2, Col: 19) }
+                                         Name = "T"
+                                         Constraint = None
+                                         Default = None }]
+                    Members =
+                     [{ Name = String "x"
+                        TypeAnn = { Kind = TypeRef { Ident = "T"
+                                                     TypeArgs = None }
+                                    Span = { Start = (Ln: 3, Col: 10)
+                                             Stop = (Ln: 3, Col: 11) }
+                                    InferredType = None }
+                        Optional = false
+                        Readonly = false };
+                      { Name = String "y"
+                        TypeAnn = { Kind = TypeRef { Ident = "T"
+                                                     TypeArgs = None }
+                                    Span = { Start = (Ln: 4, Col: 10)
+                                             Stop = (Ln: 4, Col: 11) }
+                                    InferredType = None }
+                        Optional = false
+                        Readonly = false }] }
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 6, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 6, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
@@ -1,0 +1,40 @@
+﻿input: 
+    let Point<number> {x, y} = point
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                VarDecl
+                  ({ Kind =
+                      Struct
+                        { Name = "Point"
+                          TypeArgs = Some [{ Kind = Keyword Number
+                                             Span = { Start = (Ln: 2, Col: 15)
+                                                      Stop = (Ln: 2, Col: 21) }
+                                             InferredType = None }]
+                          Elems =
+                           [ShorthandPat { Span = { Start = (Ln: 2, Col: 24)
+                                                    Stop = (Ln: 2, Col: 25) }
+                                           Name = "x"
+                                           IsMut = false
+                                           Default = None
+                                           Assertion = None };
+                            ShorthandPat { Span = { Start = (Ln: 2, Col: 27)
+                                                    Stop = (Ln: 2, Col: 28) }
+                                           Name = "y"
+                                           IsMut = false
+                                           Default = None
+                                           Assertion = None }] }
+                     Span = { Start = (Ln: 2, Col: 9)
+                              Stop = (Ln: 2, Col: 30) }
+                     InferredType = None }, { Kind = Identifier "point"
+                                              Span = { Start = (Ln: 2, Col: 32)
+                                                       Stop = (Ln: 3, Col: 5) }
+                                              InferredType = None }, None)
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 3, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
@@ -10,11 +10,13 @@ output: Ok
                 VarDecl
                   ({ Kind =
                       Struct
-                        { Name = "Point"
-                          TypeArgs = Some [{ Kind = Keyword Number
-                                             Span = { Start = (Ln: 2, Col: 15)
-                                                      Stop = (Ln: 2, Col: 21) }
-                                             InferredType = None }]
+                        { TypeRef =
+                           { Ident = "Point"
+                             TypeArgs =
+                              Some [{ Kind = Keyword Number
+                                      Span = { Start = (Ln: 2, Col: 15)
+                                               Stop = (Ln: 2, Col: 21) }
+                                      InferredType = None }] }
                           Elems =
                            [ShorthandPat { Span = { Start = (Ln: 2, Col: 24)
                                                     Stop = (Ln: 2, Col: 25) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseImpl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseImpl.verified.txt
@@ -1,0 +1,158 @@
+﻿input: 
+    impl Point {
+      fn length(self) {
+        return Math.sqrt(self.x * self.x + self.y * self.y)
+      }
+    }
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Impl
+             { Name = "Point"
+               Members =
+                [{ Name = "length"
+                   Sig =
+                    { TypeParams = None
+                      ParamList =
+                       [{ Pattern = { Kind = Ident { Name = "self"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 3, Col: 17)
+                                               Stop = (Ln: 3, Col: 21) }
+                                      InferredType = None }
+                          TypeAnn = None
+                          Optional = false }]
+                      ReturnType = None
+                      Throws = None
+                      IsAsync = false }
+                   Body =
+                    Block
+                      { Span = { Start = (Ln: 3, Col: 23)
+                                 Stop = (Ln: 6, Col: 5) }
+                        Stmts =
+                         [{ Kind =
+                             Return
+                               (Some
+                                  { Kind =
+                                     Call
+                                       { Callee =
+                                          { Kind =
+                                             Member
+                                               ({ Kind = Identifier "Math"
+                                                  Span =
+                                                   { Start = (Ln: 4, Col: 16)
+                                                     Stop = (Ln: 4, Col: 20) }
+                                                  InferredType = None }, "sqrt",
+                                                false)
+                                            Span = { Start = (Ln: 4, Col: 16)
+                                                     Stop = (Ln: 4, Col: 25) }
+                                            InferredType = None }
+                                         TypeArgs = None
+                                         Args =
+                                          [{ Kind =
+                                              Binary
+                                                ("+",
+                                                 { Kind =
+                                                    Binary
+                                                      ("*",
+                                                       { Kind =
+                                                          Member
+                                                            ({ Kind =
+                                                                Identifier
+                                                                  "self"
+                                                               Span =
+                                                                { Start =
+                                                                   (Ln: 4, Col: 26)
+                                                                  Stop =
+                                                                   (Ln: 4, Col: 30) }
+                                                               InferredType =
+                                                                None }, "x",
+                                                             false)
+                                                         Span =
+                                                          { Start =
+                                                             (Ln: 4, Col: 26)
+                                                            Stop =
+                                                             (Ln: 4, Col: 33) }
+                                                         InferredType = None },
+                                                       { Kind =
+                                                          Member
+                                                            ({ Kind =
+                                                                Identifier
+                                                                  "self"
+                                                               Span =
+                                                                { Start =
+                                                                   (Ln: 4, Col: 35)
+                                                                  Stop =
+                                                                   (Ln: 4, Col: 39) }
+                                                               InferredType =
+                                                                None }, "x",
+                                                             false)
+                                                         Span =
+                                                          { Start =
+                                                             (Ln: 4, Col: 35)
+                                                            Stop =
+                                                             (Ln: 4, Col: 42) }
+                                                         InferredType = None })
+                                                   Span =
+                                                    { Start = (Ln: 4, Col: 26)
+                                                      Stop = (Ln: 4, Col: 42) }
+                                                   InferredType = None },
+                                                 { Kind =
+                                                    Binary
+                                                      ("*",
+                                                       { Kind =
+                                                          Member
+                                                            ({ Kind =
+                                                                Identifier
+                                                                  "self"
+                                                               Span =
+                                                                { Start =
+                                                                   (Ln: 4, Col: 44)
+                                                                  Stop =
+                                                                   (Ln: 4, Col: 48) }
+                                                               InferredType =
+                                                                None }, "y",
+                                                             false)
+                                                         Span =
+                                                          { Start =
+                                                             (Ln: 4, Col: 44)
+                                                            Stop =
+                                                             (Ln: 4, Col: 51) }
+                                                         InferredType = None },
+                                                       { Kind =
+                                                          Member
+                                                            ({ Kind =
+                                                                Identifier
+                                                                  "self"
+                                                               Span =
+                                                                { Start =
+                                                                   (Ln: 4, Col: 53)
+                                                                  Stop =
+                                                                   (Ln: 4, Col: 57) }
+                                                               InferredType =
+                                                                None }, "y",
+                                                             false)
+                                                         Span =
+                                                          { Start =
+                                                             (Ln: 4, Col: 53)
+                                                            Stop =
+                                                             (Ln: 4, Col: 59) }
+                                                         InferredType = None })
+                                                   Span =
+                                                    { Start = (Ln: 4, Col: 44)
+                                                      Stop = (Ln: 4, Col: 59) }
+                                                   InferredType = None })
+                                             Span = { Start = (Ln: 4, Col: 26)
+                                                      Stop = (Ln: 4, Col: 59) }
+                                             InferredType = None }]
+                                         OptChain = false
+                                         Throws = None }
+                                    Span = { Start = (Ln: 4, Col: 16)
+                                             Stop = (Ln: 5, Col: 7) }
+                                    InferredType = None })
+                            Span = { Start = (Ln: 4, Col: 9)
+                                     Stop = (Ln: 5, Col: 7) } }] } }] }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 7, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
@@ -9,7 +9,8 @@ output: Ok
                   ("Foo",
                    { Kind =
                       Index
-                        ({ Kind = TypeRef ("Bar", None)
+                        ({ Kind = TypeRef { Ident = "Bar"
+                                            TypeArgs = None }
                            Span = { Start = (Ln: 1, Col: 12)
                                     Stop = (Ln: 1, Col: 15) }
                            InferredType = None },

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -9,7 +9,8 @@ output: Ok
                   ("ReturnType",
                    { Kind =
                       Condition
-                        { Check = { Kind = TypeRef ("T", None)
+                        { Check = { Kind = TypeRef { Ident = "T"
+                                                     TypeArgs = None }
                                     Span = { Start = (Ln: 1, Col: 25)
                                              Stop = (Ln: 1, Col: 26) }
                                     InferredType = None }
@@ -31,7 +32,8 @@ output: Ok
                                                   Stop = (Ln: 1, Col: 39) }
                                          InferredType = None }
                                       TypeAnn =
-                                       { Kind = TypeRef ("_", None)
+                                       { Kind = TypeRef { Ident = "_"
+                                                          TypeArgs = None }
                                          Span = { Start = (Ln: 1, Col: 41)
                                                   Stop = (Ln: 1, Col: 42) }
                                          InferredType = None }
@@ -46,7 +48,8 @@ output: Ok
                              Span = { Start = (Ln: 1, Col: 28)
                                       Stop = (Ln: 1, Col: 55) }
                              InferredType = None }
-                          TrueType = { Kind = TypeRef ("R", None)
+                          TrueType = { Kind = TypeRef { Ident = "R"
+                                                        TypeArgs = None }
                                        Span = { Start = (Ln: 1, Col: 57)
                                                 Stop = (Ln: 1, Col: 59) }
                                        InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
@@ -52,7 +52,8 @@ output: Ok
                         { Elems =
                            [Property
                               { Name = String "p0"
-                                TypeAnn = { Kind = TypeRef ("Point", None)
+                                TypeAnn = { Kind = TypeRef { Ident = "Point"
+                                                             TypeArgs = None }
                                             Span = { Start = (Ln: 3, Col: 22)
                                                      Stop = (Ln: 3, Col: 27) }
                                             InferredType = None }
@@ -60,7 +61,8 @@ output: Ok
                                 Readonly = false };
                             Property
                               { Name = String "p1"
-                                TypeAnn = { Kind = TypeRef ("Point", None)
+                                TypeAnn = { Kind = TypeRef { Ident = "Point"
+                                                             TypeArgs = None }
                                             Span = { Start = (Ln: 3, Col: 33)
                                                      Stop = (Ln: 3, Col: 38) }
                                             InferredType = None }
@@ -79,7 +81,8 @@ output: Ok
                                    Assertion = None }
                     Span = { Start = (Ln: 4, Col: 17)
                              Stop = (Ln: 4, Col: 21) }
-                    InferredType = None }, { Kind = TypeRef ("Line", None)
+                    InferredType = None }, { Kind = TypeRef { Ident = "Line"
+                                                              TypeArgs = None }
                                              Span = { Start = (Ln: 4, Col: 23)
                                                       Stop = (Ln: 6, Col: 5) }
                                              InferredType = None });

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
@@ -84,7 +84,8 @@ output: Ok
                      Span = { Start = (Ln: 3, Col: 25)
                               Stop = (Ln: 4, Col: 5) }
                      InferredType = None },
-                   Some { Kind = TypeRef ("Point", None)
+                   Some { Kind = TypeRef { Ident = "Point"
+                                           TypeArgs = None }
                           Span = { Start = (Ln: 3, Col: 17)
                                    Stop = (Ln: 3, Col: 23) }
                           InferredType = None })
@@ -114,7 +115,8 @@ output: Ok
                      Span = { Start = (Ln: 4, Col: 20)
                               Stop = (Ln: 5, Col: 5) }
                      InferredType = None },
-                   Some { Kind = TypeRef ("Point", None)
+                   Some { Kind = TypeRef { Ident = "Point"
+                                           TypeArgs = None }
                           Span = { Start = (Ln: 4, Col: 12)
                                    Stop = (Ln: 4, Col: 18) }
                           InferredType = None })
@@ -163,7 +165,8 @@ output: Ok
                                              Stop = (Ln: 5, Col: 25) }
                                     InferredType = None }
                                  TypeAnn =
-                                  Some { Kind = TypeRef ("Point", None)
+                                  Some { Kind = TypeRef { Ident = "Point"
+                                                          TypeArgs = None }
                                          Span = { Start = (Ln: 5, Col: 27)
                                                   Stop = (Ln: 5, Col: 32) }
                                          InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
@@ -53,13 +53,18 @@ output: Ok
                                         ReturnType =
                                          { Kind =
                                             TypeRef
-                                              ("Iterator",
-                                               Some
-                                                 [{ Kind = TypeRef ("T", None)
-                                                    Span =
-                                                     { Start = (Ln: 5, Col: 44)
-                                                       Stop = (Ln: 5, Col: 45) }
-                                                    InferredType = None }])
+                                              { Ident = "Iterator"
+                                                TypeArgs =
+                                                 Some
+                                                   [{ Kind =
+                                                       TypeRef
+                                                         { Ident = "T"
+                                                           TypeArgs = None }
+                                                      Span =
+                                                       { Start =
+                                                          (Ln: 5, Col: 44)
+                                                         Stop = (Ln: 5, Col: 45) }
+                                                      InferredType = None }] }
                                            Span = { Start = (Ln: 5, Col: 35)
                                                     Stop = (Ln: 5, Col: 46) }
                                            InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
@@ -45,7 +45,10 @@ output: Ok
                                                             { Min =
                                                                { Kind =
                                                                   TypeRef
-                                                                    ("Min", None)
+                                                                    { Ident =
+                                                                       "Min"
+                                                                      TypeArgs =
+                                                                       None }
                                                                  Span =
                                                                   { Start =
                                                                      (Ln: 3, Col: 48)
@@ -56,7 +59,10 @@ output: Ok
                                                               Max =
                                                                { Kind =
                                                                   TypeRef
-                                                                    ("Max", None)
+                                                                    { Ident =
+                                                                       "Max"
+                                                                      TypeArgs =
+                                                                       None }
                                                                  Span =
                                                                   { Start =
                                                                      (Ln: 3, Col: 53)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseStruct.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseStruct.verified.txt
@@ -1,0 +1,34 @@
+﻿input: 
+    struct Point {
+      x: number,
+      y: number,
+    }
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                StructDecl
+                  { Name = "Point"
+                    TypeParams = None
+                    Members =
+                     [{ Name = String "x"
+                        TypeAnn = { Kind = Keyword Number
+                                    Span = { Start = (Ln: 3, Col: 10)
+                                             Stop = (Ln: 3, Col: 16) }
+                                    InferredType = None }
+                        Optional = false
+                        Readonly = false };
+                      { Name = String "y"
+                        TypeAnn = { Kind = Keyword Number
+                                    Span = { Start = (Ln: 4, Col: 10)
+                                             Stop = (Ln: 4, Col: 16) }
+                                    InferredType = None }
+                        Optional = false
+                        Readonly = false }] }
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 6, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 6, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseStruct.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseStruct.verified.txt
@@ -13,7 +13,7 @@ output: Ok
                 StructDecl
                   { Name = "Point"
                     TypeParams = None
-                    Members =
+                    Elems =
                      [{ Name = String "x"
                         TypeAnn = { Kind = Keyword Number
                                     Span = { Start = (Ln: 3, Col: 10)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
@@ -17,8 +17,8 @@ output: Ok
                      InferredType = None },
                    { Kind =
                       Struct
-                        { Name = "Foo"
-                          TypeArgs = None
+                        { TypeRef = { Ident = "Foo"
+                                      TypeArgs = None }
                           Elems =
                            [Property
                               ({ Start = (Ln: 2, Col: 21)
@@ -54,11 +54,13 @@ output: Ok
                      InferredType = None },
                    { Kind =
                       Struct
-                        { Name = "Bar"
-                          TypeArgs = Some [{ Kind = Keyword Number
-                                             Span = { Start = (Ln: 3, Col: 19)
-                                                      Stop = (Ln: 3, Col: 25) }
-                                             InferredType = None }]
+                        { TypeRef =
+                           { Ident = "Bar"
+                             TypeArgs =
+                              Some [{ Kind = Keyword Number
+                                      Span = { Start = (Ln: 3, Col: 19)
+                                               Stop = (Ln: 3, Col: 25) }
+                                      InferredType = None }] }
                           Elems =
                            [Property
                               ({ Start = (Ln: 3, Col: 29)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
@@ -1,0 +1,83 @@
+﻿input: 
+    let foo = Foo { a: 5, b: "hello" }
+    let bar = Bar<number> { a: 5, b: "hello" }
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                VarDecl
+                  ({ Kind = Ident { Name = "foo"
+                                    IsMut = false
+                                    Assertion = None }
+                     Span = { Start = (Ln: 2, Col: 9)
+                              Stop = (Ln: 2, Col: 13) }
+                     InferredType = None },
+                   { Kind =
+                      Struct
+                        { Name = "Foo"
+                          TypeArgs = None
+                          Elems =
+                           [Property
+                              ({ Start = (Ln: 2, Col: 21)
+                                 Stop = (Ln: 2, Col: 25) }, String "a",
+                               { Kind = Literal (Number (Int 5))
+                                 Span = { Start = (Ln: 2, Col: 24)
+                                          Stop = (Ln: 2, Col: 25) }
+                                 InferredType = None });
+                            Property
+                              ({ Start = (Ln: 2, Col: 27)
+                                 Stop = (Ln: 2, Col: 38) }, String "b",
+                               { Kind = Literal (String "hello")
+                                 Span = { Start = (Ln: 2, Col: 30)
+                                          Stop = (Ln: 2, Col: 37) }
+                                 InferredType = None })] }
+                     Span = { Start = (Ln: 2, Col: 15)
+                              Stop = (Ln: 3, Col: 5) }
+                     InferredType = None }, None)
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 3, Col: 5) } };
+      Stmt
+        { Kind =
+           Decl
+             { Kind =
+                VarDecl
+                  ({ Kind = Ident { Name = "bar"
+                                    IsMut = false
+                                    Assertion = None }
+                     Span = { Start = (Ln: 3, Col: 9)
+                              Stop = (Ln: 3, Col: 13) }
+                     InferredType = None },
+                   { Kind =
+                      Struct
+                        { Name = "Bar"
+                          TypeArgs = Some [{ Kind = Keyword Number
+                                             Span = { Start = (Ln: 3, Col: 19)
+                                                      Stop = (Ln: 3, Col: 25) }
+                                             InferredType = None }]
+                          Elems =
+                           [Property
+                              ({ Start = (Ln: 3, Col: 29)
+                                 Stop = (Ln: 3, Col: 33) }, String "a",
+                               { Kind = Literal (Number (Int 5))
+                                 Span = { Start = (Ln: 3, Col: 32)
+                                          Stop = (Ln: 3, Col: 33) }
+                                 InferredType = None });
+                            Property
+                              ({ Start = (Ln: 3, Col: 35)
+                                 Stop = (Ln: 3, Col: 46) }, String "b",
+                               { Kind = Literal (String "hello")
+                                 Span = { Start = (Ln: 3, Col: 38)
+                                          Stop = (Ln: 3, Col: 45) }
+                                 InferredType = None })] }
+                     Span = { Start = (Ln: 3, Col: 15)
+                              Stop = (Ln: 4, Col: 5) }
+                     InferredType = None }, None)
+               Span = { Start = (Ln: 3, Col: 5)
+                        Stop = (Ln: 4, Col: 5) } }
+          Span = { Start = (Ln: 3, Col: 5)
+                   Stop = (Ln: 4, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionAndIntersectionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseUnionAndIntersectionType.verified.txt
@@ -3,10 +3,12 @@ output: Success: { Kind =
    Union
      [{ Kind =
          Intersection
-           [{ Kind = TypeRef ("A", None)
+           [{ Kind = TypeRef { Ident = "A"
+                               TypeArgs = None }
               Span = { Start = (Ln: 1, Col: 1)
                        Stop = (Ln: 1, Col: 3) }
-              InferredType = None }; { Kind = TypeRef ("B", None)
+              InferredType = None }; { Kind = TypeRef { Ident = "B"
+                                                        TypeArgs = None }
                                        Span = { Start = (Ln: 1, Col: 5)
                                                 Stop = (Ln: 1, Col: 7) }
                                        InferredType = None }]
@@ -15,10 +17,12 @@ output: Success: { Kind =
         InferredType = None };
       { Kind =
          Intersection
-           [{ Kind = TypeRef ("C", None)
+           [{ Kind = TypeRef { Ident = "C"
+                               TypeArgs = None }
               Span = { Start = (Ln: 1, Col: 9)
                        Stop = (Ln: 1, Col: 11) }
-              InferredType = None }; { Kind = TypeRef ("D", None)
+              InferredType = None }; { Kind = TypeRef { Ident = "D"
+                                                        TypeArgs = None }
                                        Span = { Start = (Ln: 1, Col: 13)
                                                 Stop = (Ln: 1, Col: 14) }
                                        InferredType = None }]

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -667,7 +667,7 @@ module Parser =
       (opt (between (strWs "<") (strWs ">") (sepBy typeParam (strWs ","))))
       (between (strWs "{") (strWs "}") (sepEndBy propertyTypeAnn (strWs ",")))
       getPosition
-    <| fun start name typeParams members stop ->
+    <| fun start name typeParams elems stop ->
       let span = { Start = start; Stop = stop }
 
       { Stmt.Kind =
@@ -676,7 +676,7 @@ module Parser =
                 StructDecl
                   { Name = name
                     TypeParams = typeParams
-                    Members = members }
+                    Elems = elems }
               Span = span }
         Span = span }
 

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -316,6 +316,24 @@ module Parser =
         Span = { Start = start; Stop = stop }
         InferredType = None }
 
+  let structExpr: Parser<Expr, unit> =
+    pipe5
+      getPosition
+      ident
+      (opt (between (strWs "<") (strWs ">") (sepBy typeAnn (strWs ","))))
+      (between (strWs "{") (strWs "}") (sepBy objElem (strWs ",")))
+      getPosition
+    <| fun start name typeArgs elems stop ->
+      let kind =
+        ExprKind.Struct
+          { Name = name
+            TypeArgs = typeArgs
+            Elems = elems }
+
+      { Kind = kind
+        Span = { Start = start; Stop = stop }
+        InferredType = None }
+
   let catchClause: Parser<list<MatchCase>, unit> =
     pipe3
       getPosition
@@ -363,6 +381,7 @@ module Parser =
         attempt throwExpr // conflicts with identExpr
         attempt tryExpr // conflicts with identExpr
         attempt matchExpr // conflicts with identExpr
+        attempt structExpr // conflicts with identExpr
         tupleExpr
         objectExpr
         imTupleExpr

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -326,8 +326,7 @@ module Parser =
     <| fun start name typeArgs elems stop ->
       let kind =
         ExprKind.Struct
-          { Name = name
-            TypeArgs = typeArgs
+          { TypeRef = { Ident = name; TypeArgs = typeArgs }
             Elems = elems }
 
       { Kind = kind
@@ -862,9 +861,8 @@ module Parser =
     |>> fun ((name, typeArgs, elems), span) ->
       let kind =
         PatternKind.Struct
-          { Name = name
-            Elems = elems
-            TypeArgs = typeArgs }
+          { TypeRef = { Ident = name; TypeArgs = typeArgs }
+            Elems = elems }
 
       { Pattern.Kind = kind
         Span = span

--- a/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
+++ b/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
@@ -18,6 +18,7 @@
         <Compile Include="Symbol.fs"/>
         <Compile Include="ArrayTuple.fs"/>
         <Compile Include="PatternMatching.fs"/>
+        <Compile Include="Structs.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>
 

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -122,6 +122,48 @@ let PropertyAccessOnStructs () =
   Assert.False(Result.isError res)
 
 [<Fact>]
+let PropertyAccessOnPrivateStructs () =
+  let res =
+    result {
+      let src =
+        """
+        let makePoint = fn (x, y) {
+          struct Point {x: number, y: number}
+          return Point {x, y}
+        }
+        let point = makePoint(5, 10)
+        let x = point.x
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "x", "number")
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)
+
+[<Fact(Skip = "update getPropType to return an Result")>]
+let PropertyAccessOnPrivateStructsWrongKey () =
+  let res =
+    result {
+      let src =
+        """
+        let makePoint = fn (x, y) {
+          struct Point {x: number, y: number}
+          return Point {x, y}
+        }
+        let point = makePoint(5, 10)
+        let z = point.z
+        """
+
+      let! _ = inferScript src
+      ()
+    }
+
+  Assert.True(Result.isError res)
+
+[<Fact>]
 let ObjectDestructuringOfStructs () =
   let res =
     result {

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -42,13 +42,13 @@ let InferBasicStruct () =
     result {
       let src =
         """
-        struct Point { x: number, y: number }
-        let point = Point { x: 5, y: 10 }
+        struct Point {x: number, y: number}
+        let point = Point {x: 5, y: 10}
         """
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "point", "Point {x: 5, y: 10}")
+      Assert.Value(env, "point", "Point {x: number, y: number}")
     }
 
   Assert.False(Result.isError res)
@@ -82,7 +82,24 @@ let InferGenericStruct () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "point", "Point<number> {x: 5, y: 10}")
+      Assert.Value(env, "point", "Point<number> {x: number, y: number}")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let StructsAreSubtypesOfObjects () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point {x: number, y: number}
+        let point: {x: number, y: number} = Point { x: 5, y: 10 }
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "point", "{x: number, y: number}")
     }
 
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -48,7 +48,7 @@ let InferBasicStruct () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "point", "Point {x: number, y: number}")
+      Assert.Value(env, "point", "Point")
     }
 
   Assert.False(Result.isError res)
@@ -59,13 +59,12 @@ let InferBasicStructIncorrectTypes () =
     result {
       let src =
         """
-        struct Point { x: number, y: number }
-        let point = Point { x: "hello", y: true }
+        struct Point {x: number, y: number}
+        let point = Point {x: "hello", y: true}
         """
 
-      let! _, env = inferScript src
-
-      Assert.Value(env, "point", "Point {x: \"hello\", y: true}")
+      let! _ = inferScript src
+      ()
     }
 
   Assert.True(Result.isError res)
@@ -76,13 +75,13 @@ let InferGenericStruct () =
     result {
       let src =
         """
-        struct Point<T> { x: T, y: T }
-        let point = Point<number> { x: 5, y: 10 }
+        struct Point<T> {x: T, y: T}
+        let point = Point<number> {x: 5, y: 10}
         """
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "point", "Point<number> {x: number, y: number}")
+      Assert.Value(env, "point", "Point<number>")
     }
 
   Assert.False(Result.isError res)
@@ -94,12 +93,48 @@ let StructsAreSubtypesOfObjects () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point: {x: number, y: number} = Point { x: 5, y: 10 }
+        let point: {x: number, y: number} = Point {x: 5, y: 10}
         """
 
       let! _, env = inferScript src
 
       Assert.Value(env, "point", "{x: number, y: number}")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let PropertyAccessOnStructs () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point {x: number, y: number}
+        let point = Point {x: 5, y: 10}
+        let x = point.x
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "x", "number")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let ObjectDestructuringOfStructs () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point {x: number, y: number}
+        let point = Point {x: 5, y: 10}
+        let {x, y} = point
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "x", "number")
     }
 
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -138,3 +138,39 @@ let ObjectDestructuringOfStructs () =
     }
 
   Assert.False(Result.isError res)
+
+[<Fact>]
+let StructDestructuring () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point {x: number, y: number}
+        let point = Point {x: 5, y: 10}
+        let Point {x, y} = point
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "x", "number")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let StructPartialDestructuring () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point {x: number, y: number}
+        let point = Point {x: 5, y: 10}
+        let Point {x} = point
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "x", "number")
+    }
+
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -1,0 +1,88 @@
+module Structs
+
+open FsToolkit.ErrorHandling
+open System.IO.Abstractions.TestingHelpers
+open Xunit
+
+open Escalier.Parser
+open Escalier.TypeChecker
+open Escalier.TypeChecker.Env
+open Escalier.TypeChecker.Infer
+
+type Assert with
+
+  static member inline Value(env: Env, name: string, expected: string) =
+    let t, _ = Map.find name env.Values
+    Assert.Equal(expected, t.ToString())
+
+  static member inline Type(env: Env, name: string, expected: string) =
+    let scheme = Map.find name env.Schemes
+    Assert.Equal(expected, scheme.ToString())
+
+type CompileError = Prelude.CompileError
+
+
+let inferScript src =
+  result {
+    let! ast = Parser.parseScript src |> Result.mapError CompileError.ParseError
+
+    let mockFileSystem = MockFileSystem()
+    let! ctx, env = Prelude.getEnvAndCtx mockFileSystem "/" "/input.esc"
+
+    let! env =
+      inferScript ctx env "input.esc" ast
+      |> Result.mapError CompileError.TypeError
+
+    return ctx, env
+  }
+
+[<Fact>]
+let InferBasicStruct () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point { x: number, y: number }
+        let point = Point { x: 5, y: 10 }
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "point", "Point {x: 5, y: 10}")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let InferBasicStructIncorrectTypes () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point { x: number, y: number }
+        let point = Point { x: "hello", y: true }
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "point", "Point {x: \"hello\", y: true}")
+    }
+
+  Assert.True(Result.isError res)
+
+[<Fact>]
+let InferGenericStruct () =
+  let res =
+    result {
+      let src =
+        """
+        struct Point<T> { x: T, y: T }
+        let point = Point<number> { x: 5, y: 10 }
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "point", "Point<number> {x: 5, y: 10}")
+    }
+
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -215,6 +215,11 @@ module rec Env =
         else
           Error(TypeError.SemanticError $"Undefined symbol {name}")
 
+    member this.GetScheme(name: string) : Result<Scheme, TypeError> =
+      match this.Schemes |> Map.tryFind name with
+      | Some(s) -> Ok(s)
+      | None -> Error(TypeError.SemanticError $"Undefined symbol {name}")
+
     member this.GetBinding(name: string) : Result<Type * bool, TypeError> =
       match this.Values |> Map.tryFind name with
       | Some(var) -> Ok var

--- a/src/Escalier.TypeChecker/Error.fs
+++ b/src/Escalier.TypeChecker/Error.fs
@@ -8,6 +8,7 @@ module Error =
     | SemanticError of string
     | NotInferred
     | TypeMismatch of Type * Type
+    | PropertyMissing of PropName
     | RecursiveUnification of Type * Type
     | WrongNumberOfTypeArgs
 
@@ -17,6 +18,7 @@ module Error =
       | SemanticError s -> $"SemanticError: {s}"
       | NotInferred -> "NotInferred"
       | TypeMismatch(``type``, type1) -> $"TypeMismatch: {``type``} != {type1}"
+      | PropertyMissing propName -> $"Object is missing property {propName}"
       | RecursiveUnification(``type``, type1) ->
         $"RecursiveUnification: {``type``} != {type1}"
       | WrongNumberOfTypeArgs -> "WrongNumberOfTypeArgs"

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -373,26 +373,29 @@ module rec Infer =
 
           let t = expandScheme ctx env None scheme Map.empty typeArgs
 
-          let structObjType =
-            match t.Kind with
-            | TypeKind.Struct { Elems = elems } ->
+          // let structObjType =
+          match t.Kind with
+          | TypeKind.Struct { Elems = elems } ->
+            let structObjType =
               { Kind = TypeKind.Object { Elems = elems; Immutable = false }
                 Mutable = false
                 Provenance = None }
-            | _ -> failwith "TODO: handle non-struct types"
 
-          do! unify ctx env None initObjType structObjType
+            do! unify ctx env None initObjType structObjType
 
-          let kind: TypeKind =
-            TypeKind.Struct
-              { Name = name
-                TypeArgs = typeArgs
-                Elems = elems }
+            let kind: TypeKind =
+              TypeKind.Struct
+                { Name = name
+                  TypeArgs = typeArgs
+                  Elems = elems }
 
-          return
-            { Type.Kind = kind
-              Mutable = false
-              Provenance = None }
+            return
+              { Type.Kind = kind
+                Mutable = false
+                Provenance = None }
+          | _ ->
+            return!
+              Error(TypeError.SemanticError $"Expected Struct type, got {t}")
 
         | ExprKind.Member(obj, prop, optChain) ->
           let! objType = inferExpr ctx env obj

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -701,11 +701,15 @@ module rec Infer =
                   | ObjTypeAnnElem.Constructor functionType ->
                     let! f = inferFunctionType ctx env functionType
                     return Constructor f
-                  | ObjTypeAnnElem.Method(name, isMut, ``type``) ->
+                  | ObjTypeAnnElem.Method { Name = name; Type = t } ->
                     return! Error(TypeError.NotImplemented "todo")
-                  | ObjTypeAnnElem.Getter(name, returnType, throws) ->
+                  | ObjTypeAnnElem.Getter { Name = name
+                                            ReturnType = returnType
+                                            Throws = throws } ->
                     return! Error(TypeError.NotImplemented "todo")
-                  | ObjTypeAnnElem.Setter(name, param, throws) ->
+                  | ObjTypeAnnElem.Setter { Name = name
+                                            Param = param
+                                            Throws = throws } ->
                     return! Error(TypeError.NotImplemented "todo")
                   | ObjTypeAnnElem.Mapped mapped ->
                     let! c = inferTypeAnn ctx env mapped.TypeParam.Constraint

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -753,7 +753,7 @@ module rec Infer =
         | TypeAnnKind.Intersection types ->
           let! types = List.traverseResultM (inferTypeAnn ctx env) types
           return TypeKind.Intersection types
-        | TypeAnnKind.TypeRef(name, typeArgs) ->
+        | TypeAnnKind.TypeRef { Ident = name; TypeArgs = typeArgs } ->
           match env.Schemes.TryFind(name) with
           | Some(scheme) ->
 

--- a/src/Escalier.TypeChecker/Mutability.fs
+++ b/src/Escalier.TypeChecker/Mutability.fs
@@ -100,7 +100,7 @@ module Mutability =
       | ExprKind.Object { Elems = elems } ->
         for elem in elems do
           match elem with
-          | Syntax.Property(span, name, value) ->
+          | ObjElem.Property(span, name, value) ->
             let name =
               match name with
               | Syntax.Ident s -> s

--- a/src/Escalier.TypeChecker/Mutability.fs
+++ b/src/Escalier.TypeChecker/Mutability.fs
@@ -19,8 +19,21 @@ module Mutability =
       match pat.Kind with
       | PatternKind.Ident { Name = name; IsMut = mut } ->
         result <- Map.add name (path, mut) result
-      | PatternKind.Object object ->
-        for elem in object.Elems do
+      | PatternKind.Object { Elems = elems } ->
+        for elem in elems do
+          match elem with
+          | KeyValuePat { Key = key; Value = value } ->
+            walkPattern value (key :: path)
+          | ShorthandPat { Name = name; IsMut = mut } ->
+            result <- Map.add name ((name :: path), mut) result
+          | RestPat { Target = target; IsMut = mut } ->
+            // TODO: What should be the path for the rest pattern?
+            // It should be multiple paths, one for each property in the pattern
+            // We could use a "wildcard" path element to model this as long as
+            // we only check paths with wildcards after checking those without
+            printfn "TODO: getBindingPaths - ObjPatElem.RestPat"
+      | PatternKind.Struct { Elems = elems } ->
+        for elem in elems do
           match elem with
           | KeyValuePat { Key = key; Value = value } ->
             walkPattern value (key :: path)

--- a/src/Escalier.TypeChecker/Poly.fs
+++ b/src/Escalier.TypeChecker/Poly.fs
@@ -118,6 +118,26 @@ module Poly =
           { Kind = TypeKind.Range { Min = fold min; Max = fold max }
             Mutable = false
             Provenance = None }
+        | TypeKind.Struct { Name = name
+                            TypeArgs = typeArgs
+                            Elems = elems } ->
+          let typeArgs = Option.map (List.map fold) typeArgs
+
+          let elems =
+            List.map
+              (fun elem ->
+                match elem with
+                | Property p -> Property { p with Type = fold p.Type }
+                | _ -> failwith "TODO: foldType - ObjTypeElem")
+              elems
+
+          { Kind =
+              TypeKind.Struct
+                { Name = name
+                  TypeArgs = typeArgs
+                  Elems = elems }
+            Mutable = false
+            Provenance = None }
         | _ -> failwith $"TODO: foldType - {t.Kind}"
 
       match f t with

--- a/src/Escalier.TypeChecker/Poly.fs
+++ b/src/Escalier.TypeChecker/Poly.fs
@@ -118,10 +118,8 @@ module Poly =
           { Kind = TypeKind.Range { Min = fold min; Max = fold max }
             Mutable = false
             Provenance = None }
-        | TypeKind.Struct { Name = name
-                            TypeArgs = typeArgs
-                            Elems = elems } ->
-          let typeArgs = Option.map (List.map fold) typeArgs
+        | TypeKind.Struct { TypeRef = typeRef; Elems = elems } ->
+          let typeArgs = Option.map (List.map fold) typeRef.TypeArgs
 
           let elems =
             List.map
@@ -133,8 +131,7 @@ module Poly =
 
           { Kind =
               TypeKind.Struct
-                { Name = name
-                  TypeArgs = typeArgs
+                { TypeRef = { typeRef with TypeArgs = typeArgs }
                   Elems = elems }
             Mutable = false
             Provenance = None }

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -293,6 +293,16 @@ module rec Unify =
         let namedProps2 = getNamedProps obj.Elems
         do! unifyObjProps ctx env ips namedProps1 namedProps2
 
+      | TypeKind.Struct { Name = name1; Elems = elems1 },
+        TypeKind.Struct { Name = name2; Elems = elems2 } ->
+        // TODO: handle immutable objects/structs
+
+        if name1 <> name2 then
+          return! Error(TypeError.TypeMismatch(t1, t2))
+
+        let namedProps1 = getNamedProps elems1
+        let namedProps2 = getNamedProps elems2
+        do! unifyObjProps ctx env ips namedProps1 namedProps2
       | TypeKind.Object obj, TypeKind.Intersection types ->
         let mutable combinedElems = []
         let mutable restTypes = []

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -293,12 +293,14 @@ module rec Unify =
         let namedProps2 = getNamedProps obj.Elems
         do! unifyObjProps ctx env ips namedProps1 namedProps2
 
-      | TypeKind.Struct { Name = name1; Elems = elems1 },
-        TypeKind.Struct { Name = name2; Elems = elems2 } ->
+      | TypeKind.Struct { TypeRef = typeRef1; Elems = elems1 },
+        TypeKind.Struct { TypeRef = typeRef2; Elems = elems2 } ->
         // TODO: handle immutable objects/structs
 
-        if name1 <> name2 then
+        if typeRef1.Name <> typeRef2.Name then
           return! Error(TypeError.TypeMismatch(t1, t2))
+
+        // TODO: unify the type args (we need to know their variance)
 
         let namedProps1 = getNamedProps elems1
         let namedProps2 = getNamedProps elems2
@@ -833,7 +835,7 @@ module rec Unify =
 
           match t with
           | Some t -> t
-          | None -> failwithf $"Property {key} not found"
+          | None -> failwith $"Property {key} not found"
         | _ ->
           // TODO: Handle the case where the type is a primitive and use a
           // special function to expand the type

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -146,7 +146,7 @@ module rec ExprVisitor =
         | TypeAnnKind.Tuple { Elems = elems } -> List.iter walk elems
         | TypeAnnKind.Union types -> List.iter walk types
         | TypeAnnKind.Intersection types -> List.iter walk types
-        | TypeAnnKind.TypeRef(_name, typeArgs) ->
+        | TypeAnnKind.TypeRef { TypeArgs = typeArgs } ->
           Option.iter (List.iter walk) typeArgs
         | TypeAnnKind.Function f ->
           walk f.ReturnType

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -61,7 +61,9 @@ module rec ExprVisitor =
         | ExprKind.Unary(_op, value) -> walk value
         | ExprKind.Object elems ->
           // TODO:
-          // failwith "todo"
+          ()
+        | ExprKind.Struct { Elems = elems; TypeRef = typeRef } ->
+          // TODO:
           ()
         | ExprKind.Try { Body = body
                          Catch = catch
@@ -108,6 +110,22 @@ module rec ExprVisitor =
         | StmtKind.Decl({ Kind = DeclKind.TypeDecl(name, typeAnn, typeParams) }) ->
           // TODO: walk type params
           walkTypeAnn visitor typeAnn
+        | StmtKind.Decl({ Kind = DeclKind.StructDecl { Elems = elems
+                                                       TypeParams = typeParams } }) ->
+          match typeParams with
+          | Some typeParams ->
+            for param in typeParams do
+              match param.Constraint with
+              | Some c -> walkTypeAnn visitor c
+              | None -> ()
+
+              match param.Default with
+              | Some d -> walkTypeAnn visitor d
+              | None -> ()
+          | None -> ()
+
+          for prop in elems do
+            walkTypeAnn visitor prop.TypeAnn
         | StmtKind.Return exprOption ->
           Option.iter (walkExpr visitor) exprOption
 
@@ -129,9 +147,22 @@ module rec ExprVisitor =
                 Option.iter (walkExpr visitor) init
               | ObjPatElem.RestPat { Target = target } -> walk target)
             elems
+        | PatternKind.Struct { Elems = elems } ->
+          // TODO: walk typeArgs
+          List.iter
+            (fun (elem: ObjPatElem) ->
+              match elem with
+              | ObjPatElem.KeyValuePat { Value = value; Default = init } ->
+                walk value
+                Option.iter (walkExpr visitor) init
+              | ObjPatElem.ShorthandPat { Default = init } ->
+                Option.iter (walkExpr visitor) init
+              | ObjPatElem.RestPat { Target = target } -> walk target)
+            elems
         | PatternKind.Tuple { Elems = elems } -> List.iter walk elems
         | PatternKind.Wildcard _ -> ()
         | PatternKind.Literal _ -> ()
+        | PatternKind.Rest arg -> walk arg
 
     walk pat
 


### PR DESCRIPTION
Instead of having classes, we're going to try structs with impl blocks.

TODO:
- [x] parse syntax for initializing a new struct
- [x] infer instance type from struct ~+ impl blocks~ (I'm going to handle impl blocks in a separate PR)
- [x] infer struct initialization expressions

I'll work on static members in a separate PR.