### PR TITLE
implement inferModule

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -281,7 +281,7 @@ module rec Codegen =
 
     for item in m.Items do
       match item with
-      | Import _ -> failwith "TODO: buildModuleTypes - Import"
+      | ScriptItem.Import _ -> failwith "TODO: buildModuleTypes - Import"
       | Stmt stmt ->
         match stmt.Kind with
         | StmtKind.Decl decl ->

--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -217,7 +217,7 @@ module rec Codegen =
             stmts
         | StmtKind.Decl decl ->
           match decl.Kind with
-          | VarDecl(pattern, init, typeAnnOption) ->
+          | VarDecl { Pattern = pattern; Init = init } ->
             let pattern = buildPattern ctx pattern
             let initExpr, initStmts = buildExpr ctx init
 
@@ -286,7 +286,7 @@ module rec Codegen =
         match stmt.Kind with
         | StmtKind.Decl decl ->
           match decl.Kind with
-          | TypeDecl(name, typeAnn, typeParams) ->
+          | TypeDecl { Name = name; TypeAnn = typeAnn } ->
             match typeAnn.InferredType with
             | Some(typeAnn) ->
               let decl =
@@ -304,7 +304,7 @@ module rec Codegen =
 
               items <- item :: items
             | None -> ()
-          | VarDecl(pattern, init, typeAnnOption) ->
+          | VarDecl { Pattern = pattern } ->
             for Operators.KeyValue(name, _) in findBindings pattern do
               let n: string = name
 

--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -24,7 +24,7 @@ module rec Codegen =
     { Start = FParsec.Position("", 0, 0, 0)
       Stop = FParsec.Position("", 0, 0, 0) }
 
-  let buildScript (ctx: Ctx) (m: Module) =
+  let buildScript (ctx: Ctx) (m: Script) =
     let stmts: list<Stmt> =
       m.Items
       |> List.choose (fun item ->
@@ -276,7 +276,7 @@ module rec Codegen =
   // TODO: our ModuleItem enum should contain: Decl and Imports
   // TODO: pass in `env: Env` so that we can look up the types of
   // the exported symbols since we aren't tracking provenance consistently yet
-  let buildModuleTypes (env: Env) (ctx: Ctx) (m: Module) : TS.Module =
+  let buildModuleTypes (env: Env) (ctx: Ctx) (m: Script) : TS.Module =
     let mutable items: list<TS.ModuleItem> = []
 
     for item in m.Items do

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -344,12 +344,19 @@ module Syntax =
       Self: TypeRef
       Elems: list<ImplElem> }
 
+  type VarDecl =
+    { Pattern: Pattern
+      TypeAnn: option<TypeAnn>
+      Init: Expr }
+
+  type TypeDecl =
+    { Name: string
+      TypeAnn: TypeAnn
+      TypeParams: option<list<TypeParam>> }
+
   type DeclKind =
-    | VarDecl of name: Pattern * init: Expr * typeAnn: option<TypeAnn>
-    | TypeDecl of
-      name: string *
-      typeAnn: TypeAnn *
-      typeParams: option<list<TypeParam>>
+    | VarDecl of VarDecl
+    | TypeDecl of TypeDecl
     | StructDecl of StructDecl
 
   type Decl = { Kind: DeclKind; Span: Span }
@@ -467,13 +474,14 @@ module Syntax =
   type ScriptItem =
     | Import of Import
     | DeclareLet of name: Pattern * typeAnn: TypeAnn
-    | Stmt of Stmt
+    | Stmt of Stmt // contains decls along with other statements
 
   type Script = { Items: list<ScriptItem> }
 
   type ModuleItem =
     | Import of Import
     | DeclareLet of name: Pattern * typeAnn: TypeAnn
+    | Decl of Decl
 
   type Module = { Items: list<ModuleItem> }
 

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -471,6 +471,12 @@ module Syntax =
 
   type Script = { Items: list<ScriptItem> }
 
+  type ModuleItem =
+    | Import of Import
+    | DeclareLet of name: Pattern * typeAnn: TypeAnn
+
+  type Module = { Items: list<ModuleItem> }
+
 module Type =
   type PropName =
     | String of string

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -464,12 +464,12 @@ module Syntax =
     { Path: string
       Specifiers: list<ImportSpecifier> }
 
-  type ModuleItem =
+  type ScriptItem =
     | Import of Import
     | DeclareLet of name: Pattern * typeAnn: TypeAnn
     | Stmt of Stmt
 
-  type Module = { Items: list<ModuleItem> }
+  type Script = { Items: list<ScriptItem> }
 
 module Type =
   type PropName =

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrowIdentifier.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrowIdentifier.verified.txt
@@ -6,44 +6,48 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "fst"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 1, Col: 5)
-                              Stop = (Ln: 1, Col: 9) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern = { Kind = Ident { Name = "x"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 1, Col: 15)
-                                                      Stop = (Ln: 1, Col: 16) }
-                                             InferredType = None }
-                                 TypeAnn = None
-                                 Optional = false };
-                               { Pattern = { Kind = Ident { Name = "y"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 1, Col: 18)
-                                                      Stop = (Ln: 1, Col: 19) }
-                                             InferredType = None }
-                                 TypeAnn = None
-                                 Optional = false }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body = Expr { Kind = Identifier "x"
-                                        Span = { Start = (Ln: 1, Col: 24)
-                                                 Stop = (Ln: 1, Col: 25) }
-                                        InferredType = None } }
-                     Span = { Start = (Ln: 1, Col: 11)
-                              Stop = (Ln: 1, Col: 25) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "fst"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 1, Col: 5)
+                                         Stop = (Ln: 1, Col: 9) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind = Ident { Name = "x"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 1, Col: 15)
+                                               Stop = (Ln: 1, Col: 16) }
+                                      InferredType = None }
+                                   TypeAnn = None
+                                   Optional = false };
+                                 { Pattern =
+                                    { Kind = Ident { Name = "y"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 1, Col: 18)
+                                               Stop = (Ln: 1, Col: 19) }
+                                      InferredType = None }
+                                   TypeAnn = None
+                                   Optional = false }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body = Expr { Kind = Identifier "x"
+                                          Span = { Start = (Ln: 1, Col: 24)
+                                                   Stop = (Ln: 1, Col: 25) }
+                                          InferredType = None } }
+                       Span = { Start = (Ln: 1, Col: 11)
+                                Stop = (Ln: 1, Col: 25) }
+                       InferredType = None } }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 25) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseAsyncFunc.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseAsyncFunc.verified.txt
@@ -11,92 +11,102 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "bar"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig = { TypeParams = None
-                                  Self = None
-                                  ParamList = []
-                                  ReturnType = None
-                                  Throws = None
-                                  IsAsync = true }
-                          Body =
-                           Block
-                             { Span = { Start = (Ln: 2, Col: 27)
-                                        Stop = (Ln: 6, Col: 5) }
-                               Stmts =
-                                [{ Kind =
-                                    Decl
-                                      { Kind =
-                                         VarDecl
-                                           ({ Kind = Ident { Name = "x"
-                                                             IsMut = false
-                                                             Assertion = None }
-                                              Span = { Start = (Ln: 3, Col: 11)
-                                                       Stop = (Ln: 3, Col: 13) }
-                                              InferredType = None },
-                                            { Kind =
-                                               Await
-                                                 { Value =
-                                                    { Kind =
-                                                       Call
-                                                         { Callee =
-                                                            { Kind =
-                                                               Identifier "foo"
-                                                              Span =
-                                                               { Start =
-                                                                  (Ln: 3, Col: 21)
-                                                                 Stop =
-                                                                  (Ln: 3, Col: 24) }
-                                                              InferredType =
-                                                               None }
-                                                           TypeArgs = None
-                                                           Args = []
-                                                           OptChain = false
-                                                           Throws = None }
-                                                      Span =
-                                                       { Start =
-                                                          (Ln: 3, Col: 21)
-                                                         Stop = (Ln: 4, Col: 7) }
-                                                      InferredType = None }
-                                                   Throws = None }
-                                              Span = { Start = (Ln: 3, Col: 21)
-                                                       Stop = (Ln: 4, Col: 7) }
-                                              InferredType = None }, None)
-                                        Span = { Start = (Ln: 3, Col: 7)
-                                                 Stop = (Ln: 4, Col: 7) } }
-                                   Span = { Start = (Ln: 3, Col: 7)
-                                            Stop = (Ln: 4, Col: 7) } };
-                                 { Kind =
-                                    Return
-                                      (Some
-                                         { Kind =
-                                            Binary
-                                              ("+",
-                                               { Kind = Identifier "x"
-                                                 Span =
-                                                  { Start = (Ln: 4, Col: 14)
-                                                    Stop = (Ln: 4, Col: 16) }
-                                                 InferredType = None },
-                                               { Kind =
-                                                  Literal (Number (Int 10))
-                                                 Span =
-                                                  { Start = (Ln: 4, Col: 18)
-                                                    Stop = (Ln: 5, Col: 5) }
-                                                 InferredType = None })
-                                           Span = { Start = (Ln: 4, Col: 14)
-                                                    Stop = (Ln: 5, Col: 5) }
-                                           InferredType = None })
-                                   Span = { Start = (Ln: 4, Col: 7)
-                                            Stop = (Ln: 5, Col: 5) } }] } }
-                     Span = { Start = (Ln: 2, Col: 15)
-                              Stop = (Ln: 6, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "bar"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig = { TypeParams = None
+                                    Self = None
+                                    ParamList = []
+                                    ReturnType = None
+                                    Throws = None
+                                    IsAsync = true }
+                            Body =
+                             Block
+                               { Span = { Start = (Ln: 2, Col: 27)
+                                          Stop = (Ln: 6, Col: 5) }
+                                 Stmts =
+                                  [{ Kind =
+                                      Decl
+                                        { Kind =
+                                           VarDecl
+                                             { Pattern =
+                                                { Kind =
+                                                   Ident { Name = "x"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                                  Span =
+                                                   { Start = (Ln: 3, Col: 11)
+                                                     Stop = (Ln: 3, Col: 13) }
+                                                  InferredType = None }
+                                               TypeAnn = None
+                                               Init =
+                                                { Kind =
+                                                   Await
+                                                     { Value =
+                                                        { Kind =
+                                                           Call
+                                                             { Callee =
+                                                                { Kind =
+                                                                   Identifier
+                                                                     "foo"
+                                                                  Span =
+                                                                   { Start =
+                                                                      (Ln: 3, Col: 21)
+                                                                     Stop =
+                                                                      (Ln: 3, Col: 24) }
+                                                                  InferredType =
+                                                                   None }
+                                                               TypeArgs = None
+                                                               Args = []
+                                                               OptChain = false
+                                                               Throws = None }
+                                                          Span =
+                                                           { Start =
+                                                              (Ln: 3, Col: 21)
+                                                             Stop =
+                                                              (Ln: 4, Col: 7) }
+                                                          InferredType = None }
+                                                       Throws = None }
+                                                  Span =
+                                                   { Start = (Ln: 3, Col: 21)
+                                                     Stop = (Ln: 4, Col: 7) }
+                                                  InferredType = None } }
+                                          Span = { Start = (Ln: 3, Col: 7)
+                                                   Stop = (Ln: 4, Col: 7) } }
+                                     Span = { Start = (Ln: 3, Col: 7)
+                                              Stop = (Ln: 4, Col: 7) } };
+                                   { Kind =
+                                      Return
+                                        (Some
+                                           { Kind =
+                                              Binary
+                                                ("+",
+                                                 { Kind = Identifier "x"
+                                                   Span =
+                                                    { Start = (Ln: 4, Col: 14)
+                                                      Stop = (Ln: 4, Col: 16) }
+                                                   InferredType = None },
+                                                 { Kind =
+                                                    Literal (Number (Int 10))
+                                                   Span =
+                                                    { Start = (Ln: 4, Col: 18)
+                                                      Stop = (Ln: 5, Col: 5) }
+                                                   InferredType = None })
+                                             Span = { Start = (Ln: 4, Col: 14)
+                                                      Stop = (Ln: 5, Col: 5) }
+                                             InferredType = None })
+                                     Span = { Start = (Ln: 4, Col: 7)
+                                              Stop = (Ln: 5, Col: 5) } }] } }
+                       Span = { Start = (Ln: 2, Col: 15)
+                                Stop = (Ln: 6, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 6, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
@@ -8,29 +8,32 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind =
-                      Struct
-                        { TypeRef = { Ident = "Point"
-                                      TypeArgs = None }
-                          Elems =
-                           [ShorthandPat { Span = { Start = (Ln: 2, Col: 16)
-                                                    Stop = (Ln: 2, Col: 17) }
-                                           Name = "x"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None };
-                            ShorthandPat { Span = { Start = (Ln: 2, Col: 19)
-                                                    Stop = (Ln: 2, Col: 20) }
-                                           Name = "y"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None }] }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 22) }
-                     InferredType = None }, { Kind = Identifier "point"
-                                              Span = { Start = (Ln: 2, Col: 24)
-                                                       Stop = (Ln: 3, Col: 5) }
-                                              InferredType = None }, None)
+                  { Pattern =
+                     { Kind =
+                        Struct
+                          { TypeRef = { Ident = "Point"
+                                        TypeArgs = None }
+                            Elems =
+                             [ShorthandPat { Span = { Start = (Ln: 2, Col: 16)
+                                                      Stop = (Ln: 2, Col: 17) }
+                                             Name = "x"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None };
+                              ShorthandPat { Span = { Start = (Ln: 2, Col: 19)
+                                                      Stop = (Ln: 2, Col: 20) }
+                                             Name = "y"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None }] }
+                       Span = { Start = (Ln: 2, Col: 9)
+                                Stop = (Ln: 2, Col: 22) }
+                       InferredType = None }
+                    TypeAnn = None
+                    Init = { Kind = Identifier "point"
+                             Span = { Start = (Ln: 2, Col: 24)
+                                      Stop = (Ln: 3, Col: 5) }
+                             InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
@@ -11,36 +11,38 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Callable",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Constructor
-                              { TypeParams = None
-                                Self = None
-                                ParamList = []
-                                ReturnType =
-                                 { Kind = Keyword Symbol
-                                   Span = { Start = (Ln: 3, Col: 20)
-                                            Stop = (Ln: 3, Col: 26) }
-                                   InferredType = None }
-                                Throws = None
-                                IsAsync = false };
-                            Callable
-                              { TypeParams = None
-                                Self = None
-                                ParamList = []
-                                ReturnType =
-                                 { Kind = Keyword Symbol
-                                   Span = { Start = (Ln: 4, Col: 16)
-                                            Stop = (Ln: 4, Col: 22) }
-                                   InferredType = None }
-                                Throws = None
-                                IsAsync = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 21)
-                              Stop = (Ln: 6, Col: 5) }
-                     InferredType = None }, None)
+                  { Name = "Callable"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Constructor
+                                { TypeParams = None
+                                  Self = None
+                                  ParamList = []
+                                  ReturnType =
+                                   { Kind = Keyword Symbol
+                                     Span = { Start = (Ln: 3, Col: 20)
+                                              Stop = (Ln: 3, Col: 26) }
+                                     InferredType = None }
+                                  Throws = None
+                                  IsAsync = false };
+                              Callable
+                                { TypeParams = None
+                                  Self = None
+                                  ParamList = []
+                                  ReturnType =
+                                   { Kind = Keyword Symbol
+                                     Span = { Start = (Ln: 4, Col: 16)
+                                              Stop = (Ln: 4, Col: 22) }
+                                     InferredType = None }
+                                  Throws = None
+                                  IsAsync = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 21)
+                                Stop = (Ln: 6, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 6, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
@@ -8,55 +8,57 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Foo",
-                   { Kind =
-                      Condition
-                        { Check = { Kind = TypeRef { Ident = "T"
-                                                     TypeArgs = None }
-                                    Span = { Start = (Ln: 2, Col: 22)
-                                             Stop = (Ln: 2, Col: 23) }
-                                    InferredType = None }
-                          Extends = { Kind = Keyword Number
-                                      Span = { Start = (Ln: 2, Col: 25)
-                                               Stop = (Ln: 2, Col: 32) }
+                  { Name = "Foo"
+                    TypeAnn =
+                     { Kind =
+                        Condition
+                          { Check = { Kind = TypeRef { Ident = "T"
+                                                       TypeArgs = None }
+                                      Span = { Start = (Ln: 2, Col: 22)
+                                               Stop = (Ln: 2, Col: 23) }
                                       InferredType = None }
-                          TrueType = { Kind = Literal (String "number")
-                                       Span = { Start = (Ln: 2, Col: 34)
-                                                Stop = (Ln: 2, Col: 42) }
-                                       InferredType = None }
-                          FalseType =
-                           { Kind =
-                              Condition
-                                { Check = { Kind = TypeRef { Ident = "T"
-                                                             TypeArgs = None }
-                                            Span = { Start = (Ln: 2, Col: 53)
-                                                     Stop = (Ln: 2, Col: 54) }
-                                            InferredType = None }
-                                  Extends = { Kind = Keyword String
-                                              Span = { Start = (Ln: 2, Col: 56)
-                                                       Stop = (Ln: 2, Col: 63) }
+                            Extends = { Kind = Keyword Number
+                                        Span = { Start = (Ln: 2, Col: 25)
+                                                 Stop = (Ln: 2, Col: 32) }
+                                        InferredType = None }
+                            TrueType = { Kind = Literal (String "number")
+                                         Span = { Start = (Ln: 2, Col: 34)
+                                                  Stop = (Ln: 2, Col: 42) }
+                                         InferredType = None }
+                            FalseType =
+                             { Kind =
+                                Condition
+                                  { Check = { Kind = TypeRef { Ident = "T"
+                                                               TypeArgs = None }
+                                              Span = { Start = (Ln: 2, Col: 53)
+                                                       Stop = (Ln: 2, Col: 54) }
                                               InferredType = None }
-                                  TrueType =
-                                   { Kind = Literal (String "string")
-                                     Span = { Start = (Ln: 2, Col: 65)
-                                              Stop = (Ln: 2, Col: 73) }
-                                     InferredType = None }
-                                  FalseType =
-                                   { Kind = Literal (String "other")
-                                     Span = { Start = (Ln: 2, Col: 83)
-                                              Stop = (Ln: 2, Col: 90) }
-                                     InferredType = None } }
-                             Span = { Start = (Ln: 2, Col: 50)
-                                      Stop = (Ln: 3, Col: 5) }
-                             InferredType = None } }
-                     Span = { Start = (Ln: 2, Col: 19)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None },
-                   Some [{ Span = { Start = (Ln: 2, Col: 14)
-                                    Stop = (Ln: 2, Col: 15) }
-                           Name = "T"
-                           Constraint = None
-                           Default = None }])
+                                    Extends =
+                                     { Kind = Keyword String
+                                       Span = { Start = (Ln: 2, Col: 56)
+                                                Stop = (Ln: 2, Col: 63) }
+                                       InferredType = None }
+                                    TrueType =
+                                     { Kind = Literal (String "string")
+                                       Span = { Start = (Ln: 2, Col: 65)
+                                                Stop = (Ln: 2, Col: 73) }
+                                       InferredType = None }
+                                    FalseType =
+                                     { Kind = Literal (String "other")
+                                       Span = { Start = (Ln: 2, Col: 83)
+                                                Stop = (Ln: 2, Col: 90) }
+                                       InferredType = None } }
+                               Span = { Start = (Ln: 2, Col: 50)
+                                        Stop = (Ln: 3, Col: 5) }
+                               InferredType = None } }
+                       Span = { Start = (Ln: 2, Col: 19)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None }
+                    TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 14)
+                                                  Stop = (Ln: 2, Col: 15) }
+                                         Name = "T"
+                                         Constraint = None
+                                         Default = None }] }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
@@ -8,41 +8,43 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Exclude",
-                   { Kind =
-                      Condition
-                        { Check = { Kind = TypeRef { Ident = "T"
-                                                     TypeArgs = None }
-                                    Span = { Start = (Ln: 2, Col: 29)
-                                             Stop = (Ln: 2, Col: 30) }
-                                    InferredType = None }
-                          Extends = { Kind = TypeRef { Ident = "U"
+                  { Name = "Exclude"
+                    TypeAnn =
+                     { Kind =
+                        Condition
+                          { Check = { Kind = TypeRef { Ident = "T"
                                                        TypeArgs = None }
-                                      Span = { Start = (Ln: 2, Col: 32)
-                                               Stop = (Ln: 2, Col: 34) }
+                                      Span = { Start = (Ln: 2, Col: 29)
+                                               Stop = (Ln: 2, Col: 30) }
                                       InferredType = None }
-                          TrueType = { Kind = Keyword Never
-                                       Span = { Start = (Ln: 2, Col: 36)
-                                                Stop = (Ln: 2, Col: 42) }
-                                       InferredType = None }
-                          FalseType = { Kind = TypeRef { Ident = "T"
+                            Extends = { Kind = TypeRef { Ident = "U"
                                                          TypeArgs = None }
-                                        Span = { Start = (Ln: 2, Col: 51)
-                                                 Stop = (Ln: 2, Col: 53) }
-                                        InferredType = None } }
-                     Span = { Start = (Ln: 2, Col: 26)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None },
-                   Some
-                     [{ Span = { Start = (Ln: 2, Col: 18)
-                                 Stop = (Ln: 2, Col: 19) }
-                        Name = "T"
-                        Constraint = None
-                        Default = None }; { Span = { Start = (Ln: 2, Col: 21)
-                                                     Stop = (Ln: 2, Col: 22) }
-                                            Name = "U"
-                                            Constraint = None
-                                            Default = None }])
+                                        Span = { Start = (Ln: 2, Col: 32)
+                                                 Stop = (Ln: 2, Col: 34) }
+                                        InferredType = None }
+                            TrueType = { Kind = Keyword Never
+                                         Span = { Start = (Ln: 2, Col: 36)
+                                                  Stop = (Ln: 2, Col: 42) }
+                                         InferredType = None }
+                            FalseType = { Kind = TypeRef { Ident = "T"
+                                                           TypeArgs = None }
+                                          Span = { Start = (Ln: 2, Col: 51)
+                                                   Stop = (Ln: 2, Col: 53) }
+                                          InferredType = None } }
+                       Span = { Start = (Ln: 2, Col: 26)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None }
+                    TypeParams =
+                     Some
+                       [{ Span = { Start = (Ln: 2, Col: 18)
+                                   Stop = (Ln: 2, Col: 19) }
+                          Name = "T"
+                          Constraint = None
+                          Default = None }; { Span = { Start = (Ln: 2, Col: 21)
+                                                       Stop = (Ln: 2, Col: 22) }
+                                              Name = "U"
+                                              Constraint = None
+                                              Default = None }] }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
@@ -8,34 +8,37 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind =
-                      Struct
-                        { TypeRef =
-                           { Ident = "Point"
-                             TypeArgs =
-                              Some [{ Kind = Keyword Number
-                                      Span = { Start = (Ln: 2, Col: 15)
-                                               Stop = (Ln: 2, Col: 21) }
-                                      InferredType = None }] }
-                          Elems =
-                           [ShorthandPat { Span = { Start = (Ln: 2, Col: 24)
-                                                    Stop = (Ln: 2, Col: 25) }
-                                           Name = "x"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None };
-                            ShorthandPat { Span = { Start = (Ln: 2, Col: 27)
-                                                    Stop = (Ln: 2, Col: 28) }
-                                           Name = "y"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None }] }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 30) }
-                     InferredType = None }, { Kind = Identifier "point"
-                                              Span = { Start = (Ln: 2, Col: 32)
-                                                       Stop = (Ln: 3, Col: 5) }
-                                              InferredType = None }, None)
+                  { Pattern =
+                     { Kind =
+                        Struct
+                          { TypeRef =
+                             { Ident = "Point"
+                               TypeArgs =
+                                Some [{ Kind = Keyword Number
+                                        Span = { Start = (Ln: 2, Col: 15)
+                                                 Stop = (Ln: 2, Col: 21) }
+                                        InferredType = None }] }
+                            Elems =
+                             [ShorthandPat { Span = { Start = (Ln: 2, Col: 24)
+                                                      Stop = (Ln: 2, Col: 25) }
+                                             Name = "x"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None };
+                              ShorthandPat { Span = { Start = (Ln: 2, Col: 27)
+                                                      Stop = (Ln: 2, Col: 28) }
+                                             Name = "y"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None }] }
+                       Span = { Start = (Ln: 2, Col: 9)
+                                Stop = (Ln: 2, Col: 30) }
+                       InferredType = None }
+                    TypeAnn = None
+                    Init = { Kind = Identifier "point"
+                             Span = { Start = (Ln: 2, Col: 32)
+                                      Stop = (Ln: 3, Col: 5) }
+                             InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
@@ -6,21 +6,23 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Foo",
-                   { Kind =
-                      Index
-                        ({ Kind = TypeRef { Ident = "Bar"
-                                            TypeArgs = None }
-                           Span = { Start = (Ln: 1, Col: 12)
-                                    Stop = (Ln: 1, Col: 15) }
-                           InferredType = None },
-                         { Kind = Literal (String "baz")
-                           Span = { Start = (Ln: 1, Col: 16)
-                                    Stop = (Ln: 1, Col: 21) }
-                           InferredType = None })
-                     Span = { Start = (Ln: 1, Col: 12)
-                              Stop = (Ln: 1, Col: 22) }
-                     InferredType = None }, None)
+                  { Name = "Foo"
+                    TypeAnn =
+                     { Kind =
+                        Index
+                          ({ Kind = TypeRef { Ident = "Bar"
+                                              TypeArgs = None }
+                             Span = { Start = (Ln: 1, Col: 12)
+                                      Stop = (Ln: 1, Col: 15) }
+                             InferredType = None },
+                           { Kind = Literal (String "baz")
+                             Span = { Start = (Ln: 1, Col: 16)
+                                      Stop = (Ln: 1, Col: 21) }
+                             InferredType = None })
+                       Span = { Start = (Ln: 1, Col: 12)
+                                Stop = (Ln: 1, Col: 22) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 22) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -6,66 +6,69 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("ReturnType",
-                   { Kind =
-                      Condition
-                        { Check = { Kind = TypeRef { Ident = "T"
-                                                     TypeArgs = None }
-                                    Span = { Start = (Ln: 1, Col: 25)
-                                             Stop = (Ln: 1, Col: 26) }
-                                    InferredType = None }
-                          Extends =
-                           { Kind =
-                              Function
-                                { TypeParams = None
-                                  Self = None
-                                  ParamList =
-                                   [{ Pattern =
-                                       { Kind =
-                                          Rest
-                                            { Kind = Ident { Name = "args"
-                                                             IsMut = false
-                                                             Assertion = None }
-                                              Span = { Start = (Ln: 1, Col: 35)
-                                                       Stop = (Ln: 1, Col: 39) }
-                                              InferredType = None }
-                                         Span = { Start = (Ln: 1, Col: 32)
-                                                  Stop = (Ln: 1, Col: 39) }
-                                         InferredType = None }
-                                      TypeAnn =
-                                       { Kind = TypeRef { Ident = "_"
-                                                          TypeArgs = None }
-                                         Span = { Start = (Ln: 1, Col: 41)
-                                                  Stop = (Ln: 1, Col: 42) }
-                                         InferredType = None }
-                                      Optional = false }]
-                                  ReturnType =
-                                   { Kind = Infer "R"
-                                     Span = { Start = (Ln: 1, Col: 47)
-                                              Stop = (Ln: 1, Col: 55) }
-                                     InferredType = None }
-                                  Throws = None
-                                  IsAsync = false }
-                             Span = { Start = (Ln: 1, Col: 28)
-                                      Stop = (Ln: 1, Col: 55) }
-                             InferredType = None }
-                          TrueType = { Kind = TypeRef { Ident = "R"
-                                                        TypeArgs = None }
-                                       Span = { Start = (Ln: 1, Col: 57)
-                                                Stop = (Ln: 1, Col: 59) }
+                  { Name = "ReturnType"
+                    TypeAnn =
+                     { Kind =
+                        Condition
+                          { Check = { Kind = TypeRef { Ident = "T"
+                                                       TypeArgs = None }
+                                      Span = { Start = (Ln: 1, Col: 25)
+                                               Stop = (Ln: 1, Col: 26) }
+                                      InferredType = None }
+                            Extends =
+                             { Kind =
+                                Function
+                                  { TypeParams = None
+                                    Self = None
+                                    ParamList =
+                                     [{ Pattern =
+                                         { Kind =
+                                            Rest
+                                              { Kind =
+                                                 Ident { Name = "args"
+                                                         IsMut = false
+                                                         Assertion = None }
+                                                Span =
+                                                 { Start = (Ln: 1, Col: 35)
+                                                   Stop = (Ln: 1, Col: 39) }
+                                                InferredType = None }
+                                           Span = { Start = (Ln: 1, Col: 32)
+                                                    Stop = (Ln: 1, Col: 39) }
+                                           InferredType = None }
+                                        TypeAnn =
+                                         { Kind = TypeRef { Ident = "_"
+                                                            TypeArgs = None }
+                                           Span = { Start = (Ln: 1, Col: 41)
+                                                    Stop = (Ln: 1, Col: 42) }
+                                           InferredType = None }
+                                        Optional = false }]
+                                    ReturnType =
+                                     { Kind = Infer "R"
+                                       Span = { Start = (Ln: 1, Col: 47)
+                                                Stop = (Ln: 1, Col: 55) }
                                        InferredType = None }
-                          FalseType = { Kind = Keyword Never
-                                        Span = { Start = (Ln: 1, Col: 68)
-                                                 Stop = (Ln: 1, Col: 74) }
-                                        InferredType = None } }
-                     Span = { Start = (Ln: 1, Col: 22)
-                              Stop = (Ln: 1, Col: 75) }
-                     InferredType = None },
-                   Some [{ Span = { Start = (Ln: 1, Col: 17)
-                                    Stop = (Ln: 1, Col: 18) }
-                           Name = "T"
-                           Constraint = None
-                           Default = None }])
+                                    Throws = None
+                                    IsAsync = false }
+                               Span = { Start = (Ln: 1, Col: 28)
+                                        Stop = (Ln: 1, Col: 55) }
+                               InferredType = None }
+                            TrueType = { Kind = TypeRef { Ident = "R"
+                                                          TypeArgs = None }
+                                         Span = { Start = (Ln: 1, Col: 57)
+                                                  Stop = (Ln: 1, Col: 59) }
+                                         InferredType = None }
+                            FalseType = { Kind = Keyword Never
+                                          Span = { Start = (Ln: 1, Col: 68)
+                                                   Stop = (Ln: 1, Col: 74) }
+                                          InferredType = None } }
+                       Span = { Start = (Ln: 1, Col: 22)
+                                Stop = (Ln: 1, Col: 75) }
+                       InferredType = None }
+                    TypeParams = Some [{ Span = { Start = (Ln: 1, Col: 17)
+                                                  Stop = (Ln: 1, Col: 18) }
+                                         Name = "T"
+                                         Constraint = None
+                                         Default = None }] }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 75) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
@@ -6,38 +6,40 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Point",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Mapped
-                              { TypeParam =
-                                 { Name = "P"
-                                   Constraint =
-                                    { Kind =
-                                       Union
-                                         [{ Kind = Literal (String "x")
-                                            Span = { Start = (Ln: 1, Col: 36)
-                                                     Stop = (Ln: 1, Col: 39) }
-                                            InferredType = None };
-                                          { Kind = Literal (String "y")
-                                            Span = { Start = (Ln: 1, Col: 42)
-                                                     Stop = (Ln: 1, Col: 45) }
-                                            InferredType = None }]
-                                      Span = { Start = (Ln: 1, Col: 36)
-                                               Stop = (Ln: 1, Col: 45) }
-                                      InferredType = None } }
-                                Name = None
-                                TypeAnn = { Kind = Keyword Number
-                                            Span = { Start = (Ln: 1, Col: 20)
-                                                     Stop = (Ln: 1, Col: 27) }
-                                            InferredType = None }
-                                Optional = None
-                                Readonly = None }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 1, Col: 14)
-                              Stop = (Ln: 1, Col: 46) }
-                     InferredType = None }, None)
+                  { Name = "Point"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Mapped
+                                { TypeParam =
+                                   { Name = "P"
+                                     Constraint =
+                                      { Kind =
+                                         Union
+                                           [{ Kind = Literal (String "x")
+                                              Span = { Start = (Ln: 1, Col: 36)
+                                                       Stop = (Ln: 1, Col: 39) }
+                                              InferredType = None };
+                                            { Kind = Literal (String "y")
+                                              Span = { Start = (Ln: 1, Col: 42)
+                                                       Stop = (Ln: 1, Col: 45) }
+                                              InferredType = None }]
+                                        Span = { Start = (Ln: 1, Col: 36)
+                                                 Stop = (Ln: 1, Col: 45) }
+                                        InferredType = None } }
+                                  Name = None
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 1, Col: 20)
+                                                       Stop = (Ln: 1, Col: 27) }
+                                              InferredType = None }
+                                  Optional = None
+                                  Readonly = None }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 1, Col: 14)
+                                Stop = (Ln: 1, Col: 46) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 46) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
@@ -13,30 +13,32 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Point",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              { Name = String "x"
-                                TypeAnn = { Kind = Keyword Number
-                                            Span = { Start = (Ln: 2, Col: 22)
-                                                     Stop = (Ln: 2, Col: 28) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false };
-                            Property
-                              { Name = String "y"
-                                TypeAnn = { Kind = Keyword Number
-                                            Span = { Start = (Ln: 2, Col: 33)
-                                                     Stop = (Ln: 2, Col: 39) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 18)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Name = "Point"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "x"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 22)
+                                                       Stop = (Ln: 2, Col: 28) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false };
+                              Property
+                                { Name = String "y"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 33)
+                                                       Stop = (Ln: 2, Col: 39) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 18)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -46,32 +48,34 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Line",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              { Name = String "p0"
-                                TypeAnn = { Kind = TypeRef { Ident = "Point"
-                                                             TypeArgs = None }
-                                            Span = { Start = (Ln: 3, Col: 22)
-                                                     Stop = (Ln: 3, Col: 27) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false };
-                            Property
-                              { Name = String "p1"
-                                TypeAnn = { Kind = TypeRef { Ident = "Point"
-                                                             TypeArgs = None }
-                                            Span = { Start = (Ln: 3, Col: 33)
-                                                     Stop = (Ln: 3, Col: 38) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 3, Col: 17)
-                              Stop = (Ln: 4, Col: 5) }
-                     InferredType = None }, None)
+                  { Name = "Line"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "p0"
+                                  TypeAnn = { Kind = TypeRef { Ident = "Point"
+                                                               TypeArgs = None }
+                                              Span = { Start = (Ln: 3, Col: 22)
+                                                       Stop = (Ln: 3, Col: 27) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false };
+                              Property
+                                { Name = String "p1"
+                                  TypeAnn = { Kind = TypeRef { Ident = "Point"
+                                                               TypeArgs = None }
+                                              Span = { Start = (Ln: 3, Col: 33)
+                                                       Stop = (Ln: 3, Col: 38) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 3, Col: 17)
+                                Stop = (Ln: 4, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)
@@ -91,33 +95,36 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind =
-                      Object
-                        { Elems =
-                           [ShorthandPat { Span = { Start = (Ln: 6, Col: 10)
-                                                    Stop = (Ln: 6, Col: 16) }
-                                           Name = "p0"
-                                           IsMut = true
-                                           Default = None
-                                           Assertion = None };
-                            KeyValuePat
-                              { Span = { Start = (Ln: 6, Col: 18)
-                                         Stop = (Ln: 6, Col: 27) }
-                                Key = "p1"
-                                Value = { Kind = Ident { Name = "q"
-                                                         IsMut = true
-                                                         Assertion = None }
-                                          Span = { Start = (Ln: 6, Col: 22)
-                                                   Stop = (Ln: 6, Col: 27) }
-                                          InferredType = None }
-                                Default = None }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 6, Col: 9)
-                              Stop = (Ln: 6, Col: 29) }
-                     InferredType = None }, { Kind = Identifier "line"
-                                              Span = { Start = (Ln: 6, Col: 31)
-                                                       Stop = (Ln: 7, Col: 5) }
-                                              InferredType = None }, None)
+                  { Pattern =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [ShorthandPat { Span = { Start = (Ln: 6, Col: 10)
+                                                      Stop = (Ln: 6, Col: 16) }
+                                             Name = "p0"
+                                             IsMut = true
+                                             Default = None
+                                             Assertion = None };
+                              KeyValuePat
+                                { Span = { Start = (Ln: 6, Col: 18)
+                                           Stop = (Ln: 6, Col: 27) }
+                                  Key = "p1"
+                                  Value = { Kind = Ident { Name = "q"
+                                                           IsMut = true
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 6, Col: 22)
+                                                     Stop = (Ln: 6, Col: 27) }
+                                            InferredType = None }
+                                  Default = None }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 6, Col: 9)
+                                Stop = (Ln: 6, Col: 29) }
+                       InferredType = None }
+                    TypeAnn = None
+                    Init = { Kind = Identifier "line"
+                             Span = { Start = (Ln: 6, Col: 31)
+                                      Stop = (Ln: 7, Col: 5) }
+                             InferredType = None } }
                Span = { Start = (Ln: 6, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }
           Span = { Start = (Ln: 6, Col: 5)
@@ -125,17 +132,17 @@ output: Ok
       Stmt
         { Kind =
            Decl
-             { Kind =
-                VarDecl
-                  ({ Kind = Ident { Name = "r"
-                                    IsMut = true
-                                    Assertion = None }
-                     Span = { Start = (Ln: 7, Col: 9)
-                              Stop = (Ln: 7, Col: 15) }
-                     InferredType = None }, { Kind = Identifier "q"
-                                              Span = { Start = (Ln: 7, Col: 17)
-                                                       Stop = (Ln: 8, Col: 5) }
-                                              InferredType = None }, None)
+             { Kind = VarDecl { Pattern = { Kind = Ident { Name = "r"
+                                                           IsMut = true
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 7, Col: 9)
+                                                     Stop = (Ln: 7, Col: 15) }
+                                            InferredType = None }
+                                TypeAnn = None
+                                Init = { Kind = Identifier "q"
+                                         Span = { Start = (Ln: 7, Col: 17)
+                                                  Stop = (Ln: 8, Col: 5) }
+                                         InferredType = None } }
                Span = { Start = (Ln: 7, Col: 5)
                         Stop = (Ln: 8, Col: 5) } }
           Span = { Start = (Ln: 7, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableParams.verified.txt
@@ -12,173 +12,179 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "update"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 16) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern = { Kind = Ident { Name = "array"
-                                                            IsMut = true
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 2, Col: 22)
-                                                      Stop = (Ln: 2, Col: 31) }
-                                             InferredType = None }
-                                 TypeAnn =
-                                  Some
-                                    { Kind =
-                                       Array
-                                         { Kind = Keyword Number
-                                           Span = { Start = (Ln: 2, Col: 33)
-                                                    Stop = (Ln: 2, Col: 39) }
-                                           InferredType = None }
-                                      Span = { Start = (Ln: 2, Col: 33)
-                                               Stop = (Ln: 2, Col: 41) }
+                  { Pattern = { Kind = Ident { Name = "update"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 16) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind = Ident { Name = "array"
+                                                     IsMut = true
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 2, Col: 22)
+                                               Stop = (Ln: 2, Col: 31) }
                                       InferredType = None }
-                                 Optional = false }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body =
-                           Block
-                             { Span = { Start = (Ln: 2, Col: 43)
-                                        Stop = (Ln: 7, Col: 5) }
-                               Stmts =
-                                [{ Kind =
-                                    For
-                                      ({ Kind = Ident { Name = "i"
-                                                        IsMut = false
-                                                        Assertion = None }
-                                         Span = { Start = (Ln: 3, Col: 11)
-                                                  Stop = (Ln: 3, Col: 13) }
-                                         InferredType = None },
-                                       { Kind =
-                                          Range
-                                            { Min =
-                                               { Kind = Literal (Number (Int 0))
-                                                 Span =
-                                                  { Start = (Ln: 3, Col: 16)
-                                                    Stop = (Ln: 3, Col: 17) }
-                                                 InferredType = None }
-                                              Max =
-                                               { Kind =
-                                                  Member
-                                                    ({ Kind = Identifier "array"
-                                                       Span =
-                                                        { Start =
-                                                           (Ln: 3, Col: 19)
-                                                          Stop =
-                                                           (Ln: 3, Col: 24) }
-                                                       InferredType = None },
-                                                     "length", false)
-                                                 Span =
-                                                  { Start = (Ln: 3, Col: 19)
+                                   TypeAnn =
+                                    Some
+                                      { Kind =
+                                         Array
+                                           { Kind = Keyword Number
+                                             Span = { Start = (Ln: 2, Col: 33)
+                                                      Stop = (Ln: 2, Col: 39) }
+                                             InferredType = None }
+                                        Span = { Start = (Ln: 2, Col: 33)
+                                                 Stop = (Ln: 2, Col: 41) }
+                                        InferredType = None }
+                                   Optional = false }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body =
+                             Block
+                               { Span = { Start = (Ln: 2, Col: 43)
+                                          Stop = (Ln: 7, Col: 5) }
+                                 Stmts =
+                                  [{ Kind =
+                                      For
+                                        ({ Kind = Ident { Name = "i"
+                                                          IsMut = false
+                                                          Assertion = None }
+                                           Span = { Start = (Ln: 3, Col: 11)
+                                                    Stop = (Ln: 3, Col: 13) }
+                                           InferredType = None },
+                                         { Kind =
+                                            Range
+                                              { Min =
+                                                 { Kind =
+                                                    Literal (Number (Int 0))
+                                                   Span =
+                                                    { Start = (Ln: 3, Col: 16)
+                                                      Stop = (Ln: 3, Col: 17) }
+                                                   InferredType = None }
+                                                Max =
+                                                 { Kind =
+                                                    Member
+                                                      ({ Kind =
+                                                          Identifier "array"
+                                                         Span =
+                                                          { Start =
+                                                             (Ln: 3, Col: 19)
+                                                            Stop =
+                                                             (Ln: 3, Col: 24) }
+                                                         InferredType = None },
+                                                       "length", false)
+                                                   Span =
+                                                    { Start = (Ln: 3, Col: 19)
+                                                      Stop = (Ln: 3, Col: 32) }
+                                                   InferredType = None } }
+                                           Span = { Start = (Ln: 3, Col: 16)
                                                     Stop = (Ln: 3, Col: 32) }
-                                                 InferredType = None } }
-                                         Span = { Start = (Ln: 3, Col: 16)
-                                                  Stop = (Ln: 3, Col: 32) }
-                                         InferredType = None },
-                                       { Span = { Start = (Ln: 3, Col: 32)
-                                                  Stop = (Ln: 6, Col: 5) }
-                                         Stmts =
-                                          [{ Kind =
-                                              Expr
-                                                { Kind =
-                                                   Assign
-                                                     ("=",
-                                                      { Kind =
-                                                         Index
-                                                           ({ Kind =
-                                                               Identifier
-                                                                 "array"
-                                                              Span =
-                                                               { Start =
-                                                                  (Ln: 4, Col: 9)
-                                                                 Stop =
-                                                                  (Ln: 4, Col: 14) }
-                                                              InferredType =
-                                                               None },
-                                                            { Kind =
-                                                               Identifier "i"
-                                                              Span =
-                                                               { Start =
-                                                                  (Ln: 4, Col: 15)
-                                                                 Stop =
-                                                                  (Ln: 4, Col: 16) }
-                                                              InferredType =
-                                                               None }, false)
-                                                        Span =
-                                                         { Start =
-                                                            (Ln: 4, Col: 9)
-                                                           Stop =
-                                                            (Ln: 4, Col: 18) }
-                                                        InferredType = None },
-                                                      { Kind =
-                                                         Binary
-                                                           ("+",
-                                                            { Kind =
-                                                               Index
-                                                                 ({ Kind =
-                                                                     Identifier
-                                                                       "array"
-                                                                    Span =
-                                                                     { Start =
-                                                                        (Ln: 4, Col: 20)
-                                                                       Stop =
-                                                                        (Ln: 4, Col: 25) }
-                                                                    InferredType =
-                                                                     None },
-                                                                  { Kind =
-                                                                     Identifier
-                                                                       "i"
-                                                                    Span =
-                                                                     { Start =
-                                                                        (Ln: 4, Col: 26)
-                                                                       Stop =
-                                                                        (Ln: 4, Col: 27) }
-                                                                    InferredType =
-                                                                     None },
-                                                                  false)
-                                                              Span =
-                                                               { Start =
-                                                                  (Ln: 4, Col: 20)
-                                                                 Stop =
-                                                                  (Ln: 4, Col: 29) }
-                                                              InferredType =
-                                                               None },
-                                                            { Kind =
-                                                               Literal
-                                                                 (Number (Int 1))
-                                                              Span =
-                                                               { Start =
-                                                                  (Ln: 4, Col: 31)
-                                                                 Stop =
-                                                                  (Ln: 5, Col: 7) }
-                                                              InferredType =
-                                                               None })
-                                                        Span =
-                                                         { Start =
-                                                            (Ln: 4, Col: 20)
-                                                           Stop =
-                                                            (Ln: 5, Col: 7) }
-                                                        InferredType = None })
-                                                  Span =
-                                                   { Start = (Ln: 4, Col: 9)
-                                                     Stop = (Ln: 5, Col: 7) }
-                                                  InferredType = None }
-                                             Span = { Start = (Ln: 4, Col: 9)
-                                                      Stop = (Ln: 5, Col: 7) } }] })
-                                   Span = { Start = (Ln: 3, Col: 7)
-                                            Stop = (Ln: 6, Col: 5) } }] } }
-                     Span = { Start = (Ln: 2, Col: 18)
-                              Stop = (Ln: 7, Col: 5) }
-                     InferredType = None }, None)
+                                           InferredType = None },
+                                         { Span = { Start = (Ln: 3, Col: 32)
+                                                    Stop = (Ln: 6, Col: 5) }
+                                           Stmts =
+                                            [{ Kind =
+                                                Expr
+                                                  { Kind =
+                                                     Assign
+                                                       ("=",
+                                                        { Kind =
+                                                           Index
+                                                             ({ Kind =
+                                                                 Identifier
+                                                                   "array"
+                                                                Span =
+                                                                 { Start =
+                                                                    (Ln: 4, Col: 9)
+                                                                   Stop =
+                                                                    (Ln: 4, Col: 14) }
+                                                                InferredType =
+                                                                 None },
+                                                              { Kind =
+                                                                 Identifier "i"
+                                                                Span =
+                                                                 { Start =
+                                                                    (Ln: 4, Col: 15)
+                                                                   Stop =
+                                                                    (Ln: 4, Col: 16) }
+                                                                InferredType =
+                                                                 None }, false)
+                                                          Span =
+                                                           { Start =
+                                                              (Ln: 4, Col: 9)
+                                                             Stop =
+                                                              (Ln: 4, Col: 18) }
+                                                          InferredType = None },
+                                                        { Kind =
+                                                           Binary
+                                                             ("+",
+                                                              { Kind =
+                                                                 Index
+                                                                   ({ Kind =
+                                                                       Identifier
+                                                                         "array"
+                                                                      Span =
+                                                                       { Start =
+                                                                          (Ln: 4, Col: 20)
+                                                                         Stop =
+                                                                          (Ln: 4, Col: 25) }
+                                                                      InferredType =
+                                                                       None },
+                                                                    { Kind =
+                                                                       Identifier
+                                                                         "i"
+                                                                      Span =
+                                                                       { Start =
+                                                                          (Ln: 4, Col: 26)
+                                                                         Stop =
+                                                                          (Ln: 4, Col: 27) }
+                                                                      InferredType =
+                                                                       None },
+                                                                    false)
+                                                                Span =
+                                                                 { Start =
+                                                                    (Ln: 4, Col: 20)
+                                                                   Stop =
+                                                                    (Ln: 4, Col: 29) }
+                                                                InferredType =
+                                                                 None },
+                                                              { Kind =
+                                                                 Literal
+                                                                   (Number
+                                                                      (Int 1))
+                                                                Span =
+                                                                 { Start =
+                                                                    (Ln: 4, Col: 31)
+                                                                   Stop =
+                                                                    (Ln: 5, Col: 7) }
+                                                                InferredType =
+                                                                 None })
+                                                          Span =
+                                                           { Start =
+                                                              (Ln: 4, Col: 20)
+                                                             Stop =
+                                                              (Ln: 5, Col: 7) }
+                                                          InferredType = None })
+                                                    Span =
+                                                     { Start = (Ln: 4, Col: 9)
+                                                       Stop = (Ln: 5, Col: 7) }
+                                                    InferredType = None }
+                                               Span = { Start = (Ln: 4, Col: 9)
+                                                        Stop = (Ln: 5, Col: 7) } }] })
+                                     Span = { Start = (Ln: 3, Col: 7)
+                                              Stop = (Ln: 6, Col: 5) } }] } }
+                       Span = { Start = (Ln: 2, Col: 18)
+                                Stop = (Ln: 7, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
@@ -11,30 +11,32 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Point",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              { Name = String "x"
-                                TypeAnn = { Kind = Keyword Number
-                                            Span = { Start = (Ln: 2, Col: 22)
-                                                     Stop = (Ln: 2, Col: 28) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false };
-                            Property
-                              { Name = String "y"
-                                TypeAnn = { Kind = Keyword Number
-                                            Span = { Start = (Ln: 2, Col: 33)
-                                                     Stop = (Ln: 2, Col: 39) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 18)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Name = "Point"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "x"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 22)
+                                                       Stop = (Ln: 2, Col: 28) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false };
+                              Property
+                                { Name = String "y"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 33)
+                                                       Stop = (Ln: 2, Col: 39) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 18)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -44,51 +46,53 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind =
-                      Object
-                        { Elems =
-                           [ShorthandPat { Span = { Start = (Ln: 3, Col: 10)
-                                                    Stop = (Ln: 3, Col: 11) }
-                                           Name = "x"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None };
-                            ShorthandPat { Span = { Start = (Ln: 3, Col: 13)
-                                                    Stop = (Ln: 3, Col: 14) }
-                                           Name = "y"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 3, Col: 9)
-                              Stop = (Ln: 3, Col: 15) }
-                     InferredType = None },
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              ({ Start = (Ln: 3, Col: 26)
-                                 Stop = (Ln: 3, Col: 30) }, String "x",
-                               { Kind = Literal (Number (Int 5))
-                                 Span = { Start = (Ln: 3, Col: 29)
-                                          Stop = (Ln: 3, Col: 30) }
-                                 InferredType = None });
-                            Property
-                              ({ Start = (Ln: 3, Col: 32)
-                                 Stop = (Ln: 3, Col: 37) }, String "y",
-                               { Kind = Literal (Number (Int 10))
-                                 Span = { Start = (Ln: 3, Col: 35)
-                                          Stop = (Ln: 3, Col: 37) }
-                                 InferredType = None })]
-                          Immutable = false }
-                     Span = { Start = (Ln: 3, Col: 25)
-                              Stop = (Ln: 4, Col: 5) }
-                     InferredType = None },
-                   Some { Kind = TypeRef { Ident = "Point"
-                                           TypeArgs = None }
-                          Span = { Start = (Ln: 3, Col: 17)
-                                   Stop = (Ln: 3, Col: 23) }
-                          InferredType = None })
+                  { Pattern =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [ShorthandPat { Span = { Start = (Ln: 3, Col: 10)
+                                                      Stop = (Ln: 3, Col: 11) }
+                                             Name = "x"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None };
+                              ShorthandPat { Span = { Start = (Ln: 3, Col: 13)
+                                                      Stop = (Ln: 3, Col: 14) }
+                                             Name = "y"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 3, Col: 9)
+                                Stop = (Ln: 3, Col: 15) }
+                       InferredType = None }
+                    TypeAnn = Some { Kind = TypeRef { Ident = "Point"
+                                                      TypeArgs = None }
+                                     Span = { Start = (Ln: 3, Col: 17)
+                                              Stop = (Ln: 3, Col: 23) }
+                                     InferredType = None }
+                    Init =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                ({ Start = (Ln: 3, Col: 26)
+                                   Stop = (Ln: 3, Col: 30) }, String "x",
+                                 { Kind = Literal (Number (Int 5))
+                                   Span = { Start = (Ln: 3, Col: 29)
+                                            Stop = (Ln: 3, Col: 30) }
+                                   InferredType = None });
+                              Property
+                                ({ Start = (Ln: 3, Col: 32)
+                                   Stop = (Ln: 3, Col: 37) }, String "y",
+                                 { Kind = Literal (Number (Int 10))
+                                   Span = { Start = (Ln: 3, Col: 35)
+                                            Stop = (Ln: 3, Col: 37) }
+                                   InferredType = None })]
+                            Immutable = false }
+                       Span = { Start = (Ln: 3, Col: 25)
+                                Stop = (Ln: 4, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)
@@ -98,28 +102,29 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "p"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 4, Col: 9)
-                              Stop = (Ln: 4, Col: 10) }
-                     InferredType = None },
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Shorthand ({ Start = (Ln: 4, Col: 21)
-                                         Stop = (Ln: 4, Col: 22) }, "x");
-                            Shorthand ({ Start = (Ln: 4, Col: 24)
-                                         Stop = (Ln: 4, Col: 25) }, "y")]
-                          Immutable = false }
-                     Span = { Start = (Ln: 4, Col: 20)
-                              Stop = (Ln: 5, Col: 5) }
-                     InferredType = None },
-                   Some { Kind = TypeRef { Ident = "Point"
-                                           TypeArgs = None }
-                          Span = { Start = (Ln: 4, Col: 12)
-                                   Stop = (Ln: 4, Col: 18) }
-                          InferredType = None })
+                  { Pattern = { Kind = Ident { Name = "p"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 4, Col: 9)
+                                         Stop = (Ln: 4, Col: 10) }
+                                InferredType = None }
+                    TypeAnn = Some { Kind = TypeRef { Ident = "Point"
+                                                      TypeArgs = None }
+                                     Span = { Start = (Ln: 4, Col: 12)
+                                              Stop = (Ln: 4, Col: 18) }
+                                     InferredType = None }
+                    Init =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Shorthand ({ Start = (Ln: 4, Col: 21)
+                                           Stop = (Ln: 4, Col: 22) }, "x");
+                              Shorthand ({ Start = (Ln: 4, Col: 24)
+                                           Stop = (Ln: 4, Col: 25) }, "y")]
+                            Immutable = false }
+                       Span = { Start = (Ln: 4, Col: 20)
+                                Stop = (Ln: 5, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 4, Col: 5)
                         Stop = (Ln: 5, Col: 5) } }
           Span = { Start = (Ln: 4, Col: 5)
@@ -129,70 +134,72 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "foo"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 5, Col: 9)
-                              Stop = (Ln: 5, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern =
-                                  { Kind =
-                                     Object
-                                       { Elems =
-                                          [ShorthandPat
-                                             { Span =
-                                                { Start = (Ln: 5, Col: 20)
-                                                  Stop = (Ln: 5, Col: 21) }
-                                               Name = "x"
+                  { Pattern = { Kind = Ident { Name = "foo"
                                                IsMut = false
-                                               Default = None
-                                               Assertion = None };
-                                           ShorthandPat
-                                             { Span =
-                                                { Start = (Ln: 5, Col: 23)
-                                                  Stop = (Ln: 5, Col: 24) }
-                                               Name = "y"
-                                               IsMut = false
-                                               Default = None
-                                               Assertion = None }]
-                                         Immutable = false }
-                                    Span = { Start = (Ln: 5, Col: 19)
-                                             Stop = (Ln: 5, Col: 25) }
-                                    InferredType = None }
-                                 TypeAnn =
-                                  Some { Kind = TypeRef { Ident = "Point"
-                                                          TypeArgs = None }
-                                         Span = { Start = (Ln: 5, Col: 27)
-                                                  Stop = (Ln: 5, Col: 32) }
-                                         InferredType = None }
-                                 Optional = false }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body =
-                           Expr
-                             { Kind =
-                                Binary
-                                  ("+", { Kind = Identifier "x"
-                                          Span = { Start = (Ln: 5, Col: 37)
-                                                   Stop = (Ln: 5, Col: 39) }
-                                          InferredType = None },
-                                   { Kind = Identifier "y"
-                                     Span = { Start = (Ln: 5, Col: 41)
-                                              Stop = (Ln: 6, Col: 5) }
-                                     InferredType = None })
-                               Span = { Start = (Ln: 5, Col: 37)
-                                        Stop = (Ln: 6, Col: 5) }
-                               InferredType = None } }
-                     Span = { Start = (Ln: 5, Col: 15)
-                              Stop = (Ln: 6, Col: 5) }
-                     InferredType = None }, None)
+                                               Assertion = None }
+                                Span = { Start = (Ln: 5, Col: 9)
+                                         Stop = (Ln: 5, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind =
+                                       Object
+                                         { Elems =
+                                            [ShorthandPat
+                                               { Span =
+                                                  { Start = (Ln: 5, Col: 20)
+                                                    Stop = (Ln: 5, Col: 21) }
+                                                 Name = "x"
+                                                 IsMut = false
+                                                 Default = None
+                                                 Assertion = None };
+                                             ShorthandPat
+                                               { Span =
+                                                  { Start = (Ln: 5, Col: 23)
+                                                    Stop = (Ln: 5, Col: 24) }
+                                                 Name = "y"
+                                                 IsMut = false
+                                                 Default = None
+                                                 Assertion = None }]
+                                           Immutable = false }
+                                      Span = { Start = (Ln: 5, Col: 19)
+                                               Stop = (Ln: 5, Col: 25) }
+                                      InferredType = None }
+                                   TypeAnn =
+                                    Some { Kind = TypeRef { Ident = "Point"
+                                                            TypeArgs = None }
+                                           Span = { Start = (Ln: 5, Col: 27)
+                                                    Stop = (Ln: 5, Col: 32) }
+                                           InferredType = None }
+                                   Optional = false }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body =
+                             Expr
+                               { Kind =
+                                  Binary
+                                    ("+", { Kind = Identifier "x"
+                                            Span = { Start = (Ln: 5, Col: 37)
+                                                     Stop = (Ln: 5, Col: 39) }
+                                            InferredType = None },
+                                     { Kind = Identifier "y"
+                                       Span = { Start = (Ln: 5, Col: 41)
+                                                Stop = (Ln: 6, Col: 5) }
+                                       InferredType = None })
+                                 Span = { Start = (Ln: 5, Col: 37)
+                                          Stop = (Ln: 6, Col: 5) }
+                                 InferredType = None } }
+                       Span = { Start = (Ln: 5, Col: 15)
+                                Stop = (Ln: 6, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 5, Col: 5)
                         Stop = (Ln: 6, Col: 5) } }
           Span = { Start = (Ln: 5, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
@@ -9,40 +9,42 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "obj"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              ({ Start = (Ln: 2, Col: 16)
-                                 Stop = (Ln: 2, Col: 20) }, String "a",
-                               { Kind = Literal (Number (Int 5))
-                                 Span = { Start = (Ln: 2, Col: 19)
-                                          Stop = (Ln: 2, Col: 20) }
-                                 InferredType = None });
-                            Property
-                              ({ Start = (Ln: 2, Col: 22)
-                                 Stop = (Ln: 2, Col: 32) }, String "b",
-                               { Kind = Literal (String "hello")
-                                 Span = { Start = (Ln: 2, Col: 25)
-                                          Stop = (Ln: 2, Col: 32) }
-                                 InferredType = None });
-                            Property
-                              ({ Start = (Ln: 2, Col: 34)
-                                 Stop = (Ln: 2, Col: 41) }, String "c",
-                               { Kind = Literal (Boolean true)
-                                 Span = { Start = (Ln: 2, Col: 37)
-                                          Stop = (Ln: 2, Col: 41) }
-                                 InferredType = None })]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 15)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "obj"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                ({ Start = (Ln: 2, Col: 16)
+                                   Stop = (Ln: 2, Col: 20) }, String "a",
+                                 { Kind = Literal (Number (Int 5))
+                                   Span = { Start = (Ln: 2, Col: 19)
+                                            Stop = (Ln: 2, Col: 20) }
+                                   InferredType = None });
+                              Property
+                                ({ Start = (Ln: 2, Col: 22)
+                                   Stop = (Ln: 2, Col: 32) }, String "b",
+                                 { Kind = Literal (String "hello")
+                                   Span = { Start = (Ln: 2, Col: 25)
+                                            Stop = (Ln: 2, Col: 32) }
+                                   InferredType = None });
+                              Property
+                                ({ Start = (Ln: 2, Col: 34)
+                                   Stop = (Ln: 2, Col: 41) }, String "c",
+                                 { Kind = Literal (Boolean true)
+                                   Span = { Start = (Ln: 2, Col: 37)
+                                            Stop = (Ln: 2, Col: 41) }
+                                   InferredType = None })]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 15)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -52,32 +54,35 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind =
-                      Object
-                        { Elems =
-                           [ShorthandPat { Span = { Start = (Ln: 3, Col: 10)
-                                                    Stop = (Ln: 3, Col: 11) }
-                                           Name = "a"
-                                           IsMut = false
-                                           Default = None
-                                           Assertion = None };
-                            RestPat
-                              { Span = { Start = (Ln: 3, Col: 13)
-                                         Stop = (Ln: 3, Col: 20) }
-                                Target = { Kind = Ident { Name = "rest"
-                                                          IsMut = false
-                                                          Assertion = None }
-                                           Span = { Start = (Ln: 3, Col: 16)
-                                                    Stop = (Ln: 3, Col: 20) }
-                                           InferredType = None }
-                                IsMut = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 3, Col: 9)
-                              Stop = (Ln: 3, Col: 22) }
-                     InferredType = None }, { Kind = Identifier "obj"
-                                              Span = { Start = (Ln: 3, Col: 24)
-                                                       Stop = (Ln: 4, Col: 3) }
-                                              InferredType = None }, None)
+                  { Pattern =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [ShorthandPat { Span = { Start = (Ln: 3, Col: 10)
+                                                      Stop = (Ln: 3, Col: 11) }
+                                             Name = "a"
+                                             IsMut = false
+                                             Default = None
+                                             Assertion = None };
+                              RestPat
+                                { Span = { Start = (Ln: 3, Col: 13)
+                                           Stop = (Ln: 3, Col: 20) }
+                                  Target = { Kind = Ident { Name = "rest"
+                                                            IsMut = false
+                                                            Assertion = None }
+                                             Span = { Start = (Ln: 3, Col: 16)
+                                                      Stop = (Ln: 3, Col: 20) }
+                                             InferredType = None }
+                                  IsMut = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 3, Col: 9)
+                                Stop = (Ln: 3, Col: 22) }
+                       InferredType = None }
+                    TypeAnn = None
+                    Init = { Kind = Identifier "obj"
+                             Span = { Start = (Ln: 3, Col: 24)
+                                      Stop = (Ln: 4, Col: 3) }
+                             InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 3) } }
           Span = { Start = (Ln: 3, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalParams.verified.txt
@@ -8,52 +8,56 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "foo"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern = { Kind = Ident { Name = "a"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 2, Col: 18)
-                                                      Stop = (Ln: 2, Col: 19) }
-                                             InferredType = None }
-                                 TypeAnn =
-                                  Some { Kind = Keyword Number
-                                         Span = { Start = (Ln: 2, Col: 22)
-                                                  Stop = (Ln: 2, Col: 28) }
-                                         InferredType = None }
-                                 Optional = true };
-                               { Pattern = { Kind = Ident { Name = "b"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 2, Col: 30)
-                                                      Stop = (Ln: 2, Col: 31) }
-                                             InferredType = None }
-                                 TypeAnn =
-                                  Some { Kind = Keyword String
-                                         Span = { Start = (Ln: 2, Col: 34)
-                                                  Stop = (Ln: 2, Col: 40) }
-                                         InferredType = None }
-                                 Optional = true }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body = Expr { Kind = Identifier "a"
-                                        Span = { Start = (Ln: 2, Col: 45)
-                                                 Stop = (Ln: 3, Col: 5) }
-                                        InferredType = None } }
-                     Span = { Start = (Ln: 2, Col: 15)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "foo"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind = Ident { Name = "a"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 2, Col: 18)
+                                               Stop = (Ln: 2, Col: 19) }
+                                      InferredType = None }
+                                   TypeAnn =
+                                    Some { Kind = Keyword Number
+                                           Span = { Start = (Ln: 2, Col: 22)
+                                                    Stop = (Ln: 2, Col: 28) }
+                                           InferredType = None }
+                                   Optional = true };
+                                 { Pattern =
+                                    { Kind = Ident { Name = "b"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 2, Col: 30)
+                                               Stop = (Ln: 2, Col: 31) }
+                                      InferredType = None }
+                                   TypeAnn =
+                                    Some { Kind = Keyword String
+                                           Span = { Start = (Ln: 2, Col: 34)
+                                                    Stop = (Ln: 2, Col: 40) }
+                                           InferredType = None }
+                                   Optional = true }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body = Expr { Kind = Identifier "a"
+                                          Span = { Start = (Ln: 2, Col: 45)
+                                                   Stop = (Ln: 3, Col: 5) }
+                                          InferredType = None } }
+                       Span = { Start = (Ln: 2, Col: 15)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
@@ -8,53 +8,55 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Obj",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              { Name = String "a"
-                                TypeAnn =
-                                 { Kind =
-                                    Object
-                                      { Elems =
-                                         [Property
-                                            { Name = String "b"
-                                              TypeAnn =
-                                               { Kind =
-                                                  Object
-                                                    { Elems =
-                                                       [Property
-                                                          { Name = String "c"
-                                                            TypeAnn =
-                                                             { Kind =
-                                                                Keyword Number
-                                                               Span =
-                                                                { Start =
-                                                                   (Ln: 2, Col: 31)
-                                                                  Stop =
-                                                                   (Ln: 2, Col: 37) }
-                                                               InferredType =
-                                                                None }
-                                                            Optional = true
-                                                            Readonly = false }]
-                                                      Immutable = false }
-                                                 Span =
-                                                  { Start = (Ln: 2, Col: 26)
-                                                    Stop = (Ln: 2, Col: 38) }
-                                                 InferredType = None }
-                                              Optional = true
-                                              Readonly = false }]
-                                        Immutable = false }
-                                   Span = { Start = (Ln: 2, Col: 21)
-                                            Stop = (Ln: 2, Col: 39) }
-                                   InferredType = None }
-                                Optional = true
-                                Readonly = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 16)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Name = "Obj"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "a"
+                                  TypeAnn =
+                                   { Kind =
+                                      Object
+                                        { Elems =
+                                           [Property
+                                              { Name = String "b"
+                                                TypeAnn =
+                                                 { Kind =
+                                                    Object
+                                                      { Elems =
+                                                         [Property
+                                                            { Name = String "c"
+                                                              TypeAnn =
+                                                               { Kind =
+                                                                  Keyword Number
+                                                                 Span =
+                                                                  { Start =
+                                                                     (Ln: 2, Col: 31)
+                                                                    Stop =
+                                                                     (Ln: 2, Col: 37) }
+                                                                 InferredType =
+                                                                  None }
+                                                              Optional = true
+                                                              Readonly = false }]
+                                                        Immutable = false }
+                                                   Span =
+                                                    { Start = (Ln: 2, Col: 26)
+                                                      Stop = (Ln: 2, Col: 38) }
+                                                   InferredType = None }
+                                                Optional = true
+                                                Readonly = false }]
+                                          Immutable = false }
+                                     Span = { Start = (Ln: 2, Col: 21)
+                                              Stop = (Ln: 2, Col: 39) }
+                                     InferredType = None }
+                                  Optional = true
+                                  Readonly = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 16)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOtherLiterals.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOtherLiterals.verified.txt
@@ -7,17 +7,17 @@ output: Ok
      [Stmt
         { Kind =
            Decl
-             { Kind =
-                VarDecl
-                  ({ Kind = Ident { Name = "a"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 11) }
-                     InferredType = None }, { Kind = Literal Undefined
-                                              Span = { Start = (Ln: 2, Col: 13)
-                                                       Stop = (Ln: 2, Col: 22) }
-                                              InferredType = None }, None)
+             { Kind = VarDecl { Pattern = { Kind = Ident { Name = "a"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 2, Col: 9)
+                                                     Stop = (Ln: 2, Col: 11) }
+                                            InferredType = None }
+                                TypeAnn = None
+                                Init = { Kind = Literal Undefined
+                                         Span = { Start = (Ln: 2, Col: 13)
+                                                  Stop = (Ln: 2, Col: 22) }
+                                         InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -25,17 +25,17 @@ output: Ok
       Stmt
         { Kind =
            Decl
-             { Kind =
-                VarDecl
-                  ({ Kind = Ident { Name = "b"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 3, Col: 9)
-                              Stop = (Ln: 3, Col: 11) }
-                     InferredType = None }, { Kind = Literal Null
-                                              Span = { Start = (Ln: 3, Col: 13)
-                                                       Stop = (Ln: 3, Col: 17) }
-                                              InferredType = None }, None)
+             { Kind = VarDecl { Pattern = { Kind = Ident { Name = "b"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 3, Col: 9)
+                                                     Stop = (Ln: 3, Col: 11) }
+                                            InferredType = None }
+                                TypeAnn = None
+                                Init = { Kind = Literal Null
+                                         Span = { Start = (Ln: 3, Col: 13)
+                                                  Stop = (Ln: 3, Col: 17) }
+                                         InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePatternMatching.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePatternMatching.verified.txt
@@ -14,116 +14,124 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "foo"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern = { Kind = Ident { Name = "x"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 2, Col: 19)
-                                                      Stop = (Ln: 2, Col: 20) }
-                                             InferredType = None }
-                                 TypeAnn = None
-                                 Optional = false }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body =
-                           Expr
-                             { Kind =
-                                Match
-                                  ({ Kind = Identifier "x"
-                                     Span = { Start = (Ln: 3, Col: 13)
-                                              Stop = (Ln: 3, Col: 15) }
-                                     InferredType = None },
-                                   [{ Span = { Start = (Ln: 4, Col: 9)
-                                               Stop = (Ln: 5, Col: 9) }
-                                      Pattern =
-                                       { Kind = Literal (Number (Int 0))
-                                         Span = { Start = (Ln: 4, Col: 11)
-                                                  Stop = (Ln: 4, Col: 13) }
-                                         InferredType = None }
-                                      Guard = None
-                                      Body =
-                                       Expr { Kind = Literal (String "none")
-                                              Span = { Start = (Ln: 4, Col: 16)
-                                                       Stop = (Ln: 4, Col: 22) }
-                                              InferredType = None } };
-                                    { Span = { Start = (Ln: 5, Col: 9)
-                                               Stop = (Ln: 6, Col: 9) }
-                                      Pattern =
-                                       { Kind = Literal (Number (Int 1))
-                                         Span = { Start = (Ln: 5, Col: 11)
-                                                  Stop = (Ln: 5, Col: 13) }
-                                         InferredType = None }
-                                      Guard = None
-                                      Body =
-                                       Expr { Kind = Literal (String "one")
-                                              Span = { Start = (Ln: 5, Col: 16)
-                                                       Stop = (Ln: 5, Col: 21) }
-                                              InferredType = None } };
-                                    { Span = { Start = (Ln: 6, Col: 9)
-                                               Stop = (Ln: 7, Col: 9) }
-                                      Pattern =
-                                       { Kind = Ident { Name = "n"
-                                                        IsMut = false
-                                                        Assertion = None }
-                                         Span = { Start = (Ln: 6, Col: 11)
-                                                  Stop = (Ln: 6, Col: 13) }
-                                         InferredType = None }
-                                      Guard =
-                                       Some
-                                         { Kind =
-                                            Binary
-                                              ("<",
-                                               { Kind = Identifier "n"
-                                                 Span =
-                                                  { Start = (Ln: 6, Col: 16)
-                                                    Stop = (Ln: 6, Col: 18) }
-                                                 InferredType = None },
-                                               { Kind = Literal (Number (Int 0))
-                                                 Span =
-                                                  { Start = (Ln: 6, Col: 20)
-                                                    Stop = (Ln: 6, Col: 22) }
-                                                 InferredType = None })
-                                           Span = { Start = (Ln: 6, Col: 16)
-                                                    Stop = (Ln: 6, Col: 22) }
+                  { Pattern = { Kind = Ident { Name = "foo"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind = Ident { Name = "x"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 2, Col: 19)
+                                               Stop = (Ln: 2, Col: 20) }
+                                      InferredType = None }
+                                   TypeAnn = None
+                                   Optional = false }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body =
+                             Expr
+                               { Kind =
+                                  Match
+                                    ({ Kind = Identifier "x"
+                                       Span = { Start = (Ln: 3, Col: 13)
+                                                Stop = (Ln: 3, Col: 15) }
+                                       InferredType = None },
+                                     [{ Span = { Start = (Ln: 4, Col: 9)
+                                                 Stop = (Ln: 5, Col: 9) }
+                                        Pattern =
+                                         { Kind = Literal (Number (Int 0))
+                                           Span = { Start = (Ln: 4, Col: 11)
+                                                    Stop = (Ln: 4, Col: 13) }
                                            InferredType = None }
-                                      Body =
-                                       Expr { Kind = Literal (String "negative")
-                                              Span = { Start = (Ln: 6, Col: 25)
-                                                       Stop = (Ln: 6, Col: 35) }
-                                              InferredType = None } };
-                                    { Span = { Start = (Ln: 7, Col: 9)
-                                               Stop = (Ln: 8, Col: 7) }
-                                      Pattern =
-                                       { Kind = Ident { Name = "_"
-                                                        IsMut = false
-                                                        Assertion = None }
-                                         Span = { Start = (Ln: 7, Col: 11)
-                                                  Stop = (Ln: 7, Col: 13) }
-                                         InferredType = None }
-                                      Guard = None
-                                      Body =
-                                       Expr { Kind = Literal (String "other")
-                                              Span = { Start = (Ln: 7, Col: 16)
-                                                       Stop = (Ln: 7, Col: 23) }
-                                              InferredType = None } }])
-                               Span = { Start = (Ln: 3, Col: 7)
-                                        Stop = (Ln: 9, Col: 5) }
-                               InferredType = None } }
-                     Span = { Start = (Ln: 2, Col: 15)
-                              Stop = (Ln: 9, Col: 5) }
-                     InferredType = None }, None)
+                                        Guard = None
+                                        Body =
+                                         Expr
+                                           { Kind = Literal (String "none")
+                                             Span = { Start = (Ln: 4, Col: 16)
+                                                      Stop = (Ln: 4, Col: 22) }
+                                             InferredType = None } };
+                                      { Span = { Start = (Ln: 5, Col: 9)
+                                                 Stop = (Ln: 6, Col: 9) }
+                                        Pattern =
+                                         { Kind = Literal (Number (Int 1))
+                                           Span = { Start = (Ln: 5, Col: 11)
+                                                    Stop = (Ln: 5, Col: 13) }
+                                           InferredType = None }
+                                        Guard = None
+                                        Body =
+                                         Expr
+                                           { Kind = Literal (String "one")
+                                             Span = { Start = (Ln: 5, Col: 16)
+                                                      Stop = (Ln: 5, Col: 21) }
+                                             InferredType = None } };
+                                      { Span = { Start = (Ln: 6, Col: 9)
+                                                 Stop = (Ln: 7, Col: 9) }
+                                        Pattern =
+                                         { Kind = Ident { Name = "n"
+                                                          IsMut = false
+                                                          Assertion = None }
+                                           Span = { Start = (Ln: 6, Col: 11)
+                                                    Stop = (Ln: 6, Col: 13) }
+                                           InferredType = None }
+                                        Guard =
+                                         Some
+                                           { Kind =
+                                              Binary
+                                                ("<",
+                                                 { Kind = Identifier "n"
+                                                   Span =
+                                                    { Start = (Ln: 6, Col: 16)
+                                                      Stop = (Ln: 6, Col: 18) }
+                                                   InferredType = None },
+                                                 { Kind =
+                                                    Literal (Number (Int 0))
+                                                   Span =
+                                                    { Start = (Ln: 6, Col: 20)
+                                                      Stop = (Ln: 6, Col: 22) }
+                                                   InferredType = None })
+                                             Span = { Start = (Ln: 6, Col: 16)
+                                                      Stop = (Ln: 6, Col: 22) }
+                                             InferredType = None }
+                                        Body =
+                                         Expr
+                                           { Kind = Literal (String "negative")
+                                             Span = { Start = (Ln: 6, Col: 25)
+                                                      Stop = (Ln: 6, Col: 35) }
+                                             InferredType = None } };
+                                      { Span = { Start = (Ln: 7, Col: 9)
+                                                 Stop = (Ln: 8, Col: 7) }
+                                        Pattern =
+                                         { Kind = Ident { Name = "_"
+                                                          IsMut = false
+                                                          Assertion = None }
+                                           Span = { Start = (Ln: 7, Col: 11)
+                                                    Stop = (Ln: 7, Col: 13) }
+                                           InferredType = None }
+                                        Guard = None
+                                        Body =
+                                         Expr
+                                           { Kind = Literal (String "other")
+                                             Span = { Start = (Ln: 7, Col: 16)
+                                                      Stop = (Ln: 7, Col: 23) }
+                                             InferredType = None } }])
+                                 Span = { Start = (Ln: 3, Col: 7)
+                                          Stop = (Ln: 9, Col: 5) }
+                                 InferredType = None } }
+                       Span = { Start = (Ln: 2, Col: 15)
+                                Stop = (Ln: 9, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 9, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
@@ -12,74 +12,77 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("Array",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              { Name = Number (Int 5)
-                                TypeAnn = { Kind = Keyword String
-                                            Span = { Start = (Ln: 3, Col: 10)
-                                                     Stop = (Ln: 3, Col: 16) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false };
-                            Property
-                              { Name = String "hello"
-                                TypeAnn = { Kind = Keyword Number
-                                            Span = { Start = (Ln: 4, Col: 16)
-                                                     Stop = (Ln: 4, Col: 22) }
-                                            InferredType = None }
-                                Optional = false
-                                Readonly = false };
-                            Property
-                              { Name =
-                                 Computed
+                  { Name = "Array"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = Number (Int 5)
+                                  TypeAnn = { Kind = Keyword String
+                                              Span = { Start = (Ln: 3, Col: 10)
+                                                       Stop = (Ln: 3, Col: 16) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false };
+                              Property
+                                { Name = String "hello"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 4, Col: 16)
+                                                       Stop = (Ln: 4, Col: 22) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false };
+                              Property
+                                { Name =
+                                   Computed
+                                     { Kind =
+                                        Member
+                                          ({ Kind = Identifier "Symbol"
+                                             Span = { Start = (Ln: 5, Col: 8)
+                                                      Stop = (Ln: 5, Col: 14) }
+                                             InferredType = None }, "iterator",
+                                           false)
+                                       Span = { Start = (Ln: 5, Col: 8)
+                                                Stop = (Ln: 5, Col: 23) }
+                                       InferredType = None }
+                                  TypeAnn =
                                    { Kind =
-                                      Member
-                                        ({ Kind = Identifier "Symbol"
-                                           Span = { Start = (Ln: 5, Col: 8)
-                                                    Stop = (Ln: 5, Col: 14) }
-                                           InferredType = None }, "iterator",
-                                         false)
-                                     Span = { Start = (Ln: 5, Col: 8)
-                                              Stop = (Ln: 5, Col: 23) }
+                                      Function
+                                        { TypeParams = None
+                                          Self = None
+                                          ParamList = []
+                                          ReturnType =
+                                           { Kind =
+                                              TypeRef
+                                                { Ident = "Iterator"
+                                                  TypeArgs =
+                                                   Some
+                                                     [{ Kind =
+                                                         TypeRef
+                                                           { Ident = "T"
+                                                             TypeArgs = None }
+                                                        Span =
+                                                         { Start =
+                                                            (Ln: 5, Col: 44)
+                                                           Stop =
+                                                            (Ln: 5, Col: 45) }
+                                                        InferredType = None }] }
+                                             Span = { Start = (Ln: 5, Col: 35)
+                                                      Stop = (Ln: 5, Col: 46) }
+                                             InferredType = None }
+                                          Throws = None
+                                          IsAsync = false }
+                                     Span = { Start = (Ln: 5, Col: 26)
+                                              Stop = (Ln: 5, Col: 46) }
                                      InferredType = None }
-                                TypeAnn =
-                                 { Kind =
-                                    Function
-                                      { TypeParams = None
-                                        Self = None
-                                        ParamList = []
-                                        ReturnType =
-                                         { Kind =
-                                            TypeRef
-                                              { Ident = "Iterator"
-                                                TypeArgs =
-                                                 Some
-                                                   [{ Kind =
-                                                       TypeRef
-                                                         { Ident = "T"
-                                                           TypeArgs = None }
-                                                      Span =
-                                                       { Start =
-                                                          (Ln: 5, Col: 44)
-                                                         Stop = (Ln: 5, Col: 45) }
-                                                      InferredType = None }] }
-                                           Span = { Start = (Ln: 5, Col: 35)
-                                                    Stop = (Ln: 5, Col: 46) }
-                                           InferredType = None }
-                                        Throws = None
-                                        IsAsync = false }
-                                   Span = { Start = (Ln: 5, Col: 26)
-                                            Stop = (Ln: 5, Col: 46) }
-                                   InferredType = None }
-                                Optional = false
-                                Readonly = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 18)
-                              Stop = (Ln: 7, Col: 5) }
-                     InferredType = None }, None)
+                                  Optional = false
+                                  Readonly = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 18)
+                                Stop = (Ln: 7, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
@@ -9,18 +9,20 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("DieRoll",
-                   { Kind = Range { Min = { Kind = Literal (Number (Int 1))
-                                            Span = { Start = (Ln: 2, Col: 20)
-                                                     Stop = (Ln: 2, Col: 21) }
-                                            InferredType = None }
-                                    Max = { Kind = Literal (Number (Int 6))
-                                            Span = { Start = (Ln: 2, Col: 23)
-                                                     Stop = (Ln: 3, Col: 5) }
-                                            InferredType = None } }
-                     Span = { Start = (Ln: 2, Col: 20)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Name = "DieRoll"
+                    TypeAnn =
+                     { Kind = Range { Min = { Kind = Literal (Number (Int 1))
+                                              Span = { Start = (Ln: 2, Col: 20)
+                                                       Stop = (Ln: 2, Col: 21) }
+                                              InferredType = None }
+                                      Max = { Kind = Literal (Number (Int 6))
+                                              Span = { Start = (Ln: 2, Col: 23)
+                                                       Stop = (Ln: 3, Col: 5) }
+                                              InferredType = None } }
+                       Span = { Start = (Ln: 2, Col: 20)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -30,23 +32,25 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "range"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 3, Col: 9)
-                              Stop = (Ln: 3, Col: 15) }
-                     InferredType = None },
-                   { Kind = Range { Min = { Kind = Literal (Number (Int 0))
-                                            Span = { Start = (Ln: 3, Col: 17)
-                                                     Stop = (Ln: 3, Col: 18) }
-                                            InferredType = None }
-                                    Max = { Kind = Literal (Number (Int 10))
-                                            Span = { Start = (Ln: 3, Col: 20)
-                                                     Stop = (Ln: 4, Col: 5) }
-                                            InferredType = None } }
-                     Span = { Start = (Ln: 3, Col: 17)
-                              Stop = (Ln: 4, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "range"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 3, Col: 9)
+                                         Stop = (Ln: 3, Col: 15) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind = Range { Min = { Kind = Literal (Number (Int 0))
+                                              Span = { Start = (Ln: 3, Col: 17)
+                                                       Stop = (Ln: 3, Col: 18) }
+                                              InferredType = None }
+                                      Max = { Kind = Literal (Number (Int 10))
+                                              Span = { Start = (Ln: 3, Col: 20)
+                                                       Stop = (Ln: 4, Col: 5) }
+                                              InferredType = None } }
+                       Span = { Start = (Ln: 3, Col: 17)
+                                Stop = (Ln: 4, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
@@ -10,107 +10,110 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("RangeIterator",
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              { Name = String "next"
-                                TypeAnn =
-                                 { Kind =
-                                    Function
-                                      { TypeParams = None
-                                        Self = None
-                                        ParamList = []
-                                        ReturnType =
-                                         { Kind =
-                                            Object
-                                              { Elems =
-                                                 [Property
-                                                    { Name = String "done"
-                                                      TypeAnn =
-                                                       { Kind = Keyword Boolean
-                                                         Span =
-                                                          { Start =
-                                                             (Ln: 3, Col: 32)
-                                                            Stop =
-                                                             (Ln: 3, Col: 39) }
-                                                         InferredType = None }
-                                                      Optional = false
-                                                      Readonly = false };
-                                                  Property
-                                                    { Name = String "value"
-                                                      TypeAnn =
-                                                       { Kind =
-                                                          Range
-                                                            { Min =
-                                                               { Kind =
-                                                                  TypeRef
-                                                                    { Ident =
-                                                                       "Min"
-                                                                      TypeArgs =
-                                                                       None }
-                                                                 Span =
-                                                                  { Start =
-                                                                     (Ln: 3, Col: 48)
-                                                                    Stop =
-                                                                     (Ln: 3, Col: 51) }
-                                                                 InferredType =
-                                                                  None }
-                                                              Max =
-                                                               { Kind =
-                                                                  TypeRef
-                                                                    { Ident =
-                                                                       "Max"
-                                                                      TypeArgs =
-                                                                       None }
-                                                                 Span =
-                                                                  { Start =
-                                                                     (Ln: 3, Col: 53)
-                                                                    Stop =
-                                                                     (Ln: 3, Col: 57) }
-                                                                 InferredType =
-                                                                  None } }
-                                                         Span =
-                                                          { Start =
-                                                             (Ln: 3, Col: 48)
-                                                            Stop =
-                                                             (Ln: 3, Col: 57) }
-                                                         InferredType = None }
-                                                      Optional = false
-                                                      Readonly = false }]
-                                                Immutable = false }
-                                           Span = { Start = (Ln: 3, Col: 24)
-                                                    Stop = (Ln: 4, Col: 7) }
-                                           InferredType = None }
-                                        Throws = None
-                                        IsAsync = false }
-                                   Span = { Start = (Ln: 3, Col: 15)
-                                            Stop = (Ln: 4, Col: 7) }
-                                   InferredType = None }
-                                Optional = false
-                                Readonly = false }]
-                          Immutable = false }
-                     Span = { Start = (Ln: 2, Col: 54)
-                              Stop = (Ln: 5, Col: 5) }
-                     InferredType = None },
-                   Some
-                     [{ Span = { Start = (Ln: 2, Col: 26)
-                                 Stop = (Ln: 2, Col: 37) }
-                        Name = "Min"
-                        Constraint = Some { Kind = Keyword Number
-                                            Span = { Start = (Ln: 2, Col: 31)
-                                                     Stop = (Ln: 2, Col: 37) }
-                                            InferredType = None }
-                        Default = None };
-                      { Span = { Start = (Ln: 2, Col: 39)
-                                 Stop = (Ln: 2, Col: 50) }
-                        Name = "Max"
-                        Constraint = Some { Kind = Keyword Number
-                                            Span = { Start = (Ln: 2, Col: 44)
-                                                     Stop = (Ln: 2, Col: 50) }
-                                            InferredType = None }
-                        Default = None }])
+                  { Name = "RangeIterator"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "next"
+                                  TypeAnn =
+                                   { Kind =
+                                      Function
+                                        { TypeParams = None
+                                          Self = None
+                                          ParamList = []
+                                          ReturnType =
+                                           { Kind =
+                                              Object
+                                                { Elems =
+                                                   [Property
+                                                      { Name = String "done"
+                                                        TypeAnn =
+                                                         { Kind =
+                                                            Keyword Boolean
+                                                           Span =
+                                                            { Start =
+                                                               (Ln: 3, Col: 32)
+                                                              Stop =
+                                                               (Ln: 3, Col: 39) }
+                                                           InferredType = None }
+                                                        Optional = false
+                                                        Readonly = false };
+                                                    Property
+                                                      { Name = String "value"
+                                                        TypeAnn =
+                                                         { Kind =
+                                                            Range
+                                                              { Min =
+                                                                 { Kind =
+                                                                    TypeRef
+                                                                      { Ident =
+                                                                         "Min"
+                                                                        TypeArgs =
+                                                                         None }
+                                                                   Span =
+                                                                    { Start =
+                                                                       (Ln: 3, Col: 48)
+                                                                      Stop =
+                                                                       (Ln: 3, Col: 51) }
+                                                                   InferredType =
+                                                                    None }
+                                                                Max =
+                                                                 { Kind =
+                                                                    TypeRef
+                                                                      { Ident =
+                                                                         "Max"
+                                                                        TypeArgs =
+                                                                         None }
+                                                                   Span =
+                                                                    { Start =
+                                                                       (Ln: 3, Col: 53)
+                                                                      Stop =
+                                                                       (Ln: 3, Col: 57) }
+                                                                   InferredType =
+                                                                    None } }
+                                                           Span =
+                                                            { Start =
+                                                               (Ln: 3, Col: 48)
+                                                              Stop =
+                                                               (Ln: 3, Col: 57) }
+                                                           InferredType = None }
+                                                        Optional = false
+                                                        Readonly = false }]
+                                                  Immutable = false }
+                                             Span = { Start = (Ln: 3, Col: 24)
+                                                      Stop = (Ln: 4, Col: 7) }
+                                             InferredType = None }
+                                          Throws = None
+                                          IsAsync = false }
+                                     Span = { Start = (Ln: 3, Col: 15)
+                                              Stop = (Ln: 4, Col: 7) }
+                                     InferredType = None }
+                                  Optional = false
+                                  Readonly = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 54)
+                                Stop = (Ln: 5, Col: 5) }
+                       InferredType = None }
+                    TypeParams =
+                     Some
+                       [{ Span = { Start = (Ln: 2, Col: 26)
+                                   Stop = (Ln: 2, Col: 37) }
+                          Name = "Min"
+                          Constraint = Some { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 31)
+                                                       Stop = (Ln: 2, Col: 37) }
+                                              InferredType = None }
+                          Default = None };
+                        { Span = { Start = (Ln: 2, Col: 39)
+                                   Stop = (Ln: 2, Col: 50) }
+                          Name = "Max"
+                          Constraint = Some { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 44)
+                                                       Stop = (Ln: 2, Col: 50) }
+                                              InferredType = None }
+                          Default = None }] }
                Span = { Start = (Ln: 2, Col: 7)
                         Stop = (Ln: 5, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 7)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecordTuple.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecordTuple.verified.txt
@@ -10,27 +10,29 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "p0"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 12) }
-                     InferredType = None },
-                   { Kind =
-                      Tuple
-                        { Elems =
-                           [{ Kind = Literal (Number (Int 5))
-                              Span = { Start = (Ln: 2, Col: 16)
-                                       Stop = (Ln: 2, Col: 17) }
-                              InferredType = None };
-                            { Kind = Literal (Number (Int 10))
-                              Span = { Start = (Ln: 2, Col: 19)
-                                       Stop = (Ln: 2, Col: 21) }
-                              InferredType = None }]
-                          Immutable = true }
-                     Span = { Start = (Ln: 2, Col: 14)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "p0"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 12) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Tuple
+                          { Elems =
+                             [{ Kind = Literal (Number (Int 5))
+                                Span = { Start = (Ln: 2, Col: 16)
+                                         Stop = (Ln: 2, Col: 17) }
+                                InferredType = None };
+                              { Kind = Literal (Number (Int 10))
+                                Span = { Start = (Ln: 2, Col: 19)
+                                         Stop = (Ln: 2, Col: 21) }
+                                InferredType = None }]
+                            Immutable = true }
+                       Span = { Start = (Ln: 2, Col: 14)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -40,33 +42,35 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "p1"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 3, Col: 9)
-                              Stop = (Ln: 3, Col: 12) }
-                     InferredType = None },
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Property
-                              ({ Start = (Ln: 3, Col: 16)
-                                 Stop = (Ln: 3, Col: 20) }, String "x",
-                               { Kind = Literal (Number (Int 5))
-                                 Span = { Start = (Ln: 3, Col: 19)
-                                          Stop = (Ln: 3, Col: 20) }
-                                 InferredType = None });
-                            Property
-                              ({ Start = (Ln: 3, Col: 22)
-                                 Stop = (Ln: 3, Col: 27) }, String "y",
-                               { Kind = Literal (Number (Int 10))
-                                 Span = { Start = (Ln: 3, Col: 25)
-                                          Stop = (Ln: 3, Col: 27) }
-                                 InferredType = None })]
-                          Immutable = true }
-                     Span = { Start = (Ln: 3, Col: 14)
-                              Stop = (Ln: 4, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "p1"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 3, Col: 9)
+                                         Stop = (Ln: 3, Col: 12) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                ({ Start = (Ln: 3, Col: 16)
+                                   Stop = (Ln: 3, Col: 20) }, String "x",
+                                 { Kind = Literal (Number (Int 5))
+                                   Span = { Start = (Ln: 3, Col: 19)
+                                            Stop = (Ln: 3, Col: 20) }
+                                   InferredType = None });
+                              Property
+                                ({ Start = (Ln: 3, Col: 22)
+                                   Stop = (Ln: 3, Col: 27) }, String "y",
+                                 { Kind = Literal (Number (Int 10))
+                                   Span = { Start = (Ln: 3, Col: 25)
+                                            Stop = (Ln: 3, Col: 27) }
+                                   InferredType = None })]
+                            Immutable = true }
+                       Span = { Start = (Ln: 3, Col: 14)
+                                Stop = (Ln: 4, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)
@@ -76,23 +80,25 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "line"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 4, Col: 9)
-                              Stop = (Ln: 4, Col: 14) }
-                     InferredType = None },
-                   { Kind =
-                      Object
-                        { Elems =
-                           [Shorthand ({ Start = (Ln: 4, Col: 18)
-                                         Stop = (Ln: 4, Col: 20) }, "p0");
-                            Shorthand ({ Start = (Ln: 4, Col: 22)
-                                         Stop = (Ln: 4, Col: 24) }, "p1")]
-                          Immutable = true }
-                     Span = { Start = (Ln: 4, Col: 16)
-                              Stop = (Ln: 5, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "line"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 4, Col: 9)
+                                         Stop = (Ln: 4, Col: 14) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Shorthand ({ Start = (Ln: 4, Col: 18)
+                                           Stop = (Ln: 4, Col: 20) }, "p0");
+                              Shorthand ({ Start = (Ln: 4, Col: 22)
+                                           Stop = (Ln: 4, Col: 24) }, "p1")]
+                            Immutable = true }
+                       Span = { Start = (Ln: 4, Col: 16)
+                                Stop = (Ln: 5, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 4, Col: 5)
                         Stop = (Ln: 5, Col: 5) } }
           Span = { Start = (Ln: 4, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
@@ -5,18 +5,18 @@ output: Ok
         { Kind =
            Decl
              { Kind =
-                VarDecl
-                  ({ Kind = Ident { Name = "msg"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 1, Col: 5)
-                              Stop = (Ln: 1, Col: 9) }
-                     InferredType = None },
-                   { Kind = Literal (String "Hello,
+                VarDecl { Pattern = { Kind = Ident { Name = "msg"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 1, Col: 5)
+                                               Stop = (Ln: 1, Col: 9) }
+                                      InferredType = None }
+                          TypeAnn = None
+                          Init = { Kind = Literal (String "Hello,
 	"world!"")
-                     Span = { Start = (Ln: 1, Col: 11)
-                              Stop = (Ln: 1, Col: 33) }
-                     InferredType = None }, None)
+                                   Span = { Start = (Ln: 1, Col: 11)
+                                            Stop = (Ln: 1, Col: 33) }
+                                   InferredType = None } }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 34) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
@@ -9,34 +9,36 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "foo"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Struct
-                        { TypeRef = { Ident = "Foo"
-                                      TypeArgs = None }
-                          Elems =
-                           [Property
-                              ({ Start = (Ln: 2, Col: 21)
-                                 Stop = (Ln: 2, Col: 25) }, String "a",
-                               { Kind = Literal (Number (Int 5))
-                                 Span = { Start = (Ln: 2, Col: 24)
-                                          Stop = (Ln: 2, Col: 25) }
-                                 InferredType = None });
-                            Property
-                              ({ Start = (Ln: 2, Col: 27)
-                                 Stop = (Ln: 2, Col: 38) }, String "b",
-                               { Kind = Literal (String "hello")
-                                 Span = { Start = (Ln: 2, Col: 30)
-                                          Stop = (Ln: 2, Col: 37) }
-                                 InferredType = None })] }
-                     Span = { Start = (Ln: 2, Col: 15)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "foo"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Struct
+                          { TypeRef = { Ident = "Foo"
+                                        TypeArgs = None }
+                            Elems =
+                             [Property
+                                ({ Start = (Ln: 2, Col: 21)
+                                   Stop = (Ln: 2, Col: 25) }, String "a",
+                                 { Kind = Literal (Number (Int 5))
+                                   Span = { Start = (Ln: 2, Col: 24)
+                                            Stop = (Ln: 2, Col: 25) }
+                                   InferredType = None });
+                              Property
+                                ({ Start = (Ln: 2, Col: 27)
+                                   Stop = (Ln: 2, Col: 38) }, String "b",
+                                 { Kind = Literal (String "hello")
+                                   Span = { Start = (Ln: 2, Col: 30)
+                                            Stop = (Ln: 2, Col: 37) }
+                                   InferredType = None })] }
+                       Span = { Start = (Ln: 2, Col: 15)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -46,39 +48,41 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "bar"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 3, Col: 9)
-                              Stop = (Ln: 3, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Struct
-                        { TypeRef =
-                           { Ident = "Bar"
-                             TypeArgs =
-                              Some [{ Kind = Keyword Number
-                                      Span = { Start = (Ln: 3, Col: 19)
-                                               Stop = (Ln: 3, Col: 25) }
-                                      InferredType = None }] }
-                          Elems =
-                           [Property
-                              ({ Start = (Ln: 3, Col: 29)
-                                 Stop = (Ln: 3, Col: 33) }, String "a",
-                               { Kind = Literal (Number (Int 5))
-                                 Span = { Start = (Ln: 3, Col: 32)
-                                          Stop = (Ln: 3, Col: 33) }
-                                 InferredType = None });
-                            Property
-                              ({ Start = (Ln: 3, Col: 35)
-                                 Stop = (Ln: 3, Col: 46) }, String "b",
-                               { Kind = Literal (String "hello")
-                                 Span = { Start = (Ln: 3, Col: 38)
-                                          Stop = (Ln: 3, Col: 45) }
-                                 InferredType = None })] }
-                     Span = { Start = (Ln: 3, Col: 15)
-                              Stop = (Ln: 4, Col: 5) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "bar"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 3, Col: 9)
+                                         Stop = (Ln: 3, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Struct
+                          { TypeRef =
+                             { Ident = "Bar"
+                               TypeArgs =
+                                Some [{ Kind = Keyword Number
+                                        Span = { Start = (Ln: 3, Col: 19)
+                                                 Stop = (Ln: 3, Col: 25) }
+                                        InferredType = None }] }
+                            Elems =
+                             [Property
+                                ({ Start = (Ln: 3, Col: 29)
+                                   Stop = (Ln: 3, Col: 33) }, String "a",
+                                 { Kind = Literal (Number (Int 5))
+                                   Span = { Start = (Ln: 3, Col: 32)
+                                            Stop = (Ln: 3, Col: 33) }
+                                   InferredType = None });
+                              Property
+                                ({ Start = (Ln: 3, Col: 35)
+                                   Stop = (Ln: 3, Col: 46) }, String "b",
+                                 { Kind = Literal (String "hello")
+                                   Span = { Start = (Ln: 3, Col: 38)
+                                            Stop = (Ln: 3, Col: 45) }
+                                   InferredType = None })] }
+                       Span = { Start = (Ln: 3, Col: 15)
+                                Stop = (Ln: 4, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
@@ -8,17 +8,19 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  ("TemplateLiteral",
-                   { Kind =
-                      TemplateLiteral
-                        { Parts = ["foo"; ""]
-                          Exprs = [{ Kind = Keyword Number
-                                     Span = { Start = (Ln: 2, Col: 36)
-                                              Stop = (Ln: 2, Col: 42) }
-                                     InferredType = None }] }
-                     Span = { Start = (Ln: 2, Col: 30)
-                              Stop = (Ln: 2, Col: 44) }
-                     InferredType = None }, None)
+                  { Name = "TemplateLiteral"
+                    TypeAnn =
+                     { Kind =
+                        TemplateLiteral
+                          { Parts = ["foo"; ""]
+                            Exprs = [{ Kind = Keyword Number
+                                       Span = { Start = (Ln: 2, Col: 36)
+                                                Stop = (Ln: 2, Col: 42) }
+                                       InferredType = None }] }
+                       Span = { Start = (Ln: 2, Col: 30)
+                                Stop = (Ln: 2, Col: 44) }
+                       InferredType = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 7)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 7)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
@@ -6,29 +6,32 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "msg"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 1, Col: 5)
-                              Stop = (Ln: 1, Col: 9) }
-                     InferredType = None },
-                   { Kind =
-                      TemplateLiteral
-                        { Parts = ["foo "; ""]
-                          Exprs =
-                           [{ Kind =
-                               TemplateLiteral
-                                 { Parts = ["bar "; ""]
-                                   Exprs = [{ Kind = Identifier "baz"
-                                              Span = { Start = (Ln: 1, Col: 25)
-                                                       Stop = (Ln: 1, Col: 28) }
-                                              InferredType = None }] }
-                              Span = { Start = (Ln: 1, Col: 18)
-                                       Stop = (Ln: 1, Col: 30) }
-                              InferredType = None }] }
-                     Span = { Start = (Ln: 1, Col: 11)
-                              Stop = (Ln: 1, Col: 32) }
-                     InferredType = None }, None)
+                  { Pattern = { Kind = Ident { Name = "msg"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 1, Col: 5)
+                                         Stop = (Ln: 1, Col: 9) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        TemplateLiteral
+                          { Parts = ["foo "; ""]
+                            Exprs =
+                             [{ Kind =
+                                 TemplateLiteral
+                                   { Parts = ["bar "; ""]
+                                     Exprs =
+                                      [{ Kind = Identifier "baz"
+                                         Span = { Start = (Ln: 1, Col: 25)
+                                                  Stop = (Ln: 1, Col: 28) }
+                                         InferredType = None }] }
+                                Span = { Start = (Ln: 1, Col: 18)
+                                         Stop = (Ln: 1, Col: 30) }
+                                InferredType = None }] }
+                       Span = { Start = (Ln: 1, Col: 11)
+                                Stop = (Ln: 1, Col: 32) }
+                       InferredType = None } }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 32) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseThrowAndTryCatch.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseThrowAndTryCatch.verified.txt
@@ -21,97 +21,107 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "foo"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern = { Kind = Ident { Name = "x"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 2, Col: 19)
-                                                      Stop = (Ln: 2, Col: 20) }
-                                             InferredType = None }
-                                 TypeAnn = None
-                                 Optional = false }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body =
-                           Block
-                             { Span = { Start = (Ln: 2, Col: 22)
-                                        Stop = (Ln: 8, Col: 5) }
-                               Stmts =
-                                [{ Kind =
-                                    Expr
-                                      { Kind =
-                                         IfElse
-                                           ({ Kind =
-                                               Binary
-                                                 ("<",
-                                                  { Kind = Identifier "x"
+                  { Pattern = { Kind = Ident { Name = "foo"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind = Ident { Name = "x"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 2, Col: 19)
+                                               Stop = (Ln: 2, Col: 20) }
+                                      InferredType = None }
+                                   TypeAnn = None
+                                   Optional = false }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body =
+                             Block
+                               { Span = { Start = (Ln: 2, Col: 22)
+                                          Stop = (Ln: 8, Col: 5) }
+                                 Stmts =
+                                  [{ Kind =
+                                      Expr
+                                        { Kind =
+                                           IfElse
+                                             ({ Kind =
+                                                 Binary
+                                                   ("<",
+                                                    { Kind = Identifier "x"
+                                                      Span =
+                                                       { Start =
+                                                          (Ln: 3, Col: 10)
+                                                         Stop = (Ln: 3, Col: 12) }
+                                                      InferredType = None },
+                                                    { Kind =
+                                                       Literal (Number (Int 0))
+                                                      Span =
+                                                       { Start =
+                                                          (Ln: 3, Col: 14)
+                                                         Stop = (Ln: 3, Col: 16) }
+                                                      InferredType = None })
+                                                Span =
+                                                 { Start = (Ln: 3, Col: 10)
+                                                   Stop = (Ln: 3, Col: 16) }
+                                                InferredType = None },
+                                              { Span =
+                                                 { Start = (Ln: 3, Col: 16)
+                                                   Stop = (Ln: 6, Col: 7) }
+                                                Stmts =
+                                                 [{ Kind =
+                                                     Expr
+                                                       { Kind =
+                                                          Throw
+                                                            { Kind =
+                                                               Literal
+                                                                 (String
+                                                                    "x must be positive")
+                                                              Span =
+                                                               { Start =
+                                                                  (Ln: 4, Col: 15)
+                                                                 Stop =
+                                                                  (Ln: 4, Col: 35) }
+                                                              InferredType =
+                                                               None }
+                                                         Span =
+                                                          { Start =
+                                                             (Ln: 4, Col: 9)
+                                                            Stop =
+                                                             (Ln: 5, Col: 7) }
+                                                         InferredType = None }
                                                     Span =
-                                                     { Start = (Ln: 3, Col: 10)
-                                                       Stop = (Ln: 3, Col: 12) }
-                                                    InferredType = None },
-                                                  { Kind =
-                                                     Literal (Number (Int 0))
-                                                    Span =
-                                                     { Start = (Ln: 3, Col: 14)
-                                                       Stop = (Ln: 3, Col: 16) }
-                                                    InferredType = None })
-                                              Span = { Start = (Ln: 3, Col: 10)
-                                                       Stop = (Ln: 3, Col: 16) }
-                                              InferredType = None },
-                                            { Span = { Start = (Ln: 3, Col: 16)
-                                                       Stop = (Ln: 6, Col: 7) }
-                                              Stmts =
-                                               [{ Kind =
-                                                   Expr
-                                                     { Kind =
-                                                        Throw
-                                                          { Kind =
-                                                             Literal
-                                                               (String
-                                                                  "x must be positive")
-                                                            Span =
-                                                             { Start =
-                                                                (Ln: 4, Col: 15)
-                                                               Stop =
-                                                                (Ln: 4, Col: 35) }
-                                                            InferredType = None }
-                                                       Span =
-                                                        { Start =
-                                                           (Ln: 4, Col: 9)
-                                                          Stop = (Ln: 5, Col: 7) }
-                                                       InferredType = None }
-                                                  Span =
-                                                   { Start = (Ln: 4, Col: 9)
-                                                     Stop = (Ln: 5, Col: 7) } }] },
-                                            None)
-                                        Span = { Start = (Ln: 3, Col: 7)
-                                                 Stop = (Ln: 6, Col: 7) }
-                                        InferredType = None }
-                                   Span = { Start = (Ln: 3, Col: 7)
-                                            Stop = (Ln: 6, Col: 7) } };
-                                 { Kind =
-                                    Return
-                                      (Some { Kind = Identifier "x"
-                                              Span = { Start = (Ln: 6, Col: 14)
-                                                       Stop = (Ln: 7, Col: 5) }
-                                              InferredType = None })
-                                   Span = { Start = (Ln: 6, Col: 7)
-                                            Stop = (Ln: 7, Col: 5) } }] } }
-                     Span = { Start = (Ln: 2, Col: 15)
-                              Stop = (Ln: 8, Col: 5) }
-                     InferredType = None }, None)
+                                                     { Start = (Ln: 4, Col: 9)
+                                                       Stop = (Ln: 5, Col: 7) } }] },
+                                              None)
+                                          Span = { Start = (Ln: 3, Col: 7)
+                                                   Stop = (Ln: 6, Col: 7) }
+                                          InferredType = None }
+                                     Span = { Start = (Ln: 3, Col: 7)
+                                              Stop = (Ln: 6, Col: 7) } };
+                                   { Kind =
+                                      Return
+                                        (Some
+                                           { Kind = Identifier "x"
+                                             Span = { Start = (Ln: 6, Col: 14)
+                                                      Stop = (Ln: 7, Col: 5) }
+                                             InferredType = None })
+                                     Span = { Start = (Ln: 6, Col: 7)
+                                              Stop = (Ln: 7, Col: 5) } }] } }
+                       Span = { Start = (Ln: 2, Col: 15)
+                                Stop = (Ln: 8, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 8, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -121,149 +131,163 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "bar"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 8, Col: 9)
-                              Stop = (Ln: 8, Col: 13) }
-                     InferredType = None },
-                   { Kind =
-                      Function
-                        { Sig =
-                           { TypeParams = None
-                             Self = None
-                             ParamList =
-                              [{ Pattern = { Kind = Ident { Name = "x"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 8, Col: 19)
-                                                      Stop = (Ln: 8, Col: 20) }
-                                             InferredType = None }
-                                 TypeAnn = None
-                                 Optional = false }]
-                             ReturnType = None
-                             Throws = None
-                             IsAsync = false }
-                          Body =
-                           Block
-                             { Span = { Start = (Ln: 8, Col: 22)
-                                        Stop = (Ln: 16, Col: 5) }
-                               Stmts =
-                                [{ Kind =
-                                    Decl
-                                      { Kind =
-                                         VarDecl
-                                           ({ Kind = Ident { Name = "result"
-                                                             IsMut = false
-                                                             Assertion = None }
-                                              Span = { Start = (Ln: 9, Col: 11)
-                                                       Stop = (Ln: 9, Col: 18) }
-                                              InferredType = None },
-                                            { Kind =
-                                               Try
-                                                 { Body =
-                                                    { Span =
-                                                       { Start =
-                                                          (Ln: 9, Col: 24)
-                                                         Stop = (Ln: 11, Col: 9) }
-                                                      Stmts =
-                                                       [{ Kind =
-                                                           Expr
-                                                             { Kind =
-                                                                Call
-                                                                  { Callee =
-                                                                     { Kind =
-                                                                        Identifier
-                                                                          "foo"
-                                                                       Span =
-                                                                        { Start =
-                                                                           (Ln: 10, Col: 9)
-                                                                          Stop =
-                                                                           (Ln: 10, Col: 12) }
-                                                                       InferredType =
-                                                                        None }
-                                                                    TypeArgs =
-                                                                     None
-                                                                    Args =
-                                                                     [{ Kind =
-                                                                         Identifier
-                                                                           "x"
-                                                                        Span =
-                                                                         { Start =
-                                                                            (Ln: 10, Col: 13)
-                                                                           Stop =
-                                                                            (Ln: 10, Col: 14) }
-                                                                        InferredType =
-                                                                         None }]
-                                                                    OptChain =
-                                                                     false
-                                                                    Throws =
-                                                                     None }
-                                                               Span =
-                                                                { Start =
-                                                                   (Ln: 10, Col: 9)
-                                                                  Stop =
-                                                                   (Ln: 11, Col: 7) }
-                                                               InferredType =
-                                                                None }
-                                                          Span =
+                  { Pattern = { Kind = Ident { Name = "bar"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 8, Col: 9)
+                                         Stop = (Ln: 8, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     { Kind =
+                        Function
+                          { Sig =
+                             { TypeParams = None
+                               Self = None
+                               ParamList =
+                                [{ Pattern =
+                                    { Kind = Ident { Name = "x"
+                                                     IsMut = false
+                                                     Assertion = None }
+                                      Span = { Start = (Ln: 8, Col: 19)
+                                               Stop = (Ln: 8, Col: 20) }
+                                      InferredType = None }
+                                   TypeAnn = None
+                                   Optional = false }]
+                               ReturnType = None
+                               Throws = None
+                               IsAsync = false }
+                            Body =
+                             Block
+                               { Span = { Start = (Ln: 8, Col: 22)
+                                          Stop = (Ln: 16, Col: 5) }
+                                 Stmts =
+                                  [{ Kind =
+                                      Decl
+                                        { Kind =
+                                           VarDecl
+                                             { Pattern =
+                                                { Kind =
+                                                   Ident { Name = "result"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                                  Span =
+                                                   { Start = (Ln: 9, Col: 11)
+                                                     Stop = (Ln: 9, Col: 18) }
+                                                  InferredType = None }
+                                               TypeAnn = None
+                                               Init =
+                                                { Kind =
+                                                   Try
+                                                     { Body =
+                                                        { Span =
                                                            { Start =
-                                                              (Ln: 10, Col: 9)
+                                                              (Ln: 9, Col: 24)
                                                              Stop =
-                                                              (Ln: 11, Col: 7) } }] }
-                                                   Catch =
-                                                    Some
-                                                      [{ Span =
-                                                          { Start =
-                                                             (Ln: 12, Col: 9)
-                                                            Stop =
-                                                             (Ln: 13, Col: 7) }
-                                                         Pattern =
-                                                          { Kind =
-                                                             Ident
-                                                               { Name = "_"
-                                                                 IsMut = false
-                                                                 Assertion =
-                                                                  None }
-                                                            Span =
-                                                             { Start =
-                                                                (Ln: 12, Col: 11)
-                                                               Stop =
-                                                                (Ln: 12, Col: 13) }
-                                                            InferredType = None }
-                                                         Guard = None
-                                                         Body =
-                                                          Expr
-                                                            { Kind =
-                                                               Literal
-                                                                 (Number (Int 0))
+                                                              (Ln: 11, Col: 9) }
+                                                          Stmts =
+                                                           [{ Kind =
+                                                               Expr
+                                                                 { Kind =
+                                                                    Call
+                                                                      { Callee =
+                                                                         { Kind =
+                                                                            Identifier
+                                                                              "foo"
+                                                                           Span =
+                                                                            { Start =
+                                                                               (Ln: 10, Col: 9)
+                                                                              Stop =
+                                                                               (Ln: 10, Col: 12) }
+                                                                           InferredType =
+                                                                            None }
+                                                                        TypeArgs =
+                                                                         None
+                                                                        Args =
+                                                                         [{ Kind =
+                                                                             Identifier
+                                                                               "x"
+                                                                            Span =
+                                                                             { Start =
+                                                                                (Ln: 10, Col: 13)
+                                                                               Stop =
+                                                                                (Ln: 10, Col: 14) }
+                                                                            InferredType =
+                                                                             None }]
+                                                                        OptChain =
+                                                                         false
+                                                                        Throws =
+                                                                         None }
+                                                                   Span =
+                                                                    { Start =
+                                                                       (Ln: 10, Col: 9)
+                                                                      Stop =
+                                                                       (Ln: 11, Col: 7) }
+                                                                   InferredType =
+                                                                    None }
                                                               Span =
                                                                { Start =
-                                                                  (Ln: 12, Col: 16)
+                                                                  (Ln: 10, Col: 9)
                                                                  Stop =
-                                                                  (Ln: 13, Col: 7) }
-                                                              InferredType =
-                                                               None } }]
-                                                   Finally = None
-                                                   Throws = None }
-                                              Span = { Start = (Ln: 9, Col: 20)
-                                                       Stop = (Ln: 14, Col: 7) }
-                                              InferredType = None }, None)
-                                        Span = { Start = (Ln: 9, Col: 7)
-                                                 Stop = (Ln: 14, Col: 7) } }
-                                   Span = { Start = (Ln: 9, Col: 7)
-                                            Stop = (Ln: 14, Col: 7) } };
-                                 { Kind =
-                                    Return
-                                      (Some { Kind = Identifier "result"
-                                              Span = { Start = (Ln: 14, Col: 14)
-                                                       Stop = (Ln: 15, Col: 5) }
-                                              InferredType = None })
-                                   Span = { Start = (Ln: 14, Col: 7)
-                                            Stop = (Ln: 15, Col: 5) } }] } }
-                     Span = { Start = (Ln: 8, Col: 15)
-                              Stop = (Ln: 16, Col: 5) }
-                     InferredType = None }, None)
+                                                                  (Ln: 11, Col: 7) } }] }
+                                                       Catch =
+                                                        Some
+                                                          [{ Span =
+                                                              { Start =
+                                                                 (Ln: 12, Col: 9)
+                                                                Stop =
+                                                                 (Ln: 13, Col: 7) }
+                                                             Pattern =
+                                                              { Kind =
+                                                                 Ident
+                                                                   { Name = "_"
+                                                                     IsMut =
+                                                                      false
+                                                                     Assertion =
+                                                                      None }
+                                                                Span =
+                                                                 { Start =
+                                                                    (Ln: 12, Col: 11)
+                                                                   Stop =
+                                                                    (Ln: 12, Col: 13) }
+                                                                InferredType =
+                                                                 None }
+                                                             Guard = None
+                                                             Body =
+                                                              Expr
+                                                                { Kind =
+                                                                   Literal
+                                                                     (Number
+                                                                        (Int 0))
+                                                                  Span =
+                                                                   { Start =
+                                                                      (Ln: 12, Col: 16)
+                                                                     Stop =
+                                                                      (Ln: 13, Col: 7) }
+                                                                  InferredType =
+                                                                   None } }]
+                                                       Finally = None
+                                                       Throws = None }
+                                                  Span =
+                                                   { Start = (Ln: 9, Col: 20)
+                                                     Stop = (Ln: 14, Col: 7) }
+                                                  InferredType = None } }
+                                          Span = { Start = (Ln: 9, Col: 7)
+                                                   Stop = (Ln: 14, Col: 7) } }
+                                     Span = { Start = (Ln: 9, Col: 7)
+                                              Stop = (Ln: 14, Col: 7) } };
+                                   { Kind =
+                                      Return
+                                        (Some
+                                           { Kind = Identifier "result"
+                                             Span = { Start = (Ln: 14, Col: 14)
+                                                      Stop = (Ln: 15, Col: 5) }
+                                             InferredType = None })
+                                     Span = { Start = (Ln: 14, Col: 7)
+                                              Stop = (Ln: 15, Col: 5) } }] } }
+                       Span = { Start = (Ln: 8, Col: 15)
+                                Stop = (Ln: 16, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 8, Col: 5)
                         Stop = (Ln: 16, Col: 5) } }
           Span = { Start = (Ln: 8, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTypeof.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTypeof.verified.txt
@@ -8,23 +8,26 @@ output: Ok
            Decl
              { Kind =
                 VarDecl
-                  ({ Kind = Ident { Name = "iterator"
-                                    IsMut = false
-                                    Assertion = None }
-                     Span = { Start = (Ln: 2, Col: 9)
-                              Stop = (Ln: 2, Col: 17) }
-                     InferredType = None },
-                   { Kind = Member ({ Kind = Identifier "Symbol"
-                                      Span = { Start = (Ln: 2, Col: 44)
-                                               Stop = (Ln: 2, Col: 50) }
-                                      InferredType = None }, "iterator", false)
-                     Span = { Start = (Ln: 2, Col: 44)
-                              Stop = (Ln: 3, Col: 5) }
-                     InferredType = None },
-                   Some { Kind = Typeof (Member (Ident "Symbol", "iterator"))
-                          Span = { Start = (Ln: 2, Col: 19)
-                                   Stop = (Ln: 2, Col: 42) }
-                          InferredType = None })
+                  { Pattern = { Kind = Ident { Name = "iterator"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 2, Col: 9)
+                                         Stop = (Ln: 2, Col: 17) }
+                                InferredType = None }
+                    TypeAnn =
+                     Some { Kind = Typeof (Member (Ident "Symbol", "iterator"))
+                            Span = { Start = (Ln: 2, Col: 19)
+                                     Stop = (Ln: 2, Col: 42) }
+                            InferredType = None }
+                    Init =
+                     { Kind =
+                        Member ({ Kind = Identifier "Symbol"
+                                  Span = { Start = (Ln: 2, Col: 44)
+                                           Stop = (Ln: 2, Col: 50) }
+                                  InferredType = None }, "iterator", false)
+                       Span = { Start = (Ln: 2, Col: 44)
+                                Stop = (Ln: 3, Col: 5) }
+                       InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -1380,18 +1380,18 @@ module Parser =
       { Path = source
         Specifiers = Option.defaultValue [] specifiers }
 
-  let declare: Parser<ModuleItem, unit> =
+  let declare: Parser<ScriptItem, unit> =
     pipe4
       getPosition
       (strWs "declare" >>. strWs "let" >>. pattern)
       (strWs ":" >>. ws >>. typeAnn)
       getPosition
-    <| fun start pattern typeAnn stop -> ModuleItem.DeclareLet(pattern, typeAnn)
+    <| fun start pattern typeAnn stop -> ScriptItem.DeclareLet(pattern, typeAnn)
 
-  let private moduleItem: Parser<ModuleItem, unit> =
+  let private moduleItem: Parser<ScriptItem, unit> =
     ws
     >>. choice
-      [ import |>> ModuleItem.Import; declare; _stmt |>> ModuleItem.Stmt ]
+      [ import |>> ScriptItem.Import; declare; _stmt |>> ScriptItem.Stmt ]
 
   // Public Exports
   let parseExpr (input: string) : Result<Expr, ParserError> =
@@ -1404,10 +1404,10 @@ module Parser =
     | ParserResult.Success(result, _, _) -> Result.Ok(result)
     | ParserResult.Failure(_, error, _) -> Result.Error(error)
 
-  let script: Parser<Module, unit> =
+  let script: Parser<Script, unit> =
     (many moduleItem) .>> eof |>> fun items -> { Items = items }
 
-  let parseScript (input: string) : Result<Module, ParserError> =
+  let parseScript (input: string) : Result<Script, ParserError> =
     match run script input with
     | ParserResult.Success(m, _, _) -> Result.Ok(m)
     | ParserResult.Failure(_, error, _) -> Result.Error(error)

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -614,8 +614,12 @@ module Parser =
     )
     |>> fun ((pat, typeAnn, init), span) ->
       { Stmt.Kind =
-          Decl(
-            { Kind = DeclKind.VarDecl(pat, init, typeAnn)
+          StmtKind.Decl(
+            { Kind =
+                DeclKind.VarDecl
+                  { Pattern = pat
+                    Init = init
+                    TypeAnn = typeAnn }
               Span = span }
           )
         Span = span }
@@ -632,8 +636,12 @@ module Parser =
       let span = { Start = start; Stop = stop }
 
       { Stmt.Kind =
-          Decl(
-            { Kind = TypeDecl(id, typeAnn, typeParams)
+          StmtKind.Decl(
+            { Kind =
+                TypeDecl
+                  { Name = id
+                    TypeAnn = typeAnn
+                    TypeParams = typeParams }
               Span = span }
           )
         Span = span }
@@ -683,7 +691,7 @@ module Parser =
       let span = { Start = start; Stop = stop }
 
       { Stmt.Kind =
-          Decl
+          StmtKind.Decl
             { Kind =
                 StructDecl
                   { Name = name

--- a/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
+++ b/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
@@ -19,6 +19,7 @@
         <Compile Include="ArrayTuple.fs"/>
         <Compile Include="PatternMatching.fs"/>
         <Compile Include="Structs.fs"/>
+        <Compile Include="Modules.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>
 

--- a/src/Escalier.TypeChecker.Tests/Modules.fs
+++ b/src/Escalier.TypeChecker.Tests/Modules.fs
@@ -1,0 +1,103 @@
+module Modules
+
+
+open FsToolkit.ErrorHandling
+open System.IO.Abstractions.TestingHelpers
+open Xunit
+
+open Escalier.Parser
+open Escalier.TypeChecker
+open Escalier.TypeChecker.Env
+open Escalier.TypeChecker.Infer
+
+type Assert with
+
+  static member inline Value(env: Env, name: string, expected: string) =
+    let t, _ = Map.find name env.Values
+    Assert.Equal(expected, t.ToString())
+
+  static member inline Type(env: Env, name: string, expected: string) =
+    let scheme = Map.find name env.Schemes
+    Assert.Equal(expected, scheme.ToString())
+
+type CompileError = Prelude.CompileError
+
+
+let inferModule src =
+  result {
+    let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
+
+    let mockFileSystem = MockFileSystem()
+    let! ctx, env = Prelude.getEnvAndCtx mockFileSystem "/" "/input.esc"
+
+    let! env =
+      inferModule ctx env "input.esc" ast
+      |> Result.mapError CompileError.TypeError
+
+    return ctx, env
+  }
+
+[<Fact>]
+let InferBasicModule () =
+  let res =
+    result {
+      let src =
+        """
+        let add = fn(a, b) => a + b
+        let sub = fn(a, b) => a - b
+        """
+
+      let! _, env = inferModule src
+
+      Assert.Value(env, "add", "fn <A: number, B: number>(a: A, b: B) -> A + B")
+      Assert.Value(env, "sub", "fn <A: number, B: number>(a: A, b: B) -> A - B")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let InferMutuallyRecursiveFunctions () =
+  let res =
+    result {
+      let src =
+        """
+        let foo = fn() => bar() + 1
+        let bar = fn() => foo() - 1
+        """
+
+      let! _, env = inferModule src
+
+      Assert.Value(env, "foo", "fn () -> number")
+      Assert.Value(env, "bar", "fn () -> number")
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let InferMutualRecursion () =
+  let res =
+    result {
+      let src =
+        """
+        let even = fn (x) => if (x == 0) {
+            true
+        } else {
+            odd(x - 1)
+        }
+
+        let odd = fn (x) => if (x == 1) {
+            true
+        } else {
+            even(x - 1)
+        }
+        """
+
+      let! _, env = inferModule src
+
+      Assert.Value(env, "even", "fn (x: number) -> true | true")
+      Assert.Value(env, "odd", "fn (x: number) -> true | true | true")
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -269,7 +269,7 @@ let UndefinedSymbol () =
 let InferPair () =
   result {
     (* letrec f = (fn x => x) in [f 4, f true] *)
-    let ast =
+    let ast: Script =
       { Items =
           [ varDecl ("f", fatArrow [ "x" ] (ident "x")) |> ScriptItem.Stmt
             varDecl (
@@ -313,7 +313,7 @@ let RecursiveUnification () =
 [<Fact>]
 let InferGenericAndNonGeneric () =
   result {
-    let ast =
+    let ast: Script =
       { Items =
           [ varDecl (
               "foo",
@@ -347,10 +347,8 @@ let InferGenericAndNonGeneric () =
 [<Fact>]
 let InferFuncComposition () =
   result {
-    let ast =
-      {
-
-        Items =
+    let ast: Script =
+      { Items =
           [ varDecl (
               "foo",
               fatArrow
@@ -411,7 +409,7 @@ let InferScriptSKK () =
 
     let i = call (call (ident "S", [ ident "K" ]), [ ident "K" ])
 
-    let script =
+    let script: Script =
       { Items =
           [ varDecl ("S", s) |> ScriptItem.Stmt
             varDecl ("K", k) |> ScriptItem.Stmt

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -176,7 +176,11 @@ let varDecl (name, expr) =
 
   { Kind =
       StmtKind.Decl(
-        { Kind = DeclKind.VarDecl(pattern, expr, None)
+        { Kind =
+            DeclKind.VarDecl
+              { Pattern = pattern
+                Init = expr
+                TypeAnn = None }
           Span = dummySpan }
       )
     Span = dummySpan }

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -271,14 +271,14 @@ let InferPair () =
     (* letrec f = (fn x => x) in [f 4, f true] *)
     let ast =
       { Items =
-          [ varDecl ("f", fatArrow [ "x" ] (ident "x")) |> ModuleItem.Stmt
+          [ varDecl ("f", fatArrow [ "x" ] (ident "x")) |> ScriptItem.Stmt
             varDecl (
               "pair",
               tuple
                 [ call (ident "f", [ number (Number.Int 4) ])
                   call (ident "f", [ boolean true ]) ]
             )
-            |> ModuleItem.Stmt ] }
+            |> ScriptItem.Stmt ] }
 
     let env = getEnv ()
 
@@ -330,7 +330,7 @@ let InferGenericAndNonGeneric () =
                     )
                   ) ]
             )
-            |> ModuleItem.Stmt ] }
+            |> ScriptItem.Stmt ] }
 
     let env = getEnv ()
 
@@ -362,7 +362,7 @@ let InferFuncComposition () =
                     (call (ident "g", [ call (ident "f", [ ident "arg" ]) ]))))
 
             )
-            |> ModuleItem.Stmt ] }
+            |> ScriptItem.Stmt ] }
 
     let env = getEnv ()
 
@@ -413,9 +413,9 @@ let InferScriptSKK () =
 
     let script =
       { Items =
-          [ varDecl ("S", s) |> ModuleItem.Stmt
-            varDecl ("K", k) |> ModuleItem.Stmt
-            varDecl ("I", i) |> ModuleItem.Stmt ] }
+          [ varDecl ("S", s) |> ScriptItem.Stmt
+            varDecl ("K", k) |> ScriptItem.Stmt
+            varDecl ("I", i) |> ScriptItem.Stmt ] }
 
     let ctx =
       Ctx((fun ctx filename import -> env), (fun ctx filename import -> ""))

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -686,6 +686,62 @@ let InferFactorial () =
   Assert.False(Result.isError result)
 
 [<Fact>]
+let InferRecursive () =
+  let result =
+    result {
+
+      let src =
+        """
+        let rec = fn () => rec()
+        """
+
+      let! _, env = inferScript src
+
+      // TODO: figure out how to get the param name back
+      Assert.Value(env, "rec", "fn <A>() -> A")
+    }
+
+  printf "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact>]
+let InferRecursiveSequence () =
+  let result =
+    result {
+
+      let src =
+        """
+        let seq = fn () => seq() + 1
+        """
+
+      let! _, env = inferScript src
+
+      // TODO: figure out how to get the param name back
+      Assert.Value(env, "seq", "fn () -> number")
+    }
+
+  printf "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact(Skip = "TODO: handle recursive types")>]
+let InferRecursiveType () =
+  let result =
+    result {
+
+      let src =
+        """
+        type Foo = number | Foo[]
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Type(env, "Foo", "number | Foo[]")
+    }
+
+  printf "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact>]
 let InferFuncGeneralization () =
   let result =
     result {

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -188,6 +188,15 @@ module rec Env =
       { this with
           Values = Map.add name binding this.Values }
 
+    member this.AddBindings(bindings: Map<string, Binding>) =
+      let mutable newEnv = this
+
+      for KeyValue(name, binding) in bindings do
+        let t, isMut = binding
+        newEnv <- newEnv.AddValue name (prune t, isMut)
+
+      newEnv
+
     // TODO: don't curry this function
     member this.AddScheme (name: string) (s: Scheme) =
       { this with

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -1791,15 +1791,6 @@ module rec Infer =
     else
       importPath
 
-  // let inferImport
-  //   (ctx: Ctx)
-  //   (env: Env)
-  //   (import: Import)
-  //   : Result<Env, TypeError> =
-  //   // TODO: read the file and infer the module
-  //   // TODO: have a way of store
-  //   failwith "TODO - inferImport"
-
   let inferImport
     (ctx: Ctx)
     (env: Env)

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -1770,7 +1770,7 @@ module rec Infer =
 
     result {
       match item with
-      | Import import ->
+      | ScriptItem.Import import ->
         let exports = ctx.GetExports filename import
 
         let mutable imports = Env.empty
@@ -1817,7 +1817,7 @@ module rec Infer =
           { env with
               Values = FSharpPlus.Map.union env.Values imports.Values
               Schemes = FSharpPlus.Map.union env.Schemes imports.Schemes }
-      | DeclareLet(name, typeAnn) ->
+      | ScriptItem.DeclareLet(name, typeAnn) ->
         let! typeAnnType = inferTypeAnn ctx env typeAnn
         let! assump, patType = inferPattern ctx env name
 

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -1764,7 +1764,7 @@ module rec Infer =
     (ctx: Ctx)
     (env: Env)
     (filename: string)
-    (item: ModuleItem)
+    (item: ScriptItem)
     (generalize: bool)
     : Result<Env, TypeError> =
 
@@ -1837,7 +1837,7 @@ module rec Infer =
     (ctx: Ctx)
     (env: Env)
     (filename: string)
-    (m: Module)
+    (m: Script)
     : Result<Env, TypeError> =
     result {
       let mutable newEnv = env
@@ -2014,7 +2014,7 @@ module rec Infer =
 
     List.rev names
 
-  let findModuleBindingNames (m: Module) : list<string> =
+  let findModuleBindingNames (m: Script) : list<string> =
     let mutable names: list<string> = []
 
     for item in m.Items do

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -70,7 +70,7 @@ module Prelude =
       match item with
       | Syntax.Stmt stmt ->
         match stmt.Kind with
-        | Syntax.StmtKind.Decl({ Kind = Syntax.DeclKind.VarDecl(pattern, _, _) }) ->
+        | Syntax.StmtKind.Decl({ Kind = Syntax.DeclKind.VarDecl { Pattern = pattern } }) ->
           names <- List.concat [ names; findBindingNames pattern ]
         | _ -> ()
       | _ -> ()
@@ -269,9 +269,7 @@ module Prelude =
 
             for item in m.Items do
               match item with
-              | Syntax.Stmt { Kind = Syntax.StmtKind.Decl { Kind = Syntax.DeclKind.TypeDecl(name,
-                                                                                            _,
-                                                                                            _) } } ->
+              | Syntax.Stmt { Kind = Syntax.StmtKind.Decl { Kind = Syntax.DeclKind.TypeDecl { Name = name } } } ->
                 match env.Schemes.TryFind(name) with
                 | Some(scheme) -> newEnv <- newEnv.AddScheme name scheme
                 | None -> failwith $"scheme {name} not found"

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -255,7 +255,9 @@ module Prelude =
             let env =
               match Infer.inferScript ctx env entry m with
               | Ok value -> value
-              | Error _ -> failwith $"failed to infer {resolvedImportPath}"
+              | Error err ->
+                printfn "err = %A" err
+                failwith $"failed to infer {resolvedImportPath}"
 
             let mutable newEnv = Env.Env.empty
 

--- a/src/Escalier.TypeChecker/Prelude.fs
+++ b/src/Escalier.TypeChecker/Prelude.fs
@@ -63,7 +63,7 @@ module Prelude =
 
     List.rev names
 
-  let private findModuleBindingNames (m: Syntax.Module) : list<string> =
+  let private findModuleBindingNames (m: Syntax.Script) : list<string> =
     let mutable names: list<string> = []
 
     for item in m.Items do

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -718,23 +718,18 @@ module rec Unify =
           | _ -> return! Error(TypeError.NotImplemented "bind error")
     }
 
-  // TODO: finish implementing this function
-  // TODO: use visitType for this
-  and occursInType (v: Type) (t2: Type) : bool =
-    match (prune t2).Kind with
-    | pruned when pruned = v.Kind -> true
-    | TypeKind.TypeRef({ TypeArgs = typeArgs }) ->
-      match typeArgs with
-      | Some(typeArgs) -> occursIn v typeArgs
-      | None -> false
-    | TypeKind.Union types -> occursIn v types
-    | TypeKind.Intersection types -> occursIn v types
-    | TypeKind.Binary(left, op, right) ->
-      occursInType v left || occursInType v right
-    | _ -> false
+  and occursInType (t1: Type) (t2: Type) : bool =
+    let mutable result: bool = false
 
-  and occursIn (t: Type) (types: list<Type>) : bool =
-    List.exists (occursInType t) types
+    let visitor =
+      fun (t: Type) ->
+        match (prune t).Kind with
+        | pruned when pruned = t1.Kind -> result <- true
+        | _ -> ()
+
+    TypeVisitor.walkType visitor t2
+
+    result
 
 
   let expandScheme

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -244,6 +244,7 @@ module rec TypeVisitor =
             | _ -> failwith "TODO: foldType - ObjTypeElem")
           elems
 
+      | TypeKind.Struct _ -> ()
       | TypeKind.Rest t -> walk t
       | TypeKind.Union types -> List.iter walk types
       | TypeKind.Intersection types -> List.iter walk types
@@ -270,6 +271,7 @@ module rec TypeVisitor =
         walk min
         walk max
       | TypeKind.UniqueNumber _ -> ()
+      | TypeKind.UniqueSymbol _ -> ()
       | TypeKind.TemplateLiteral { Exprs = exprs } -> List.iter walk exprs
 
       f t

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -104,10 +104,10 @@ module rec ExprVisitor =
           walkPattern visitor left
           walkExpr visitor right
           List.iter walk body.Stmts
-        | StmtKind.Decl({ Kind = DeclKind.VarDecl(_name, init, typeAnn) }) ->
+        | StmtKind.Decl({ Kind = DeclKind.VarDecl { Init = init } }) ->
           // TODO: walk typeAnn
           walkExpr visitor init
-        | StmtKind.Decl({ Kind = DeclKind.TypeDecl(name, typeAnn, typeParams) }) ->
+        | StmtKind.Decl({ Kind = DeclKind.TypeDecl { TypeAnn = typeAnn } }) ->
           // TODO: walk type params
           walkTypeAnn visitor typeAnn
         | StmtKind.Decl({ Kind = DeclKind.StructDecl { Elems = elems


### PR DESCRIPTION
Escalier will have two different file types: scripts and modules.  Scripts can have any statement at the top level with each statement being inferred and generalized one at a time.  Modules on the other hand can only have declarations at the top-level and all declarations being inferred and generalized at once. 