### PR TITLE
sanitize various Array methods

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -959,10 +959,11 @@ module Type =
             let readonly = if readonly then "readonly " else ""
             $"{readonly}{name}{optional}: {printType ctx t}"
           | Mapped mapped -> printMapped ctx mapped
-          | Method(propName, fn) -> $"{propName} {fn}"
-          | _ -> failwith "TODO: Type.ToString - Object - Elem"
-
-        )
+          | Method(name, fn) -> $"{name} {fn}"
+          | Getter(name, fn) -> $"get {name} {fn}"
+          | Setter(name, fn) -> $"set {name} {fn}"
+          | Callable func -> func.ToString()
+          | Constructor func -> $"new {func}")
         obj.Elems
 
     let elems = String.concat ", " elems

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -342,8 +342,29 @@ let InferArrayPrototype () =
       let! ctx, env = Prelude.getEnvAndCtxWithES5 mockFileSystem "/"
 
       let scheme = Map.find "Array" env.Schemes
+      // printfn $"Array = {scheme}"
 
-      printfn $"Array = {scheme}"
+      let value = Map.find "Array" env.Values
+      // printfn $"Array = {value}"
+
+      let scheme = Map.find "ArrayConstructor" env.Schemes
+      // printfn $"ArrayConstructor = {scheme}"
+
+      return env
+    }
+
+  Assert.True(Result.isOk result)
+
+[<Fact>]
+let InferInt8ArrayPrototype () =
+  let result =
+    result {
+      let mockFileSystem = MockFileSystem()
+      let! ctx, env = Prelude.getEnvAndCtxWithES5 mockFileSystem "/"
+
+      let scheme = Map.find "Int8Array" env.Schemes
+
+      // printfn $"Int8Array = {scheme}"
 
       return env
     }


### PR DESCRIPTION
In particular this PR makes the following changes to  `every`, `some`, `map`, `filter`, and `reduce`:
- removes `thisArg` from the param list
- removes the `array` param from the `predicate`/`callbackFn` callback