### PR TITLE
Parse 'new' and handle calls with type arguments

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -209,6 +209,12 @@ module Syntax =
       OptChain: bool
       mutable Throws: option<Type.Type> }
 
+  type New =
+    { Callee: Expr
+      TypeArgs: option<list<TypeAnn>>
+      Args: option<list<Expr>>
+      mutable Throws: option<Type.Type> }
+
   type Try =
     { Body: Block
       Catch: option<list<MatchCase>>
@@ -227,6 +233,8 @@ module Syntax =
     | Literal of Common.Literal
     | Function of Function
     | Call of Call
+    | New of New
+    | ExprWithTypeArgs of target: Expr * typeArgs: list<TypeAnn>
     | Object of Common.Object<ObjElem>
     | Struct of Struct<ObjElem>
     | Tuple of Common.Tuple<Expr>

--- a/src/Escalier.Interop/Parser.fs
+++ b/src/Escalier.Interop/Parser.fs
@@ -225,7 +225,7 @@ module Parser =
 
   // let typeQuery: Parser<TsTypeQuery, unit> = ...
 
-  let callSignDecl: Parser<TsTypeElement, unit> =
+  let callSigDecl: Parser<TsTypeElement, unit> =
     pipe3 (opt typeParams) tsFnParams (opt (strWs ":" >>. tsTypeAnn))
     <| fun typeParams ps typeAnn ->
       { TsCallSignatureDecl.TypeParams = typeParams
@@ -234,7 +234,7 @@ module Parser =
         Loc = None }
       |> TsTypeElement.TsCallSignatureDecl
 
-  let constructorSignDecl: Parser<TsTypeElement, unit> =
+  let constructorSigDecl: Parser<TsTypeElement, unit> =
     pipe3
       (strWs "new" >>. (opt typeParams))
       tsFnParams
@@ -326,8 +326,8 @@ module Parser =
 
   let typeMember: Parser<TsTypeElement, unit> =
     choice
-      [ callSignDecl
-        constructorSignDecl
+      [ callSigDecl
+        constructorSigDecl
         attempt propSig
         attempt getterSig
         attempt setterSig

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -76,7 +76,7 @@ let ParseEmptyCall () =
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
-[<Fact(Skip = "TODO")>]
+[<Fact>]
 let ParseExprWithTypeParam () =
   let src = "add<number | string>"
   let ast = Parser.parseScript src
@@ -84,7 +84,7 @@ let ParseExprWithTypeParam () =
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
-[<Fact(Skip = "TODO")>]
+[<Fact>]
 let ParseCallWithTypeParam () =
   let src = "add<number>()"
   let ast = Parser.parseScript src

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -76,6 +76,38 @@ let ParseEmptyCall () =
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
+[<Fact(Skip = "TODO")>]
+let ParseExprWithTypeParam () =
+  let src = "add<number | string>"
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact(Skip = "TODO")>]
+let ParseCallWithTypeParam () =
+  let src = "add<number>()"
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseConstructorCall () =
+  let src = "new Array()"
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact(Skip = "TODO")>]
+let ParseConstructorCallWithTypeParam () =
+  let src = "new Array<number>()"
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
 [<Fact>]
 let ParseIndexer () =
   let src = "array[0]"
@@ -623,7 +655,7 @@ let ParseBasicImpl () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
-  
+
 [<Fact>]
 let ParseImplWithStaticMethods () =
   let src =

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -100,7 +100,7 @@ let ParseConstructorCall () =
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
-[<Fact(Skip = "TODO")>]
+[<Fact>]
 let ParseConstructorCallWithTypeParam () =
   let src = "new Array<number>()"
   let ast = Parser.parseScript src

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallWithTypeParam.verified.txt
@@ -1,0 +1,23 @@
+﻿input: add<number>()
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Expr
+             { Kind =
+                Call { Callee = { Kind = Identifier "add"
+                                  Span = { Start = (Ln: 1, Col: 1)
+                                           Stop = (Ln: 1, Col: 4) }
+                                  InferredType = None }
+                       TypeArgs = Some [{ Kind = Keyword Number
+                                          Span = { Start = (Ln: 1, Col: 5)
+                                                   Stop = (Ln: 1, Col: 11) }
+                                          InferredType = None }]
+                       Args = []
+                       OptChain = false
+                       Throws = None }
+               Span = { Start = (Ln: 1, Col: 1)
+                        Stop = (Ln: 1, Col: 14) }
+               InferredType = None }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 14) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCall.verified.txt
@@ -1,0 +1,17 @@
+﻿input: new Array()
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Expr { Kind = New { Callee = { Kind = Identifier "Array"
+                                          Span = { Start = (Ln: 1, Col: 5)
+                                                   Stop = (Ln: 1, Col: 10) }
+                                          InferredType = None }
+                               TypeArgs = None
+                               Args = Some []
+                               Throws = None }
+                  Span = { Start = (Ln: 1, Col: 5)
+                           Stop = (Ln: 1, Col: 12) }
+                  InferredType = None }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 12) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCallWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCallWithTypeParam.verified.txt
@@ -1,0 +1,22 @@
+﻿input: new Array<number>()
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Expr
+             { Kind =
+                New { Callee = { Kind = Identifier "Array"
+                                 Span = { Start = (Ln: 1, Col: 5)
+                                          Stop = (Ln: 1, Col: 10) }
+                                 InferredType = None }
+                      TypeArgs = Some [{ Kind = Keyword Number
+                                         Span = { Start = (Ln: 1, Col: 11)
+                                                  Stop = (Ln: 1, Col: 17) }
+                                         InferredType = None }]
+                      Args = Some []
+                      Throws = None }
+               Span = { Start = (Ln: 1, Col: 5)
+                        Stop = (Ln: 1, Col: 20) }
+               InferredType = None }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 20) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseExprWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseExprWithTypeParam.verified.txt
@@ -1,0 +1,30 @@
+﻿input: add<number | string>
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Expr
+             { Kind =
+                ExprWithTypeArgs
+                  ({ Kind = Identifier "add"
+                     Span = { Start = (Ln: 1, Col: 1)
+                              Stop = (Ln: 1, Col: 4) }
+                     InferredType = None },
+                   [{ Kind =
+                       Union
+                         [{ Kind = Keyword Number
+                            Span = { Start = (Ln: 1, Col: 5)
+                                     Stop = (Ln: 1, Col: 12) }
+                            InferredType = None };
+                          { Kind = Keyword String
+                            Span = { Start = (Ln: 1, Col: 14)
+                                     Stop = (Ln: 1, Col: 20) }
+                            InferredType = None }]
+                      Span = { Start = (Ln: 1, Col: 5)
+                               Stop = (Ln: 1, Col: 20) }
+                      InferredType = None }])
+               Span = { Start = (Ln: 1, Col: 1)
+                        Stop = (Ln: 1, Col: 21) }
+               InferredType = None }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 21) } }] }

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -534,6 +534,13 @@ module Parser =
               match left.Kind with
               | ExprKind.New n ->
                 ExprKind.New { n with Args = Some(args.Result) }
+              | ExprKind.ExprWithTypeArgs(callee, typeArgs) ->
+                ExprKind.Call
+                  { Callee = callee
+                    TypeArgs = Some(typeArgs)
+                    Args = args.Result
+                    OptChain = false
+                    Throws = None }
               | _ ->
                 ExprKind.Call
                   { Callee = left
@@ -583,9 +590,7 @@ module Parser =
           | _ -> Reply(typeArgs.Status, typeArgs.Error)
       Precedence = precedence }
 
-  // TODO: re-enabled once we support multiple parselets per operator
-  // TODO: test out different precedences
-  // exprParser.RegisterInfix("<", typeArgsParselet 16)
+  exprParser.RegisterInfix("<", typeArgsParselet 16)
 
   exprParser.RegisterPrefix("!", unaryExprParslet 14 "!")
   // bitwise not (14)

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -573,14 +573,20 @@ module Parser =
             else
               let parseTypeArgs = sepBy typeAnn (strWs ",")
               let reply = (parseTypeArgs .>> (strWs ">")) stream
-              printfn "reply = %A" reply
               reply
 
           match typeArgs.Status with
           | Ok ->
-            Reply(
-              { Expr.Kind = ExprKind.ExprWithTypeArgs(left, typeArgs.Result)
+            let kind =
+              match left.Kind with
+              | ExprKind.New n ->
+                ExprKind.New
+                  { n with
+                      TypeArgs = Some(typeArgs.Result) }
+              | _ -> ExprKind.ExprWithTypeArgs(left, typeArgs.Result)
 
+            Reply(
+              { Expr.Kind = kind
                 Span =
                   { Start = left.Span.Start
                     Stop = stream.Position }

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -67,7 +67,6 @@ let call (f, args) =
       TypeArgs = None
       Args = args
       OptChain = false
-      New = false
       Throws = None }
 
   { Expr.Kind = ExprKind.Call(c)

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -67,6 +67,7 @@ let call (f, args) =
       TypeArgs = None
       Args = args
       OptChain = false
+      New = false
       Throws = None }
 
   { Expr.Kind = ExprKind.Call(c)

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -603,7 +603,7 @@ let StaticMethods () =
         struct Point {x: number, y: number}
 
         impl Point {
-          fn new(x, y) {
+          fn make(x, y) {
             return Self { x, y }
           }
           fn default() {
@@ -611,7 +611,7 @@ let StaticMethods () =
           }
         }
 
-        let p = Point.new(5, 10)
+        let p = Point.make(5, 10)
         let q = Point.default()
         let {x, y} = p
         """


### PR DESCRIPTION
- Add 'New' and 'ExprWithTypeArgs' ExprKinds, remove GetPrecedence() method
- handle '<' having multiple parselets
- parse `new` expressions with and without type args
- parse expressions with type args