### PR TITLE
Allow methods to call other methods in the same impl

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -539,9 +539,9 @@ module rec Codegen =
             TypeAnn = buildTypeAnn ctx prop.Type
             Loc = None }
       | _ -> failwith "TODO: buildObjTypeElem - Property"
-    | Method(name, isMut, fn) -> failwith "todo"
-    | Getter(name, returnType, throws) -> failwith "todo"
-    | Setter(name, param, throws) -> failwith "todo"
+    | Method(name, fn) -> failwith "todo"
+    | Getter(name, fn) -> failwith "todo"
+    | Setter(name, fn) -> failwith "todo"
     | Mapped mapped -> failwith "todo"
 
   type Binding = Type * bool

--- a/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
+++ b/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
@@ -103,7 +103,7 @@ let InfersPropagateAsyncError () =
       Assert.Value(
         env,
         "bar",
-        "fn (x: number) -> Promise<number, \"RangeError\">"
+        "fn <A: number>(x: A) -> Promise<A + 10, \"RangeError\">"
       )
     }
 
@@ -133,7 +133,7 @@ let InfersTryCatchAsync () =
         "fn <A: number>(x: A) -> Promise<A, \"RangeError\">"
       )
 
-      Assert.Value(env, "bar", "fn (x: number) -> Promise<number, never>")
+      Assert.Value(env, "bar", "fn <A: number>(x: A) -> Promise<A + 10 | 0, never>")
     }
 
   printfn "res: %A" res

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -378,7 +378,7 @@ let InferFuncComposition () =
     let! t = newEnv.GetType "foo"
     (* fn f (fn g (fn arg (f g arg))) *)
     Assert.Equal(
-      "fn <A, B, C>(f: fn (arg0: A) -> B) -> fn (g: fn (arg0: B) -> C) -> fn (arg: A) -> C",
+      "fn <A, C, B>(f: fn (arg0: A) -> B) -> fn (g: fn (arg0: B) -> C) -> fn (arg: A) -> C",
       t.ToString()
     )
   }

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -332,7 +332,7 @@ let GetterSetterImpl () =
   printfn "res = %A" res
   Assert.False(Result.isError res)
 
-[<Fact(Skip="TODO")>]
+[<Fact>]
 let CallingMethodInSameImpl () =
   let res =
     result {

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -331,3 +331,34 @@ let GetterSetterImpl () =
 
   printfn "res = %A" res
   Assert.False(Result.isError res)
+
+[<Fact(Skip="TODO")>]
+let CallingMethodInSameImpl () =
+  let res =
+    result {
+      let src =
+        """
+        struct Foo {x: number}
+
+        impl Foo {
+          fn bar(self) {
+            return self.x
+          }
+          
+          fn baz(self) {
+            return self.bar()
+          }
+        }
+
+        let foo = Foo {x: 5}
+        let bar = foo.bar()
+        let baz = foo.baz()
+        """
+
+      let! _, env = inferScript src
+
+      Assert.Value(env, "bar", "number")
+      Assert.Value(env, "baz", "number")
+    }
+
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -541,10 +541,10 @@ let InferSKK () =
       Assert.Value(
         env,
         "S",
-        "fn <A, B, C>(f: fn (arg0: A) -> fn (arg0: B) -> C) -> fn (g: fn (arg0: A) -> B) -> fn (x: A) -> C"
+        "fn <A, C, B>(f: fn (arg0: A) -> fn (arg0: B) -> C) -> fn (g: fn (arg0: A) -> B) -> fn (x: A) -> C"
       )
 
-      Assert.Value(env, "K", "fn <A, B>(x: A) -> fn (y: B) -> A")
+      Assert.Value(env, "K", "fn <B, A>(x: A) -> fn (y: B) -> A")
       Assert.Value(env, "I", "fn <A>(x: A) -> A")
     }
 
@@ -681,7 +681,7 @@ let InferFactorial () =
       let! _, env = inferScript src
 
       // TODO: figure out how to get the param name back
-      Assert.Value(env, "factorial", "fn (arg0: number) -> number")
+      Assert.Value(env, "factorial", "fn (arg0: number) -> 1 | number")
     }
 
   printf "result = %A" result
@@ -757,7 +757,7 @@ let InferFuncGeneralization () =
 
       let! _, env = inferScript src
 
-      Assert.Value(env, "fst", "fn <A, B>(x: A, y: B) -> A")
+      Assert.Value(env, "fst", "fn <B, A>(x: A, y: B) -> A")
     }
 
   printf "result = %A" result


### PR DESCRIPTION
- extract inferFuncSig from inferFunction
- extract second half of inferFunction into inferFuncBody
- call inferFuncBody after inferring all of the signatures
- Use inferFuncSig and inferFuncBody to infer struct impls
- update inferFuncBody to add type params, self, and regular function params to the environment before inferring the body
- update inferFuncSig to not return an updated environment
- make it so that methods can call other methods in the same struct
