### PR TITLE
Require semi-colons in some places

### DIFF
--- a/src/Escalier.Codegen.Tests/Tests.fs
+++ b/src/Escalier.Codegen.Tests/Tests.fs
@@ -147,10 +147,10 @@ let CodegenDoExpression () =
       let src =
         """
         let sum = do {
-          let x = 5
-          let y = 10
+          let x = 5;
+          let y = 10;
           x + y
-        }
+        };
         """
 
       let! escAst = Parser.parseScript src
@@ -175,17 +175,17 @@ let CodegenNestedDoExpressions () =
         """
         let sum = do {
           let x = do {
-            let a = 5
-            let b = 10
+            let a = 5;
+            let b = 10;
             a + b
-          }
+          };
           let y = do {
-            let c = 15
-            let d = 20
+            let c = 15;
+            let d = 20;
             c - d
-          }
+          };
           x * y
-        }
+        };
         """
 
       let! escAst = Parser.parseScript src
@@ -209,7 +209,7 @@ let CodegenFunction () =
       let src =
         """
         let factorial = fn (n) =>
-          if (n == 0) { 1 } else { n * factorial(n - 1) } 
+          if (n == 0) { 1 } else { n * factorial(n - 1) }; 
         """
 
       let! escAst = Parser.parseScript src
@@ -239,7 +239,7 @@ let CodegenChainedIfElse () =
           bar
         } else {
           baz
-        }
+        };
         """
 
       let! escAst = Parser.parseScript src
@@ -265,8 +265,8 @@ let CodegenDtsBasics () =
     result {
       let src =
         """
-        type Point = {x: number, y: number}
-        let add = fn (a: number, b: number) => a + b
+        type Point = {x: number, y: number};
+        let add = fn (a: number, b: number) => a + b;
         """
 
       let! escAst =
@@ -298,7 +298,7 @@ let CodegenDtsGeneric () =
     result {
       let src =
         """
-        let fst = fn (a, b) => a
+        let fst = fn (a, b) => a;
         """
 
       let! ast =

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenChainedIfElse.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenChainedIfElse.verified.txt
@@ -5,7 +5,7 @@
           bar
         } else {
           baz
-        }
+        };
         
 output:
 var temp0;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDoExpression.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDoExpression.verified.txt
@@ -1,9 +1,9 @@
 ﻿input: 
         let sum = do {
-          let x = 5
-          let y = 10
+          let x = 5;
+          let y = 10;
           x + y
-        }
+        };
         
 output:
 var temp0;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsBasics.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsBasics.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
-        type Point = {x: number, y: number}
-        let add = fn (a: number, b: number) => a + b
+        type Point = {x: number, y: number};
+        let add = fn (a: number, b: number) => a + b;
         
 output:
 export type Point = {

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsGeneric.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsGeneric.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-        let fst = fn (a, b) => a
+        let fst = fn (a, b) => a;
         
 output:
 export declare const fst;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunction.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunction.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
         let factorial = fn (n) =>
-          if (n == 0) { 1 } else { n * factorial(n - 1) } 
+          if (n == 0) { 1 } else { n * factorial(n - 1) }; 
         
 output:
 var factorial = (n) => {

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenNestedDoExpressions.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenNestedDoExpressions.verified.txt
@@ -1,17 +1,17 @@
 ﻿input: 
         let sum = do {
           let x = do {
-            let a = 5
-            let b = 10
+            let a = 5;
+            let b = 10;
             a + b
-          }
+          };
           let y = do {
-            let c = 15
-            let d = 20
+            let c = 15;
+            let d = 20;
             c - d
-          }
+          };
           x * y
-        }
+        };
         
 output:
 var temp0;

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test1/test1.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test1/test1.esc
@@ -1,3 +1,3 @@
-let a = 5
-let b = "hello"
-let c = true
+let a = 5;
+let b = "hello";
+let c = true;

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test2/test2.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test2/test2.esc
@@ -1,2 +1,2 @@
 let factorial = fn (n) =>
-  if (n == 0) { 1 } else { n * factorial(n - 1) }
+  if (n == 0) { 1 } else { n * factorial(n - 1) };

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test3/test3.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test3/test3.esc
@@ -1,2 +1,2 @@
-let foo = fn (x: number) => x
-foo("hello")
+let foo = fn (x: number) => x;
+foo("hello");

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.esc
@@ -1,5 +1,5 @@
-import "~/imports1/math" {add}
-import "./point" {makePoint, Point}
+import "~/imports1/math" {add};
+import "./point" {makePoint, Point};
 
 let p = makePoint(5, 10);
 let q: Point = {x: 20, y: 30};

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.esc
@@ -1,7 +1,7 @@
 import "~/imports1/math" {add}
 import "./point" {makePoint, Point}
 
-let p = makePoint(5, 10)
-let q: Point = {x: 20, y: 30}
-let x = add(p.x, q.x)
-let y = add(p.y, q.y)
+let p = makePoint(5, 10);
+let q: Point = {x: 20, y: 30};
+let x = add(p.x, q.x);
+let y = add(p.y, q.y);

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/math.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/math.esc
@@ -1,4 +1,4 @@
-let add = fn (a, b) => a + b
-let sub = fn (a, b) => a - b
-let mul = fn (a, b) => a * b
-let div = fn (a, b) => a / b
+let add = fn (a, b) => a + b;
+let sub = fn (a, b) => a - b;
+let mul = fn (a, b) => a * b;
+let div = fn (a, b) => a / b;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/point.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/point.esc
@@ -1,5 +1,5 @@
-type Point = {x: number, y: number}
+type Point = {x: number, y: number};
 
 let makePoint = fn (x: number, y: number) -> Point {
-    return {x: x, y: y}
-}
+    return {x: x, y: y};
+};

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/entry.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/entry.esc
@@ -1,5 +1,5 @@
-import "~/imports2/math" as math
-import "./point" as point
+import "~/imports2/math" as math;
+import "./point" as point;
 
 let p = point.makePoint(5, 10);
 let q: point.Point = {x: 20, y: 30};

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/entry.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/entry.esc
@@ -1,7 +1,7 @@
 import "~/imports2/math" as math
 import "./point" as point
 
-let p = point.makePoint(5, 10)
-let q: point.Point = {x: 20, y: 30}
-let x = math.add(p.x, q.x)
-let y = math.sub(p.y, q.y)
+let p = point.makePoint(5, 10);
+let q: point.Point = {x: 20, y: 30};
+let x = math.add(p.x, q.x);
+let y = math.sub(p.y, q.y);

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/math.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/math.esc
@@ -1,4 +1,4 @@
-let add = fn (a, b) => a + b
-let sub = fn (a, b) => a - b
-let mul = fn (a, b) => a * b
-let div = fn (a, b) => a / b
+let add = fn (a, b) => a + b;
+let sub = fn (a, b) => a - b;
+let mul = fn (a, b) => a * b;
+let div = fn (a, b) => a / b;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/point.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/point.esc
@@ -1,5 +1,5 @@
-type Point = {x: number, y: number}
+type Point = {x: number, y: number};
 
 let makePoint = fn (x: number, y: number) -> Point {
-    return {x: x, y: y}
-}
+    return {x: x, y: y};
+};

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -379,9 +379,9 @@ let CanCallMutableMethodsOnMutableArray () =
 
       let src =
         """
-        let mut a: number[] = [3, 2, 1]
-        a.sort()
-        let b = a.map(fn (x) => x * 2)
+        let mut a: number[] = [3, 2, 1];
+        a.sort();
+        let b = a.map(fn (x) => x * 2);
         """
 
       let! ast =
@@ -405,11 +405,11 @@ let CanIndexOnArrays () =
 
       let src =
         """
-        let mut a: number[] = [3, 2, 1]
-        let b = a[0]
-        let mut len1 = a.length
-        let len2 = a.length
-        len1 = len2
+        let mut a: number[] = [3, 2, 1];
+        let b = a[0];
+        let mut len1 = a.length;
+        let len2 = a.length;
+        len1 = len2;
         """
 
       let! ast =
@@ -435,9 +435,9 @@ let CannotCallMutableMethodsOnNonMutableArray () =
 
       let src =
         """
-        let a: number[] = [3, 2, 1]
-        a.sort()
-        let b = a.map(fn (x) => x * 2)
+        let a: number[] = [3, 2, 1];
+        a.sort();
+        let b = a.map(fn (x) => x * 2);
         """
 
       let! ast =
@@ -462,8 +462,8 @@ let CallArrayConstructor () =
 
       let src =
         """
-        let mut a: number[] = new Array()
-        a.push(5)
+        let mut a: number[] = new Array();
+        a.push(5);
         """
 
       let! ast =
@@ -487,8 +487,8 @@ let CallArrayConstructorWithTypeArgs () =
 
       let src =
         """
-        let mut a = new Array<number>()
-        a.push(5)
+        let mut a = new Array<number>();
+        a.push(5);
         """
 
       let! ast =
@@ -512,8 +512,8 @@ let CallArrayConstructorWithNoTypeAnnotations () =
 
       let src =
         """
-        let mut a = new Array()
-        a.push(5)
+        let mut a = new Array();
+        a.push(5);
         """
 
       let! ast =
@@ -537,7 +537,7 @@ let AcessNamespaceType () =
 
       let src =
         """
-        type NumFmt = Intl.NumberFormat
+        type NumFmt = Intl.NumberFormat;
         """
 
       let! ast =
@@ -561,8 +561,8 @@ let AcessNamespaceValue () =
 
       let src =
         """
-        let fmt = new Intl.NumberFormat("en-CA")
-        fmt.format(1.23)
+        let fmt = new Intl.NumberFormat("en-CA");
+        fmt.format(1.23);
         """
 
       let! ast =

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -17,7 +17,7 @@ settings.DisableDiff()
 
 [<Fact>]
 let ParseArithmetic () =
-  let src = "0.1 + 2 * (3 - 4) / -5.6"
+  let src = "0.1 + 2 * (3 - 4) / -5.6;"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -25,7 +25,7 @@ let ParseArithmetic () =
 
 [<Fact>]
 let ParseString () =
-  let src = """let msg = "Hello,\n\t\"world!\"" """
+  let src = """let msg = "Hello,\n\t\"world!\"";"""
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -35,8 +35,8 @@ let ParseString () =
 let ParseOtherLiterals () =
   let src =
     """
-    let a = undefined
-    let b = null
+    let a = undefined;
+    let b = null;
     """
 
   let ast = Parser.parseScript src
@@ -46,7 +46,7 @@ let ParseOtherLiterals () =
 
 [<Fact>]
 let ParseTemplateString () =
-  let src = """let msg = `foo ${`bar ${baz}`}`"""
+  let src = """let msg = `foo ${`bar ${baz}`}`;"""
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -54,7 +54,7 @@ let ParseTemplateString () =
 
 [<Fact>]
 let ParseFunctionCall () =
-  let src = "add(x, y)"
+  let src = "add(x, y);"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -62,7 +62,7 @@ let ParseFunctionCall () =
 
 [<Fact>]
 let ParseFunctionCallExtraSpaces () =
-  let src = "add( x , y )"
+  let src = "add( x , y );"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -70,7 +70,7 @@ let ParseFunctionCallExtraSpaces () =
 
 [<Fact>]
 let ParseEmptyCall () =
-  let src = "add()"
+  let src = "add();"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -78,7 +78,7 @@ let ParseEmptyCall () =
 
 [<Fact>]
 let ParseExprWithTypeParam () =
-  let src = "add<number | string>"
+  let src = "add<number | string>;"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -86,7 +86,7 @@ let ParseExprWithTypeParam () =
 
 [<Fact>]
 let ParseCallWithTypeParam () =
-  let src = "add<number>()"
+  let src = "add<number>();"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -94,7 +94,7 @@ let ParseCallWithTypeParam () =
 
 [<Fact>]
 let ParseConstructorCall () =
-  let src = "new Array()"
+  let src = "new Array();"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -102,7 +102,7 @@ let ParseConstructorCall () =
 
 [<Fact>]
 let ParseConstructorCallWithTypeParam () =
-  let src = "new Array<number>()"
+  let src = "new Array<number>();"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -110,7 +110,7 @@ let ParseConstructorCallWithTypeParam () =
 
 [<Fact>]
 let ParseIndexer () =
-  let src = "array[0]"
+  let src = "array[0];"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -118,7 +118,7 @@ let ParseIndexer () =
 
 [<Fact>]
 let ParseMultipleIndexers () =
-  let src = "array[0][1]"
+  let src = "array[0][1];"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -126,7 +126,7 @@ let ParseMultipleIndexers () =
 
 [<Fact>]
 let ParseIndexerThenCall () =
-  let src = "array[0]()"
+  let src = "array[0]();"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -134,7 +134,7 @@ let ParseIndexerThenCall () =
 
 [<Fact>]
 let ParseCallThenIndexer () =
-  let src = "foo()[0]"
+  let src = "foo()[0];"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -142,7 +142,7 @@ let ParseCallThenIndexer () =
 
 [<Fact>]
 let ParseObjProperty () =
-  let src = "obj.a.b"
+  let src = "obj.a.b;"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -150,7 +150,7 @@ let ParseObjProperty () =
 
 [<Fact>]
 let ParseObjPropWithOptChain () =
-  let src = "obj?.a?.b"
+  let src = "obj?.a?.b;"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -158,7 +158,7 @@ let ParseObjPropWithOptChain () =
 
 [<Fact>]
 let ParseFuncDef () =
-  let src = "fn (x, y) { x }"
+  let src = "fn (x, y) { x };"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -166,7 +166,7 @@ let ParseFuncDef () =
 
 [<Fact>]
 let ParseFuncDefWithTypes () =
-  let src = "fn (x: number) -> number throws \"RangeError\" { x }"
+  let src = "fn (x: number) -> number throws \"RangeError\" { x };"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -174,7 +174,7 @@ let ParseFuncDefWithTypes () =
 
 [<Fact>]
 let ParseFuncDefWithTypeParams () =
-  let src = "fn <T: Foo = Bar>(x: T) -> T { x }"
+  let src = "fn <T: Foo = Bar>(x: T) -> T { x };"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -182,7 +182,7 @@ let ParseFuncDefWithTypeParams () =
 
 [<Fact>]
 let ParseTuple () =
-  let src = "[1, 2, 3]"
+  let src = "[1, 2, 3];"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -248,10 +248,10 @@ let ParseFunctionType () =
 let ParseObjLitAndObjPat () =
   let src =
     """
-    type Point = {x: number, y: number}
-    let {x, y}: Point = {x: 5, y: 10}
-    let p: Point = {x, y}
-    let foo = fn ({x, y}: Point) => x + y
+    type Point = {x: number, y: number};
+    let {x, y}: Point = {x: 5, y: 10};
+    let p: Point = {x, y};
+    let foo = fn ({x, y}: Point) => x + y;
     """
 
   let ast = Parser.parseScript src
@@ -263,8 +263,8 @@ let ParseObjLitAndObjPat () =
 let ParseObjRestSpread () =
   let src =
     """
-    let obj = {a: 5, b: "hello", c: true}
-    let {a, ...rest} = obj
+    let obj = {a: 5, b: "hello", c: true};
+    let {a, ...rest} = obj;
   """
 
   let ast = Parser.parseScript src
@@ -276,7 +276,7 @@ let ParseObjRestSpread () =
 let ParseOptionalProps () =
   let src =
     """
-    type Obj = {a?: {b?: {c?: number}}}
+    type Obj = {a?: {b?: {c?: number}}};
     """
 
   let ast = Parser.parseScript src
@@ -288,7 +288,7 @@ let ParseOptionalProps () =
 let ParseOptionalParams () =
   let src =
     """
-    let foo = fn(a?: number, b?: string) => a
+    let foo = fn(a?: number, b?: string) => a;
     """
 
   let ast = Parser.parseScript src
@@ -298,7 +298,7 @@ let ParseOptionalParams () =
 
 [<Fact>]
 let ParseArrowIdentifier () =
-  let src = "let fst = fn (x, y) => x"
+  let src = "let fst = fn (x, y) => x;"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -322,7 +322,7 @@ let ParseImports () =
 let ParseConditionalTypeAnn () =
   let src =
     """
-    type Exclude<T, U> = if T: U { never } else { T }
+    type Exclude<T, U> = if T: U { never } else { T };
     """
 
   let ast = Parser.parseScript src
@@ -334,7 +334,7 @@ let ParseConditionalTypeAnn () =
 let ParseChainedConditionalTypeAnn () =
   let src =
     """
-    type Foo<T> = if T: number { "number" } else if T: string { "string" } else { "other" }
+    type Foo<T> = if T: number { "number" } else if T: string { "string" } else { "other" };
     """
 
   let ast = Parser.parseScript src
@@ -344,7 +344,7 @@ let ParseChainedConditionalTypeAnn () =
 
 [<Fact>]
 let ParseMappedTypes () =
-  let src = """type Point = {[P]: number for P in "x" | "y"}"""
+  let src = """type Point = {[P]: number for P in "x" | "y"};"""
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -352,7 +352,7 @@ let ParseMappedTypes () =
 
 [<Fact>]
 let ParseIndexAccessTypes () =
-  let src = "type Foo = Bar[\"baz\"]"
+  let src = "type Foo = Bar[\"baz\"];"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -360,7 +360,7 @@ let ParseIndexAccessTypes () =
 
 [<Fact>]
 let ParseNamespacedType () =
-  let src = "type Foo = Intl.NumberFormat"
+  let src = "type Foo = Intl.NumberFormat;"
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -368,7 +368,7 @@ let ParseNamespacedType () =
 
 [<Fact>]
 let ParseNamespacedValue () =
-  let src = """let fmt = new Intl.NumberFormat("en-CA")"""
+  let src = """let fmt = new Intl.NumberFormat("en-CA");"""
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -379,9 +379,9 @@ let ParseAsyncFunc () =
   let src =
     """
     let bar = async fn () {
-      let x = await foo()
-      return x + 10
-    }
+      let x = await foo();
+      return x + 10;
+    };
     """
 
   let ast = Parser.parseScript src
@@ -395,18 +395,18 @@ let ParseThrowAndTryCatch () =
     """
     let foo = fn (x) {
       if x < 0 {
-        throw "x must be positive"
+        throw "x must be positive";
       }
-      return x
-    }
+      return x;
+    };
     let bar = fn (x) {
       let result = try {
-        foo(x)
+        foo(x);
       } catch {
         | _ => 0
-      }
-      return result
-    }
+      };
+      return result;
+    };
     """
 
   let ast = Parser.parseScript src
@@ -424,7 +424,7 @@ let ParsePatternMatching () =
         | 1 => "one"
         | n if n < 0 => "negative"
         | _ => "other"
-      }
+      };
     """
 
   let ast = Parser.parseScript src
@@ -465,7 +465,7 @@ let ParseEnum () =
       | Bar([number, number])
       | Baz(number | string)
     }
-    let value = MyEnum.Foo(5, "hello", true)
+    let value = MyEnum.Foo(5, "hello", true);
     """
 
   let ast = Parser.parseScript src
@@ -512,7 +512,7 @@ let ParseCallableType () =
     type Callable = {
       new fn () -> symbol,
       fn () -> symbol,
-    }
+    };
     """
 
   let ast = Parser.parseScript src
@@ -528,7 +528,7 @@ let ParsePropKeysInObjectType () =
       5: string,
       "hello": number,
       [Symbol.iterator]: fn () -> Iterator<T>,
-    }
+    };
     """
 
   let ast = Parser.parseScript src
@@ -541,7 +541,7 @@ let ParseForLoop () =
   let src =
     """
     for x in [1, 2, 3] {
-      print(x)
+      print(x);
     }
     """
 
@@ -567,8 +567,8 @@ let ParseDeclare () =
 let ParseRange () =
   let src =
     """
-    type DieRoll = 1..6
-    let range = 0..10
+    type DieRoll = 1..6;
+    let range = 0..10;
     """
 
   let ast = Parser.parseScript src
@@ -582,7 +582,7 @@ let ParseRangeIteratorType () =
     """
       type RangeIterator<Min: number, Max: number> = {
         next: fn () -> { done: boolean, value: Min..Max }
-      }
+      };
     """
 
   let ast = Parser.parseScript src
@@ -592,10 +592,7 @@ let ParseRangeIteratorType () =
 
 [<Fact>]
 let ParseTemplateLiteralType () =
-  let src =
-    """
-      type TemplateLiteral = `foo${number}`
-    """
+  let src = """type TemplateLiteral = `foo${number}`;"""
 
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
@@ -605,7 +602,7 @@ let ParseTemplateLiteralType () =
 [<Fact>]
 let ParseInferType () =
   let src =
-    "type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never }"
+    "type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never };"
 
   let ast = Parser.parseScript src
   let result = $"input: %s{src}\noutput: %A{ast}"
@@ -616,9 +613,9 @@ let ParseInferType () =
 let ParseRecordTuple () =
   let src =
     """
-    let p0 = #[5, 10]
-    let p1 = #{x: 5, y: 10}
-    let line = #{p0, p1}
+    let p0 = #[5, 10];
+    let p1 = #{x: 5, y: 10};
+    let line = #{p0, p1};
     """
 
   let ast = Parser.parseScript src
@@ -630,12 +627,12 @@ let ParseRecordTuple () =
 let ParseMutableBindings () =
   let src =
     """
-    type Point = {x: number, y: number}
-    type Line = {p0: Point, p1: Point}
+    type Point = {x: number, y: number};
+    type Line = {p0: Point, p1: Point};
     declare let line: Line
     
-    let {mut p0, p1: mut q} = line
-    let mut r = q
+    let {mut p0, p1: mut q} = line;
+    let mut r = q;
     """
 
   let ast = Parser.parseScript src
@@ -649,9 +646,9 @@ let ParseMutableParams () =
     """
     let update = fn (mut array: number[]) {
       for i in 0..array.length {
-        array[i] = array[i] + 1
+        array[i] = array[i] + 1;
       }
-    }
+    };
     """
 
   let ast = Parser.parseScript src
@@ -663,7 +660,7 @@ let ParseMutableParams () =
 let ParseTypeof () =
   let src =
     """
-    let iterator: typeof Symbol.iterator = Symbol.iterator
+    let iterator: typeof Symbol.iterator = Symbol.iterator;
     """
 
   let ast = Parser.parseScript src
@@ -707,10 +704,10 @@ let ParseBasicImpl () =
     """
     impl Foo {
       fn bar(self) {
-        return self.x
+        return self.x;
       }
       fn baz(mut self, x: number) {
-        self.x = x
+        self.x = x;
       }
     }
     """
@@ -726,10 +723,10 @@ let ParseImplWithStaticMethods () =
     """
     impl Point {
       fn new(x, y) {
-        return Point { x, y }
+        return Point { x, y };
       }
       fn default() {
-        return Point { x: 0, y: 0 }
+        return Point { x: 0, y: 0 };
       }
     }
     """
@@ -745,10 +742,10 @@ let ParseGenericImpl () =
     """
     impl Foo<T> {
       fn bar(self) {
-        return self.x
+        return self.x;
       }
       fn baz(mut self, x: T) {
-        self.x = x
+        self.x = x;
       }
     }
     """
@@ -764,10 +761,10 @@ let ParseGetterSetterImpl () =
     """
     impl Foo {
       get bar(self) {
-        return self.x
+        return self.x;
       }
       set bar(mut self, x: number) {
-        self.x = x
+        self.x = x;
       }
     }
     """
@@ -782,8 +779,8 @@ let ParseGetterSetterImpl () =
 let ParseStructExprs () =
   let src =
     """
-    let foo = Foo { a: 5, b: "hello" }
-    let bar = Bar<number> { a: 5, b: "hello" }
+    let foo = Foo { a: 5, b: "hello" };
+    let bar = Bar<number> { a: 5, b: "hello" };
     """
 
   let ast = Parser.parseScript src
@@ -795,7 +792,7 @@ let ParseStructExprs () =
 let ParseBasicStructPattern () =
   let src =
     """
-    let Point {x, y} = point
+    let Point {x, y} = point;
     """
 
   let ast = Parser.parseScript src
@@ -807,7 +804,7 @@ let ParseBasicStructPattern () =
 let ParseGenericStructPattern () =
   let src =
     """
-    let Point<number> {x, y} = point
+    let Point<number> {x, y} = point;
     """
 
   let ast = Parser.parseScript src

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -308,9 +308,9 @@ let ParseArrowIdentifier () =
 let ParseImports () =
   let src =
     """
-    import "./math" {add, sub as subtract}
-    import "~/net" as network
-    import "path"
+    import "./math" {add, sub as subtract};
+    import "~/net" as network;
+    import "path";
     """
 
   let ast = Parser.parseScript src
@@ -554,8 +554,8 @@ let ParseForLoop () =
 let ParseDeclare () =
   let src =
     """
-    declare let foo: number
-    declare let bar: string
+    declare let foo: number;
+    declare let bar: string;
     """
 
   let ast = Parser.parseScript src
@@ -629,7 +629,7 @@ let ParseMutableBindings () =
     """
     type Point = {x: number, y: number};
     type Line = {p0: Point, p1: Point};
-    declare let line: Line
+    declare let line: Line;
     
     let {mut p0, p1: mut q} = line;
     let mut r = q;

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseArithmetic.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseArithmetic.verified.txt
@@ -1,4 +1,4 @@
-﻿input: 0.1 + 2 * (3 - 4) / -5.6
+﻿input: 0.1 + 2 * (3 - 4) / -5.6;
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrowIdentifier.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrowIdentifier.verified.txt
@@ -1,4 +1,4 @@
-﻿input: let fst = fn (x, y) => x
+﻿input: let fst = fn (x, y) => x;
 output: Ok
   { Items =
      [Stmt
@@ -49,6 +49,6 @@ output: Ok
                                 Stop = (Ln: 1, Col: 25) }
                        InferredType = None } }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 25) } }
+                        Stop = (Ln: 1, Col: 26) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 25) } }] }
+                   Stop = (Ln: 1, Col: 26) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseAsyncFunc.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseAsyncFunc.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: 
     let bar = async fn () {
-      let x = await foo()
-      return x + 10
-    }
+      let x = await foo();
+      return x + 10;
+    };
     
 output: Ok
   { Items =
@@ -30,7 +30,7 @@ output: Ok
                             Body =
                              Block
                                { Span = { Start = (Ln: 2, Col: 27)
-                                          Stop = (Ln: 6, Col: 5) }
+                                          Stop = (Ln: 5, Col: 6) }
                                  Stmts =
                                   [{ Kind =
                                       Decl
@@ -71,12 +71,12 @@ output: Ok
                                                            { Start =
                                                               (Ln: 3, Col: 21)
                                                              Stop =
-                                                              (Ln: 4, Col: 7) }
+                                                              (Ln: 3, Col: 26) }
                                                           InferredType = None }
                                                        Throws = None }
                                                   Span =
                                                    { Start = (Ln: 3, Col: 21)
-                                                     Stop = (Ln: 4, Col: 7) }
+                                                     Stop = (Ln: 3, Col: 26) }
                                                   InferredType = None } }
                                           Span = { Start = (Ln: 3, Col: 7)
                                                    Stop = (Ln: 4, Col: 7) } }
@@ -97,15 +97,15 @@ output: Ok
                                                     Literal (Number (Int 10))
                                                    Span =
                                                     { Start = (Ln: 4, Col: 18)
-                                                      Stop = (Ln: 5, Col: 5) }
+                                                      Stop = (Ln: 4, Col: 20) }
                                                    InferredType = None })
                                              Span = { Start = (Ln: 4, Col: 14)
-                                                      Stop = (Ln: 5, Col: 5) }
+                                                      Stop = (Ln: 4, Col: 20) }
                                              InferredType = None })
                                      Span = { Start = (Ln: 4, Col: 7)
                                               Stop = (Ln: 5, Col: 5) } }] } }
                        Span = { Start = (Ln: 2, Col: 15)
-                                Stop = (Ln: 6, Col: 5) }
+                                Stop = (Ln: 5, Col: 6) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 6, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicImpl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicImpl.verified.txt
@@ -1,10 +1,10 @@
 ﻿input: 
     impl Foo {
       fn bar(self) {
-        return self.x
+        return self.x;
       }
       fn baz(mut self, x: number) {
-        self.x = x
+        self.x = x;
       }
     }
     
@@ -48,7 +48,7 @@ output: Ok
                                                      Stop = (Ln: 4, Col: 20) }
                                             InferredType = None }, "x", false)
                                       Span = { Start = (Ln: 4, Col: 16)
-                                               Stop = (Ln: 5, Col: 7) }
+                                               Stop = (Ln: 4, Col: 22) }
                                       InferredType = None })
                               Span = { Start = (Ln: 4, Col: 9)
                                        Stop = (Ln: 5, Col: 7) } }] } };
@@ -102,12 +102,12 @@ output: Ok
                                          InferredType = None },
                                        { Kind = Identifier "x"
                                          Span = { Start = (Ln: 7, Col: 18)
-                                                  Stop = (Ln: 8, Col: 7) }
+                                                  Stop = (Ln: 7, Col: 19) }
                                          InferredType = None })
                                    Span = { Start = (Ln: 7, Col: 9)
-                                            Stop = (Ln: 8, Col: 7) }
+                                            Stop = (Ln: 7, Col: 19) }
                                    InferredType = None }
                               Span = { Start = (Ln: 7, Col: 9)
-                                       Stop = (Ln: 8, Col: 7) } }] } }] }
+                                       Stop = (Ln: 7, Col: 19) } }] } }] }
           Span = { Start = (Ln: 2, Col: 5)
                    Stop = (Ln: 10, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicStructPattern.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    let Point {x, y} = point
+    let Point {x, y} = point;
     
 output: Ok
   { Items =
@@ -32,7 +32,7 @@ output: Ok
                     TypeAnn = None
                     Init = { Kind = Identifier "point"
                              Span = { Start = (Ln: 2, Col: 24)
-                                      Stop = (Ln: 3, Col: 5) }
+                                      Stop = (Ln: 2, Col: 29) }
                              InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallThenIndexer.verified.txt
@@ -1,4 +1,4 @@
-﻿input: foo()[0]
+﻿input: foo()[0];
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallWithTypeParam.verified.txt
@@ -1,4 +1,4 @@
-﻿input: add<number>()
+﻿input: add<number>();
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
@@ -2,7 +2,7 @@
     type Callable = {
       new fn () -> symbol,
       fn () -> symbol,
-    }
+    };
     
 output: Ok
   { Items =
@@ -40,7 +40,7 @@ output: Ok
                                   IsAsync = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 21)
-                                Stop = (Ln: 6, Col: 5) }
+                                Stop = (Ln: 5, Col: 6) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    type Foo<T> = if T: number { "number" } else if T: string { "string" } else { "other" }
+    type Foo<T> = if T: number { "number" } else if T: string { "string" } else { "other" };
     
 output: Ok
   { Items =
@@ -49,10 +49,10 @@ output: Ok
                                                 Stop = (Ln: 2, Col: 90) }
                                        InferredType = None } }
                                Span = { Start = (Ln: 2, Col: 50)
-                                        Stop = (Ln: 3, Col: 5) }
+                                        Stop = (Ln: 2, Col: 92) }
                                InferredType = None } }
                        Span = { Start = (Ln: 2, Col: 19)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 92) }
                        InferredType = None }
                     TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 14)
                                                   Stop = (Ln: 2, Col: 15) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    type Exclude<T, U> = if T: U { never } else { T }
+    type Exclude<T, U> = if T: U { never } else { T };
     
 output: Ok
   { Items =
@@ -32,7 +32,7 @@ output: Ok
                                                    Stop = (Ln: 2, Col: 53) }
                                           InferredType = None } }
                        Span = { Start = (Ln: 2, Col: 26)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 54) }
                        InferredType = None }
                     TypeParams =
                      Some

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCall.verified.txt
@@ -1,4 +1,4 @@
-﻿input: new Array()
+﻿input: new Array();
 output: Ok
   { Items =
      [Stmt
@@ -13,5 +13,5 @@ output: Ok
                   Span = { Start = (Ln: 1, Col: 5)
                            Stop = (Ln: 1, Col: 12) }
                   InferredType = None }
-          Span = { Start = (Ln: 1, Col: 1)
+          Span = { Start = (Ln: 1, Col: 5)
                    Stop = (Ln: 1, Col: 12) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCallWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCallWithTypeParam.verified.txt
@@ -1,4 +1,4 @@
-﻿input: new Array<number>()
+﻿input: new Array<number>();
 output: Ok
   { Items =
      [Stmt
@@ -18,5 +18,5 @@ output: Ok
                Span = { Start = (Ln: 1, Col: 5)
                         Stop = (Ln: 1, Col: 20) }
                InferredType = None }
-          Span = { Start = (Ln: 1, Col: 1)
+          Span = { Start = (Ln: 1, Col: 5)
                    Stop = (Ln: 1, Col: 20) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseDeclare.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseDeclare.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
-    declare let foo: number
-    declare let bar: string
+    declare let foo: number;
+    declare let bar: string;
     
 output: Ok
   { Items =
@@ -11,7 +11,7 @@ output: Ok
                              Stop = (Ln: 2, Col: 20) }
                     InferredType = None }, { Kind = Keyword Number
                                              Span = { Start = (Ln: 2, Col: 22)
-                                                      Stop = (Ln: 3, Col: 5) }
+                                                      Stop = (Ln: 2, Col: 28) }
                                              InferredType = None });
       DeclareLet ({ Kind = Ident { Name = "bar"
                                    IsMut = false
@@ -20,5 +20,5 @@ output: Ok
                              Stop = (Ln: 3, Col: 20) }
                     InferredType = None }, { Kind = Keyword String
                                              Span = { Start = (Ln: 3, Col: 22)
-                                                      Stop = (Ln: 4, Col: 5) }
+                                                      Stop = (Ln: 3, Col: 28) }
                                              InferredType = None })] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEmptyCall.verified.txt
@@ -1,4 +1,4 @@
-﻿input: add()
+﻿input: add();
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
@@ -4,7 +4,7 @@
       | Bar([number, number])
       | Baz(number | string)
     }
-    let value = MyEnum.Foo(5, "hello", true)
+    let value = MyEnum.Foo(5, "hello", true);
     
 output: Ok
   { Items =
@@ -107,7 +107,7 @@ output: Ok
                             OptChain = false
                             Throws = None }
                        Span = { Start = (Ln: 7, Col: 17)
-                                Stop = (Ln: 8, Col: 5) }
+                                Stop = (Ln: 7, Col: 45) }
                        InferredType = None } }
                Span = { Start = (Ln: 7, Col: 5)
                         Stop = (Ln: 8, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseExprWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseExprWithTypeParam.verified.txt
@@ -1,4 +1,4 @@
-﻿input: add<number | string>
+﻿input: add<number | string>;
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseForLoop.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseForLoop.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
     for x in [1, 2, 3] {
-      print(x)
+      print(x);
     }
     
 output: Ok
@@ -51,9 +51,9 @@ output: Ok
                                  OptChain = false
                                  Throws = None }
                          Span = { Start = (Ln: 3, Col: 7)
-                                  Stop = (Ln: 4, Col: 5) }
+                                  Stop = (Ln: 3, Col: 15) }
                          InferredType = None }
                     Span = { Start = (Ln: 3, Col: 7)
-                             Stop = (Ln: 4, Col: 5) } }] })
+                             Stop = (Ln: 3, Col: 15) } }] })
           Span = { Start = (Ln: 2, Col: 5)
                    Stop = (Ln: 5, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDef.verified.txt
@@ -1,4 +1,4 @@
-﻿input: fn (x, y) { x }
+﻿input: fn (x, y) { x };
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypeParams.verified.txt
@@ -1,4 +1,4 @@
-﻿input: fn <T: Foo = Bar>(x: T) -> T { x }
+﻿input: fn <T: Foo = Bar>(x: T) -> T { x };
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDefWithTypes.verified.txt
@@ -1,4 +1,4 @@
-﻿input: fn (x: number) -> number throws "RangeError" { x }
+﻿input: fn (x: number) -> number throws "RangeError" { x };
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCall.verified.txt
@@ -1,4 +1,4 @@
-﻿input: add(x, y)
+﻿input: add(x, y);
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionCallExtraSpaces.verified.txt
@@ -1,4 +1,4 @@
-﻿input: add( x , y )
+﻿input: add( x , y );
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericImpl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericImpl.verified.txt
@@ -1,10 +1,10 @@
 ﻿input: 
     impl Foo<T> {
       fn bar(self) {
-        return self.x
+        return self.x;
       }
       fn baz(mut self, x: T) {
-        self.x = x
+        self.x = x;
       }
     }
     
@@ -52,7 +52,7 @@ output: Ok
                                                      Stop = (Ln: 4, Col: 20) }
                                             InferredType = None }, "x", false)
                                       Span = { Start = (Ln: 4, Col: 16)
-                                               Stop = (Ln: 5, Col: 7) }
+                                               Stop = (Ln: 4, Col: 22) }
                                       InferredType = None })
                               Span = { Start = (Ln: 4, Col: 9)
                                        Stop = (Ln: 5, Col: 7) } }] } };
@@ -107,12 +107,12 @@ output: Ok
                                          InferredType = None },
                                        { Kind = Identifier "x"
                                          Span = { Start = (Ln: 7, Col: 18)
-                                                  Stop = (Ln: 8, Col: 7) }
+                                                  Stop = (Ln: 7, Col: 19) }
                                          InferredType = None })
                                    Span = { Start = (Ln: 7, Col: 9)
-                                            Stop = (Ln: 8, Col: 7) }
+                                            Stop = (Ln: 7, Col: 19) }
                                    InferredType = None }
                               Span = { Start = (Ln: 7, Col: 9)
-                                       Stop = (Ln: 8, Col: 7) } }] } }] }
+                                       Stop = (Ln: 7, Col: 19) } }] } }] }
           Span = { Start = (Ln: 2, Col: 5)
                    Stop = (Ln: 10, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericStructPattern.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    let Point<number> {x, y} = point
+    let Point<number> {x, y} = point;
     
 output: Ok
   { Items =
@@ -37,7 +37,7 @@ output: Ok
                     TypeAnn = None
                     Init = { Kind = Identifier "point"
                              Span = { Start = (Ln: 2, Col: 32)
-                                      Stop = (Ln: 3, Col: 5) }
+                                      Stop = (Ln: 2, Col: 37) }
                              InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGetterSetterImpl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGetterSetterImpl.verified.txt
@@ -1,10 +1,10 @@
 ﻿input: 
     impl Foo {
       get bar(self) {
-        return self.x
+        return self.x;
       }
       set bar(mut self, x: number) {
-        self.x = x
+        self.x = x;
       }
     }
     
@@ -41,7 +41,7 @@ output: Ok
                                                      Stop = (Ln: 4, Col: 20) }
                                             InferredType = None }, "x", false)
                                       Span = { Start = (Ln: 4, Col: 16)
-                                               Stop = (Ln: 5, Col: 7) }
+                                               Stop = (Ln: 4, Col: 22) }
                                       InferredType = None })
                               Span = { Start = (Ln: 4, Col: 9)
                                        Stop = (Ln: 5, Col: 7) } }] }
@@ -91,13 +91,13 @@ output: Ok
                                          InferredType = None },
                                        { Kind = Identifier "x"
                                          Span = { Start = (Ln: 7, Col: 18)
-                                                  Stop = (Ln: 8, Col: 7) }
+                                                  Stop = (Ln: 7, Col: 19) }
                                          InferredType = None })
                                    Span = { Start = (Ln: 7, Col: 9)
-                                            Stop = (Ln: 8, Col: 7) }
+                                            Stop = (Ln: 7, Col: 19) }
                                    InferredType = None }
                               Span = { Start = (Ln: 7, Col: 9)
-                                       Stop = (Ln: 8, Col: 7) } }] }
+                                       Stop = (Ln: 7, Col: 19) } }] }
                      Throws = None }] }
           Span = { Start = (Ln: 2, Col: 5)
                    Stop = (Ln: 10, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseImplWithStaticMethods.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseImplWithStaticMethods.verified.txt
@@ -1,10 +1,10 @@
 ﻿input: 
     impl Point {
       fn new(x, y) {
-        return Point { x, y }
+        return Point { x, y };
       }
       fn default() {
-        return Point { x: 0, y: 0 }
+        return Point { x: 0, y: 0 };
       }
     }
     
@@ -61,7 +61,7 @@ output: Ok
                                                ({ Start = (Ln: 4, Col: 27)
                                                   Stop = (Ln: 4, Col: 29) }, "y")] }
                                       Span = { Start = (Ln: 4, Col: 16)
-                                               Stop = (Ln: 5, Col: 7) }
+                                               Stop = (Ln: 4, Col: 30) }
                                       InferredType = None })
                               Span = { Start = (Ln: 4, Col: 9)
                                        Stop = (Ln: 5, Col: 7) } }] } };
@@ -107,7 +107,7 @@ output: Ok
                                                      Stop = (Ln: 7, Col: 35) }
                                                   InferredType = None })] }
                                       Span = { Start = (Ln: 7, Col: 16)
-                                               Stop = (Ln: 8, Col: 7) }
+                                               Stop = (Ln: 7, Col: 36) }
                                       InferredType = None })
                               Span = { Start = (Ln: 7, Col: 9)
                                        Stop = (Ln: 8, Col: 7) } }] } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseImports.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseImports.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
-    import "./math" {add, sub as subtract}
-    import "~/net" as network
-    import "path"
+    import "./math" {add, sub as subtract};
+    import "~/net" as network;
+    import "path";
     
 output: Ok
   { Items =

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
@@ -1,4 +1,4 @@
-﻿input: type Foo = Bar["baz"]
+﻿input: type Foo = Bar["baz"];
 output: Ok
   { Items =
      [Stmt
@@ -24,6 +24,6 @@ output: Ok
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 22) } }
+                        Stop = (Ln: 1, Col: 23) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 22) } }] }
+                   Stop = (Ln: 1, Col: 23) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexer.verified.txt
@@ -1,4 +1,4 @@
-﻿input: array[0]
+﻿input: array[0];
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexerThenCall.verified.txt
@@ -1,4 +1,4 @@
-﻿input: array[0]()
+﻿input: array[0]();
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -1,4 +1,4 @@
-﻿input: type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never }
+﻿input: type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never };
 output: Ok
   { Items =
      [Stmt
@@ -70,6 +70,6 @@ output: Ok
                                          Constraint = None
                                          Default = None }] }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 75) } }
+                        Stop = (Ln: 1, Col: 76) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 75) } }] }
+                   Stop = (Ln: 1, Col: 76) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
@@ -1,4 +1,4 @@
-﻿input: type Point = {[P]: number for P in "x" | "y"}
+﻿input: type Point = {[P]: number for P in "x" | "y"};
 output: Ok
   { Items =
      [Stmt
@@ -41,6 +41,6 @@ output: Ok
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 46) } }
+                        Stop = (Ln: 1, Col: 47) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 46) } }] }
+                   Stop = (Ln: 1, Col: 47) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMultipleIndexers.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMultipleIndexers.verified.txt
@@ -1,4 +1,4 @@
-﻿input: array[0][1]
+﻿input: array[0][1];
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
@@ -1,10 +1,10 @@
 ﻿input: 
-    type Point = {x: number, y: number}
-    type Line = {p0: Point, p1: Point}
+    type Point = {x: number, y: number};
+    type Line = {p0: Point, p1: Point};
     declare let line: Line
     
-    let {mut p0, p1: mut q} = line
-    let mut r = q
+    let {mut p0, p1: mut q} = line;
+    let mut r = q;
     
 output: Ok
   { Items =
@@ -36,7 +36,7 @@ output: Ok
                                   Readonly = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 18)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 40) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
@@ -75,7 +75,7 @@ output: Ok
                                   Readonly = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 3, Col: 17)
-                                Stop = (Ln: 4, Col: 5) }
+                                Stop = (Ln: 3, Col: 39) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 3, Col: 5)
@@ -126,7 +126,7 @@ output: Ok
                     TypeAnn = None
                     Init = { Kind = Identifier "line"
                              Span = { Start = (Ln: 6, Col: 31)
-                                      Stop = (Ln: 7, Col: 5) }
+                                      Stop = (Ln: 6, Col: 35) }
                              InferredType = None } }
                Span = { Start = (Ln: 6, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }
@@ -144,7 +144,7 @@ output: Ok
                                 TypeAnn = None
                                 Init = { Kind = Identifier "q"
                                          Span = { Start = (Ln: 7, Col: 17)
-                                                  Stop = (Ln: 8, Col: 5) }
+                                                  Stop = (Ln: 7, Col: 18) }
                                          InferredType = None } }
                Span = { Start = (Ln: 7, Col: 5)
                         Stop = (Ln: 8, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
     type Point = {x: number, y: number};
     type Line = {p0: Point, p1: Point};
-    declare let line: Line
+    declare let line: Line;
     
     let {mut p0, p1: mut q} = line;
     let mut r = q;
@@ -91,7 +91,7 @@ output: Ok
            InferredType = None }, { Kind = TypeRef { Ident = Ident "Line"
                                                      TypeArgs = None }
                                     Span = { Start = (Ln: 4, Col: 23)
-                                             Stop = (Ln: 6, Col: 5) }
+                                             Stop = (Ln: 4, Col: 27) }
                                     InferredType = None });
       Stmt
         { Kind =

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableParams.verified.txt
@@ -1,9 +1,9 @@
 ﻿input: 
     let update = fn (mut array: number[]) {
       for i in 0..array.length {
-        array[i] = array[i] + 1
+        array[i] = array[i] + 1;
       }
-    }
+    };
     
 output: Ok
   { Items =
@@ -51,7 +51,7 @@ output: Ok
                             Body =
                              Block
                                { Span = { Start = (Ln: 2, Col: 43)
-                                          Stop = (Ln: 7, Col: 5) }
+                                          Stop = (Ln: 6, Col: 6) }
                                  Stmts =
                                   [{ Kind =
                                       For
@@ -165,25 +165,26 @@ output: Ok
                                                                  { Start =
                                                                     (Ln: 4, Col: 31)
                                                                    Stop =
-                                                                    (Ln: 5, Col: 7) }
+                                                                    (Ln: 4, Col: 32) }
                                                                 InferredType =
                                                                  None })
                                                           Span =
                                                            { Start =
                                                               (Ln: 4, Col: 20)
                                                              Stop =
-                                                              (Ln: 5, Col: 7) }
+                                                              (Ln: 4, Col: 32) }
                                                           InferredType = None })
                                                     Span =
                                                      { Start = (Ln: 4, Col: 9)
-                                                       Stop = (Ln: 5, Col: 7) }
+                                                       Stop = (Ln: 4, Col: 32) }
                                                     InferredType = None }
-                                               Span = { Start = (Ln: 4, Col: 9)
-                                                        Stop = (Ln: 5, Col: 7) } }] })
+                                               Span =
+                                                { Start = (Ln: 4, Col: 9)
+                                                  Stop = (Ln: 4, Col: 32) } }] })
                                      Span = { Start = (Ln: 3, Col: 7)
                                               Stop = (Ln: 6, Col: 5) } }] } }
                        Span = { Start = (Ln: 2, Col: 18)
-                                Stop = (Ln: 7, Col: 5) }
+                                Stop = (Ln: 6, Col: 6) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedType.verified.txt
@@ -1,4 +1,4 @@
-﻿input: type Foo = Intl.NumberFormat
+﻿input: type Foo = Intl.NumberFormat;
 output: Ok
   { Items =
      [Stmt
@@ -16,6 +16,6 @@ output: Ok
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 29) } }
+                        Stop = (Ln: 1, Col: 30) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 29) } }] }
+                   Stop = (Ln: 1, Col: 30) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedValue.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedValue.verified.txt
@@ -1,4 +1,4 @@
-﻿input: let fmt = new Intl.NumberFormat("en-CA")
+﻿input: let fmt = new Intl.NumberFormat("en-CA");
 output: Ok
   { Items =
      [Stmt
@@ -37,6 +37,6 @@ output: Ok
                                 Stop = (Ln: 1, Col: 41) }
                        InferredType = None } }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 41) } }
+                        Stop = (Ln: 1, Col: 42) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 41) } }] }
+                   Stop = (Ln: 1, Col: 42) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: 
-    type Point = {x: number, y: number}
-    let {x, y}: Point = {x: 5, y: 10}
-    let p: Point = {x, y}
-    let foo = fn ({x, y}: Point) => x + y
+    type Point = {x: number, y: number};
+    let {x, y}: Point = {x: 5, y: 10};
+    let p: Point = {x, y};
+    let foo = fn ({x, y}: Point) => x + y;
     
 output: Ok
   { Items =
@@ -34,7 +34,7 @@ output: Ok
                                   Readonly = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 18)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 40) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
@@ -91,7 +91,7 @@ output: Ok
                                    InferredType = None })]
                             Immutable = false }
                        Span = { Start = (Ln: 3, Col: 25)
-                                Stop = (Ln: 4, Col: 5) }
+                                Stop = (Ln: 3, Col: 38) }
                        InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
@@ -123,7 +123,7 @@ output: Ok
                                            Stop = (Ln: 4, Col: 25) }, "y")]
                             Immutable = false }
                        Span = { Start = (Ln: 4, Col: 20)
-                                Stop = (Ln: 5, Col: 5) }
+                                Stop = (Ln: 4, Col: 26) }
                        InferredType = None } }
                Span = { Start = (Ln: 4, Col: 5)
                         Stop = (Ln: 5, Col: 5) } }
@@ -193,13 +193,13 @@ output: Ok
                                             InferredType = None },
                                      { Kind = Identifier "y"
                                        Span = { Start = (Ln: 5, Col: 41)
-                                                Stop = (Ln: 6, Col: 5) }
+                                                Stop = (Ln: 5, Col: 42) }
                                        InferredType = None })
                                  Span = { Start = (Ln: 5, Col: 37)
-                                          Stop = (Ln: 6, Col: 5) }
+                                          Stop = (Ln: 5, Col: 42) }
                                  InferredType = None } }
                        Span = { Start = (Ln: 5, Col: 15)
-                                Stop = (Ln: 6, Col: 5) }
+                                Stop = (Ln: 5, Col: 42) }
                        InferredType = None } }
                Span = { Start = (Ln: 5, Col: 5)
                         Stop = (Ln: 6, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjPropWithOptChain.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjPropWithOptChain.verified.txt
@@ -1,4 +1,4 @@
-﻿input: obj?.a?.b
+﻿input: obj?.a?.b;
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjProperty.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjProperty.verified.txt
@@ -1,4 +1,4 @@
-﻿input: obj.a.b
+﻿input: obj.a.b;
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
-    let obj = {a: 5, b: "hello", c: true}
-    let {a, ...rest} = obj
+    let obj = {a: 5, b: "hello", c: true};
+    let {a, ...rest} = obj;
   
 output: Ok
   { Items =
@@ -43,7 +43,7 @@ output: Ok
                                    InferredType = None })]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 15)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 42) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
@@ -81,7 +81,7 @@ output: Ok
                     TypeAnn = None
                     Init = { Kind = Identifier "obj"
                              Span = { Start = (Ln: 3, Col: 24)
-                                      Stop = (Ln: 4, Col: 3) }
+                                      Stop = (Ln: 3, Col: 27) }
                              InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 3) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalParams.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    let foo = fn(a?: number, b?: string) => a
+    let foo = fn(a?: number, b?: string) => a;
     
 output: Ok
   { Items =
@@ -53,10 +53,10 @@ output: Ok
                                IsAsync = false }
                             Body = Expr { Kind = Identifier "a"
                                           Span = { Start = (Ln: 2, Col: 45)
-                                                   Stop = (Ln: 3, Col: 5) }
+                                                   Stop = (Ln: 2, Col: 46) }
                                           InferredType = None } }
                        Span = { Start = (Ln: 2, Col: 15)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 46) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    type Obj = {a?: {b?: {c?: number}}}
+    type Obj = {a?: {b?: {c?: number}}};
     
 output: Ok
   { Items =
@@ -54,7 +54,7 @@ output: Ok
                                   Readonly = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 16)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 40) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOtherLiterals.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOtherLiterals.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
-    let a = undefined
-    let b = null
+    let a = undefined;
+    let b = null;
     
 output: Ok
   { Items =

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePatternMatching.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePatternMatching.verified.txt
@@ -5,7 +5,7 @@
         | 1 => "one"
         | n if n < 0 => "negative"
         | _ => "other"
-      }
+      };
     
 output: Ok
   { Items =
@@ -127,10 +127,10 @@ output: Ok
                                                       Stop = (Ln: 7, Col: 23) }
                                              InferredType = None } }])
                                  Span = { Start = (Ln: 3, Col: 7)
-                                          Stop = (Ln: 9, Col: 5) }
+                                          Stop = (Ln: 8, Col: 8) }
                                  InferredType = None } }
                        Span = { Start = (Ln: 2, Col: 15)
-                                Stop = (Ln: 9, Col: 5) }
+                                Stop = (Ln: 8, Col: 8) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 9, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
@@ -3,7 +3,7 @@
       5: string,
       "hello": number,
       [Symbol.iterator]: fn () -> Iterator<T>,
-    }
+    };
     
 output: Ok
   { Items =
@@ -80,7 +80,7 @@ output: Ok
                                   Readonly = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 18)
-                                Stop = (Ln: 7, Col: 5) }
+                                Stop = (Ln: 6, Col: 6) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
-    type DieRoll = 1..6
-    let range = 0..10
+    type DieRoll = 1..6;
+    let range = 0..10;
     
 output: Ok
   { Items =
@@ -17,10 +17,10 @@ output: Ok
                                               InferredType = None }
                                       Max = { Kind = Literal (Number (Int 6))
                                               Span = { Start = (Ln: 2, Col: 23)
-                                                       Stop = (Ln: 3, Col: 5) }
+                                                       Stop = (Ln: 2, Col: 24) }
                                               InferredType = None } }
                        Span = { Start = (Ln: 2, Col: 20)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 24) }
                        InferredType = None }
                     TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
@@ -46,10 +46,10 @@ output: Ok
                                               InferredType = None }
                                       Max = { Kind = Literal (Number (Int 10))
                                               Span = { Start = (Ln: 3, Col: 20)
-                                                       Stop = (Ln: 4, Col: 5) }
+                                                       Stop = (Ln: 3, Col: 22) }
                                               InferredType = None } }
                        Span = { Start = (Ln: 3, Col: 17)
-                                Stop = (Ln: 4, Col: 5) }
+                                Stop = (Ln: 3, Col: 22) }
                        InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
       type RangeIterator<Min: number, Max: number> = {
         next: fn () -> { done: boolean, value: Min..Max }
-      }
+      };
     
 output: Ok
   { Items =
@@ -96,7 +96,7 @@ output: Ok
                                   Readonly = false }]
                             Immutable = false }
                        Span = { Start = (Ln: 2, Col: 54)
-                                Stop = (Ln: 5, Col: 5) }
+                                Stop = (Ln: 4, Col: 8) }
                        InferredType = None }
                     TypeParams =
                      Some

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecordTuple.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecordTuple.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
-    let p0 = #[5, 10]
-    let p1 = #{x: 5, y: 10}
-    let line = #{p0, p1}
+    let p0 = #[5, 10];
+    let p1 = #{x: 5, y: 10};
+    let line = #{p0, p1};
     
 output: Ok
   { Items =
@@ -31,7 +31,7 @@ output: Ok
                                 InferredType = None }]
                             Immutable = true }
                        Span = { Start = (Ln: 2, Col: 14)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 22) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
@@ -69,7 +69,7 @@ output: Ok
                                    InferredType = None })]
                             Immutable = true }
                        Span = { Start = (Ln: 3, Col: 14)
-                                Stop = (Ln: 4, Col: 5) }
+                                Stop = (Ln: 3, Col: 28) }
                        InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
@@ -97,7 +97,7 @@ output: Ok
                                            Stop = (Ln: 4, Col: 24) }, "p1")]
                             Immutable = true }
                        Span = { Start = (Ln: 4, Col: 16)
-                                Stop = (Ln: 5, Col: 5) }
+                                Stop = (Ln: 4, Col: 25) }
                        InferredType = None } }
                Span = { Start = (Ln: 4, Col: 5)
                         Stop = (Ln: 5, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
@@ -1,4 +1,4 @@
-﻿input: let msg = "Hello,\n\t\"world!\"" 
+﻿input: let msg = "Hello,\n\t\"world!\"";
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseStructExprs.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
-    let foo = Foo { a: 5, b: "hello" }
-    let bar = Bar<number> { a: 5, b: "hello" }
+    let foo = Foo { a: 5, b: "hello" };
+    let bar = Bar<number> { a: 5, b: "hello" };
     
 output: Ok
   { Items =
@@ -37,7 +37,7 @@ output: Ok
                                             Stop = (Ln: 2, Col: 37) }
                                    InferredType = None })] }
                        Span = { Start = (Ln: 2, Col: 15)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 39) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
@@ -81,7 +81,7 @@ output: Ok
                                             Stop = (Ln: 3, Col: 45) }
                                    InferredType = None })] }
                        Span = { Start = (Ln: 3, Col: 15)
-                                Stop = (Ln: 4, Col: 5) }
+                                Stop = (Ln: 3, Col: 47) }
                        InferredType = None } }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
@@ -1,6 +1,4 @@
-﻿input: 
-      type TemplateLiteral = `foo${number}`
-    
+﻿input: type TemplateLiteral = `foo${number}`;
 output: Ok
   { Items =
      [Stmt
@@ -14,14 +12,14 @@ output: Ok
                         TemplateLiteral
                           { Parts = ["foo"; ""]
                             Exprs = [{ Kind = Keyword Number
-                                       Span = { Start = (Ln: 2, Col: 36)
-                                                Stop = (Ln: 2, Col: 42) }
+                                       Span = { Start = (Ln: 1, Col: 30)
+                                                Stop = (Ln: 1, Col: 36) }
                                        InferredType = None }] }
-                       Span = { Start = (Ln: 2, Col: 30)
-                                Stop = (Ln: 2, Col: 44) }
+                       Span = { Start = (Ln: 1, Col: 24)
+                                Stop = (Ln: 1, Col: 38) }
                        InferredType = None }
                     TypeParams = None }
-               Span = { Start = (Ln: 2, Col: 7)
-                        Stop = (Ln: 3, Col: 5) } }
-          Span = { Start = (Ln: 2, Col: 7)
-                   Stop = (Ln: 3, Col: 5) } }] }
+               Span = { Start = (Ln: 1, Col: 1)
+                        Stop = (Ln: 1, Col: 39) } }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 39) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateString.verified.txt
@@ -1,4 +1,4 @@
-﻿input: let msg = `foo ${`bar ${baz}`}`
+﻿input: let msg = `foo ${`bar ${baz}`}`;
 output: Ok
   { Items =
      [Stmt
@@ -33,6 +33,6 @@ output: Ok
                                 Stop = (Ln: 1, Col: 32) }
                        InferredType = None } }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 32) } }
+                        Stop = (Ln: 1, Col: 33) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 32) } }] }
+                   Stop = (Ln: 1, Col: 33) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseThrowAndTryCatch.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseThrowAndTryCatch.verified.txt
@@ -1,18 +1,18 @@
 ﻿input: 
     let foo = fn (x) {
       if x < 0 {
-        throw "x must be positive"
+        throw "x must be positive";
       }
-      return x
-    }
+      return x;
+    };
     let bar = fn (x) {
       let result = try {
-        foo(x)
+        foo(x);
       } catch {
         | _ => 0
-      }
-      return result
-    }
+      };
+      return result;
+    };
     
 output: Ok
   { Items =
@@ -50,7 +50,7 @@ output: Ok
                             Body =
                              Block
                                { Span = { Start = (Ln: 2, Col: 22)
-                                          Stop = (Ln: 8, Col: 5) }
+                                          Stop = (Ln: 7, Col: 6) }
                                  Stmts =
                                   [{ Kind =
                                       Expr
@@ -99,11 +99,11 @@ output: Ok
                                                           { Start =
                                                              (Ln: 4, Col: 9)
                                                             Stop =
-                                                             (Ln: 5, Col: 7) }
+                                                             (Ln: 4, Col: 35) }
                                                          InferredType = None }
                                                     Span =
                                                      { Start = (Ln: 4, Col: 9)
-                                                       Stop = (Ln: 5, Col: 7) } }] },
+                                                       Stop = (Ln: 4, Col: 35) } }] },
                                               None)
                                           Span = { Start = (Ln: 3, Col: 7)
                                                    Stop = (Ln: 6, Col: 7) }
@@ -115,12 +115,12 @@ output: Ok
                                         (Some
                                            { Kind = Identifier "x"
                                              Span = { Start = (Ln: 6, Col: 14)
-                                                      Stop = (Ln: 7, Col: 5) }
+                                                      Stop = (Ln: 6, Col: 15) }
                                              InferredType = None })
                                      Span = { Start = (Ln: 6, Col: 7)
                                               Stop = (Ln: 7, Col: 5) } }] } }
                        Span = { Start = (Ln: 2, Col: 15)
-                                Stop = (Ln: 8, Col: 5) }
+                                Stop = (Ln: 7, Col: 6) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 8, Col: 5) } }
@@ -160,7 +160,7 @@ output: Ok
                             Body =
                              Block
                                { Span = { Start = (Ln: 8, Col: 22)
-                                          Stop = (Ln: 16, Col: 5) }
+                                          Stop = (Ln: 15, Col: 6) }
                                  Stmts =
                                   [{ Kind =
                                       Decl
@@ -222,14 +222,14 @@ output: Ok
                                                                     { Start =
                                                                        (Ln: 10, Col: 9)
                                                                       Stop =
-                                                                       (Ln: 11, Col: 7) }
+                                                                       (Ln: 10, Col: 15) }
                                                                    InferredType =
                                                                     None }
                                                               Span =
                                                                { Start =
                                                                   (Ln: 10, Col: 9)
                                                                  Stop =
-                                                                  (Ln: 11, Col: 7) } }] }
+                                                                  (Ln: 10, Col: 15) } }] }
                                                        Catch =
                                                         Some
                                                           [{ Span =
@@ -270,7 +270,7 @@ output: Ok
                                                        Throws = None }
                                                   Span =
                                                    { Start = (Ln: 9, Col: 20)
-                                                     Stop = (Ln: 14, Col: 7) }
+                                                     Stop = (Ln: 13, Col: 8) }
                                                   InferredType = None } }
                                           Span = { Start = (Ln: 9, Col: 7)
                                                    Stop = (Ln: 14, Col: 7) } }
@@ -281,12 +281,12 @@ output: Ok
                                         (Some
                                            { Kind = Identifier "result"
                                              Span = { Start = (Ln: 14, Col: 14)
-                                                      Stop = (Ln: 15, Col: 5) }
+                                                      Stop = (Ln: 14, Col: 20) }
                                              InferredType = None })
                                      Span = { Start = (Ln: 14, Col: 7)
                                               Stop = (Ln: 15, Col: 5) } }] } }
                        Span = { Start = (Ln: 8, Col: 15)
-                                Stop = (Ln: 16, Col: 5) }
+                                Stop = (Ln: 15, Col: 6) }
                        InferredType = None } }
                Span = { Start = (Ln: 8, Col: 5)
                         Stop = (Ln: 16, Col: 5) } }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTuple.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTuple.verified.txt
@@ -1,4 +1,4 @@
-﻿input: [1, 2, 3]
+﻿input: [1, 2, 3];
 output: Ok
   { Items =
      [Stmt

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTypeof.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTypeof.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    let iterator: typeof Symbol.iterator = Symbol.iterator
+    let iterator: typeof Symbol.iterator = Symbol.iterator;
     
 output: Ok
   { Items =
@@ -26,7 +26,7 @@ output: Ok
                                            Stop = (Ln: 2, Col: 50) }
                                   InferredType = None }, "iterator", false)
                        Span = { Start = (Ln: 2, Col: 44)
-                                Stop = (Ln: 3, Col: 5) }
+                                Stop = (Ln: 2, Col: 59) }
                        InferredType = None } }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -1532,7 +1532,7 @@ module Parser =
     pipe4
       getPosition
       (strWs "import" >>. _string .>> ws)
-      (opt importSpecifiers)
+      (opt importSpecifiers .>> (strWs ";"))
       getPosition
     <| fun start source specifiers stop ->
       { Path = source
@@ -1542,7 +1542,7 @@ module Parser =
     pipe4
       getPosition
       (strWs "declare" >>. strWs "let" >>. pattern)
-      (strWs ":" >>. ws >>. typeAnn)
+      (strWs ":" >>. ws >>. typeAnn .>> (strWs ";"))
       getPosition
     <| fun start pattern typeAnn stop -> ScriptItem.DeclareLet(pattern, typeAnn)
 

--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -246,7 +246,7 @@ let InferRangeMath () =
     result {
       let src =
         """
-        declare let range: 0..3
+        declare let range: 0..3;
         let inc_range = range + 1;
         let dec_range = range - 1;
         let mul_range = 2 * range;
@@ -269,14 +269,14 @@ let InferRangeWithArrayLength () =
     result {
       let src =
         """
-        declare let array: number[]
+        declare let array: number[];
 
         let length = array.length;
         for x in 0..length {
           let item: number = array[x];
         }
         
-        declare let range: 0..(typeof length)
+        declare let range: 0..(typeof length);
         let elem = array[range];
         
         let first = array[0];
@@ -298,14 +298,14 @@ let InferRangeWithDifferentArrayLengths () =
     result {
       let src =
         """
-        declare let array1: number[]
-        declare let array2: string[]
+        declare let array1: number[];
+        declare let array2: string[];
         
         let length1 = array1.length;
         let length2 = array2.length;
         
-        declare let range1: 0..(typeof length1)
-        declare let range2: 0..(typeof length2)
+        declare let range1: 0..(typeof length1);
+        declare let range2: 0..(typeof length2);
         
         let elem1 = array1[range1];
         let elem2 = array2[range2];
@@ -325,14 +325,14 @@ let InferRangeWithDifferentArrayLengthsAreIncompatible () =
     result {
       let src =
         """
-        declare let array1: number[]
-        declare let array2: string[]
+        declare let array1: number[];
+        declare let array2: string[];
         
         let length1 = array1.length;
         let length2 = array2.length;
         
-        declare let range1: 0..(typeof length1)
-        declare let range2: 0..(typeof length2)
+        declare let range1: 0..(typeof length1);
+        declare let range2: 0..(typeof length2);
         
         let elem1 = array1[range2];
         let elem2 = array2[range1];
@@ -351,8 +351,8 @@ let InferDestructureArray () =
     result {
       let src =
         """
-        declare let array: number[]
-        declare let tuple: [number, string, boolean]
+        declare let array: number[];
+        declare let tuple: [number, string, boolean];
         
         let [a, ...rest] = array;
         """
@@ -372,7 +372,7 @@ let InferDestructureTuple () =
     result {
       let src =
         """
-        declare let tuple: [number, string, boolean]
+        declare let tuple: [number, string, boolean];
         
         let [a, ...rest] = tuple;
         """
@@ -453,7 +453,7 @@ let ImmutableTuplesAreIncompatibleWithRegularTuples () =
     result {
       let src =
         """
-        declare let foo: fn (point: #[number, number]) -> undefined
+        declare let foo: fn (point: #[number, number]) -> undefined;
         foo([5, 10]);
         """
 
@@ -470,7 +470,7 @@ let ImmutableObjectsAreIncompatibleWithRegularObjects () =
     result {
       let src =
         """
-        declare let foo: fn (point: #{x:number, x:number}) -> undefined
+        declare let foo: fn (point: #{x:number, x:number}) -> undefined;
         foo({x:5, y:10});
         """
 
@@ -488,7 +488,7 @@ let DescructuringArray () =
     result {
       let src =
         """
-        declare let array: number[]
+        declare let array: number[];
         let [a, b] = array;
         """
 

--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -30,7 +30,7 @@ let inferScript src =
       """
         type RangeIterator<Min: number, Max: number> = {
           next: fn () -> { done: boolean, value: Min..Max }
-        }
+        };
       """
 
     let! ast =
@@ -55,8 +55,8 @@ let InferTupleLength () =
     result {
       let src =
         """
-        let tuple = [5, "hello", true]
-        let length = tuple.length
+        let tuple = [5, "hello", true];
+        let length = tuple.length;
         """
 
       let! _, env = inferScript src
@@ -73,8 +73,8 @@ let InferArrayLength () =
     result {
       let src =
         """
-        let array: number[] = [1, 2, 3]
-        let length = array.length
+        let array: number[] = [1, 2, 3];
+        let length = array.length;
         """
 
       let! _, env = inferScript src
@@ -91,11 +91,11 @@ let InferTupleIndexing () =
     result {
       let src =
         """
-        let tuple = [5, "hello", true]
-        let first = tuple[0]
-        let second = tuple[1]
-        let third = tuple[2]
-        let fourth = tuple[3]
+        let tuple = [5, "hello", true];
+        let first = tuple[0];
+        let second = tuple[1];
+        let third = tuple[2];
+        let fourth = tuple[3];
         """
 
       let! _, env = inferScript src
@@ -115,11 +115,11 @@ let InferArrayIndexing () =
     result {
       let src =
         """
-        let array: number[] = [1, 2, 3]
-        let first = array[0]
-        let second = array[1]
-        let third = array[2]
-        let fourth = array[3]
+        let array: number[] = [1, 2, 3];
+        let first = array[0];
+        let second = array[1];
+        let third = array[2];
+        let fourth = array[3];
         """
 
       let! _, env = inferScript src
@@ -138,11 +138,11 @@ let InferForIn () =
       let src =
         """
         for x in [1, 2, 3] {
-          let y: number = x
+          let y: number = x;
         }
-        let array: number[] = [1, 2, 3]
+        let array: number[] = [1, 2, 3];
         for x in array {
-          let y: number = x
+          let y: number = x;
         }
         """
 
@@ -160,9 +160,9 @@ let InferForInRange () =
       let src =
         """
         for x in 0..3 {
-          let a: number = x
-          let b: 0..10 = x
-          let c: 0..3 = x
+          let a: number = x;
+          let b: 0..10 = x;
+          let c: 0..3 = x;
         }
         """
 
@@ -179,9 +179,9 @@ let InferRangeTypeAssignment () =
     result {
       let src =
         """
-        let a: 0..3 = 0
-        let b: 0..3 = 1
-        let c: 0..3 = 2
+        let a: 0..3 = 0;
+        let b: 0..3 = 1;
+        let c: 0..3 = 2;
         """
 
       let! _ = inferScript src
@@ -197,7 +197,7 @@ let InferOutOfBoundsRangeLiteralAssignment () =
     result {
       let src =
         """
-        let out_of_bounds: 0..3 = 3
+        let out_of_bounds: 0..3 = 3;
         """
 
       let! _ = inferScript src
@@ -213,8 +213,8 @@ let InferOutOfBoundsRangeRangeAssignment () =
     result {
       let src =
         """
-        let range: 0..10 = 0
-        let bounds_mismatch: 0..3 = range
+        let range: 0..10 = 0;
+        let bounds_mismatch: 0..3 = range;
         """
 
       let! _ = inferScript src
@@ -230,7 +230,7 @@ let InferRangeWithNegativeStart () =
     result {
       let src =
         """
-        declare let range: -1..1
+        declare let range: -1..1;
         """
 
       let! _, env = inferScript src
@@ -247,10 +247,10 @@ let InferRangeMath () =
       let src =
         """
         declare let range: 0..3
-        let inc_range = range + 1
-        let dec_range = range - 1
-        let mul_range = 2 * range
-        let range_plus_range = range + range
+        let inc_range = range + 1;
+        let dec_range = range - 1;
+        let mul_range = 2 * range;
+        let range_plus_range = range + range;
         """
 
       let! _, env = inferScript src
@@ -271,15 +271,15 @@ let InferRangeWithArrayLength () =
         """
         declare let array: number[]
 
-        let length = array.length
+        let length = array.length;
         for x in 0..length {
-          let item: number = array[x]
+          let item: number = array[x];
         }
         
         declare let range: 0..(typeof length)
-        let elem = array[range]
+        let elem = array[range];
         
-        let first = array[0]
+        let first = array[0];
         """
 
       let! _, env = inferScript src
@@ -301,14 +301,14 @@ let InferRangeWithDifferentArrayLengths () =
         declare let array1: number[]
         declare let array2: string[]
         
-        let length1 = array1.length
-        let length2 = array2.length
+        let length1 = array1.length;
+        let length2 = array2.length;
         
         declare let range1: 0..(typeof length1)
         declare let range2: 0..(typeof length2)
         
-        let elem1 = array1[range1]
-        let elem2 = array2[range2]
+        let elem1 = array1[range1];
+        let elem2 = array2[range2];
         """
 
       let! _, env = inferScript src
@@ -328,14 +328,14 @@ let InferRangeWithDifferentArrayLengthsAreIncompatible () =
         declare let array1: number[]
         declare let array2: string[]
         
-        let length1 = array1.length
-        let length2 = array2.length
+        let length1 = array1.length;
+        let length2 = array2.length;
         
         declare let range1: 0..(typeof length1)
         declare let range2: 0..(typeof length2)
         
-        let elem1 = array1[range2]
-        let elem2 = array2[range1]
+        let elem1 = array1[range2];
+        let elem2 = array2[range1];
         """
 
       let! _, env = inferScript src
@@ -354,7 +354,7 @@ let InferDestructureArray () =
         declare let array: number[]
         declare let tuple: [number, string, boolean]
         
-        let [a, ...rest] = array
+        let [a, ...rest] = array;
         """
 
       let! _, env = inferScript src
@@ -374,7 +374,7 @@ let InferDestructureTuple () =
         """
         declare let tuple: [number, string, boolean]
         
-        let [a, ...rest] = tuple
+        let [a, ...rest] = tuple;
         """
 
       let! _, env = inferScript src
@@ -390,8 +390,8 @@ let InferBasicImmutableTypes () =
     result {
       let src =
         """
-        let tuple = #[5, "hello", true]
-        let record = #{ a: 5, b: "hello", c: true }
+        let tuple = #[5, "hello", true];
+        let record = #{ a: 5, b: "hello", c: true };
         """
 
       let! _, env = inferScript src
@@ -409,10 +409,10 @@ let DestructuringImmutableTypes () =
     result {
       let src =
         """
-        let [a, b] = #[5, "hello"]
-        let #[c, d] = #[5, "hello"]
-        let {e, f} = #{e: 5, f: "hello"}
-        let #{g, h} = #{g: 5, h: "hello"}
+        let [a, b] = #[5, "hello"];
+        let #[c, d] = #[5, "hello"];
+        let {e, f} = #{e: 5, f: "hello"};
+        let #{g, h} = #{g: 5, h: "hello"};
         """
 
       let! _, env = inferScript src
@@ -435,8 +435,8 @@ let PartialDestructuring () =
     result {
       let src =
         """
-        let [a] = [5, "hello"]
-        let {b} = {a: 5, b: "hello"}
+        let [a] = [5, "hello"];
+        let {b} = {a: 5, b: "hello"};
         """
 
       let! _, env = inferScript src
@@ -454,7 +454,7 @@ let ImmutableTuplesAreIncompatibleWithRegularTuples () =
       let src =
         """
         declare let foo: fn (point: #[number, number]) -> undefined
-        foo([5, 10])
+        foo([5, 10]);
         """
 
       let! ctx, env = inferScript src
@@ -471,7 +471,7 @@ let ImmutableObjectsAreIncompatibleWithRegularObjects () =
       let src =
         """
         declare let foo: fn (point: #{x:number, x:number}) -> undefined
-        foo({x:5, y:10})
+        foo({x:5, y:10});
         """
 
       let! ctx, env = inferScript src
@@ -489,7 +489,7 @@ let DescructuringArray () =
       let src =
         """
         declare let array: number[]
-        let [a, b] = array
+        let [a, b] = array;
         """
 
       let! _, env = inferScript src

--- a/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
+++ b/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
@@ -12,12 +12,12 @@ let InfersAsyncFunc () =
       let src =
         """
         let foo = async fn () {
-          return 5
-        }
+          return 5;
+        };
         let bar = async fn () {
-          let x = await foo()
-          return x + await 10
-        }
+          let x = await foo();
+          return x + await 10;
+        };
         """
 
       let! _, env = inferScript src
@@ -34,7 +34,7 @@ let InfersAsyncError () =
     result {
       let src =
         """
-        let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x }
+        let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x };
         """
 
       let! _, env = inferScript src
@@ -54,11 +54,11 @@ let InfersPropagateAsyncError () =
     result {
       let src =
         """
-        let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x }
+        let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x };
         let bar = async fn (x) {
-          let y = await foo(x)
-          return y + await 10
-        }
+          let y = await foo(x);
+          return y + await 10;
+        };
         """
 
       let! _, env = inferScript src
@@ -84,14 +84,14 @@ let InfersTryCatchAsync () =
     result {
       let src =
         """
-        let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x }
+        let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x };
         let bar = async fn (x) =>
           try {
-            let y = await foo(x)
-            y + await 10
+            let y = await foo(x);
+            y + await 10;
           } catch {
             | "RangeError" => 0
-          }
+          };
         """
 
       let! _, env = inferScript src

--- a/src/Escalier.TypeChecker.Tests/Exceptions.fs
+++ b/src/Escalier.TypeChecker.Tests/Exceptions.fs
@@ -13,10 +13,10 @@ let InfersExplicitThrow () =
         """
         let foo = fn (x) {
           if x < 0 {
-            throw "RangeError"
+            throw "RangeError";
           }
-          return x
-        }
+          return x;
+        };
         """
 
       let! _, env = inferScript src
@@ -38,7 +38,7 @@ let InfersThrowExpression () =
       let src =
         """
         let foo = fn (x) =>
-          if x < 0 { throw "RangeError" } else { x }
+          if x < 0 { throw "RangeError" } else { x };
         """
 
       let! _, env = inferScript src
@@ -58,7 +58,7 @@ let InfersJustThrowExpression () =
     result {
       let src =
         """
-        let foo = fn <T: string>(exc: T) => throw exc
+        let foo = fn <T: string>(exc: T) => throw exc;
         """
 
       let! _, env = inferScript src
@@ -75,7 +75,7 @@ let InfersThrowingMultipleExpressions () =
       let src =
         """
         let foo = fn <A: number>(x: A) =>
-          if x < 0 { throw "RangeError" } else { throw "BoundsError" }
+          if x < 0 { throw "RangeError" } else { throw "BoundsError" };
         """
 
       let! _, env = inferScript src
@@ -96,9 +96,9 @@ let InfersThrowsFromCall () =
       let src =
         """
         let foo = fn (x) =>
-          if x < 0 { throw "RangeError" } else { x }
+          if x < 0 { throw "RangeError" } else { x };
           
-        let bar = fn (x) => foo(x)
+        let bar = fn (x) => foo(x);
         """
 
       let! _, env = inferScript src
@@ -125,14 +125,14 @@ let InferCatchesException () =
       let src =
         """
         let foo = fn (x) =>
-          if x < 0 { throw "RangeError" } else { x }
+          if x < 0 { throw "RangeError" } else { x };
           
         let bar = fn (x) =>
           try {
-            foo(x)
+            foo(x);
           } catch {
             | "RangeError" => 0
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -149,15 +149,15 @@ let InferCatchesMultipleExceptions () =
       let src =
         """
         let foo = fn <A: number>(x: A) =>
-          if x < 0 { throw "RangeError" } else { throw "BoundsError" }
+          if x < 0 { throw "RangeError" } else { throw "BoundsError" };
           
         let bar = fn (x) =>
           try {
-            foo(x)
+            foo(x);
           } catch {
             | "RangeError" => 0
             | "BoundsError" => 0
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -175,14 +175,14 @@ let InferCatchesOneOfManyExceptions () =
       let src =
         """
         let foo = fn <A: number>(x: A) =>
-          if x < 0 { throw "RangeError" } else { throw "BoundsError" }
+          if x < 0 { throw "RangeError" } else { throw "BoundsError" };
           
         let bar = fn (x) =>
           try {
-            foo(x)
+            foo(x);
           } catch {
             | "RangeError" => 0
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -204,15 +204,15 @@ let InferTryFinally () =
       let src =
         """
         let foo = fn (x) =>
-          if x < 0 { throw "RangeError" } else { x }
-        let cleanup = fn () => {}
+          if x < 0 { throw "RangeError" } else { x };
+        let cleanup = fn () => {};
 
         let bar = fn (x) =>
           try {
             foo(x)
           } finally {
             cleanup()
-          }
+          };
         """
 
       let! ctx, env = inferScript src
@@ -233,17 +233,17 @@ let InferTryCatchFinally () =
       let src =
         """
         let foo = fn (x) =>
-          if x < 0 { throw "RangeError" } else { x }
-        let cleanup = fn () => {}
+          if x < 0 { throw "RangeError" } else { x };
+        let cleanup = fn () => {};
 
         let bar = fn (x) =>
           try {
-            foo(x)
+            foo(x);
           } catch {
             | "RangeError" => 0
           } finally {
-            cleanup()
-          }
+            cleanup();
+          };
         """
 
       let! ctx, env = inferScript src

--- a/src/Escalier.TypeChecker.Tests/Functions.fs
+++ b/src/Escalier.TypeChecker.Tests/Functions.fs
@@ -12,8 +12,8 @@ let InferCallFuncWithSingleWrongArg () =
     result {
       let src =
         """
-        let add = fn (x, y) => {value: x + y}
-        let sum = add("hello", "world")
+        let add = fn (x, y) => {value: x + y};
+        let sum = add("hello", "world");
         """
 
       let! ctx, env = inferScript src
@@ -31,8 +31,8 @@ let InferCallFuncWithWrongArgs () =
     result {
       let src =
         """
-        let add = fn (x, y) => x + y
-        let sum = "hello" + "world"
+        let add = fn (x, y) => x + y;
+        let sum = "hello" + "world";
         """
 
       let! ctx, env = inferScript src
@@ -49,8 +49,8 @@ let InferCallGenericFuncWithWrongArg () =
     result {
       let src =
         """
-        let foo = fn <T: number>(x: T) -> T => x
-        let bar = foo("bar")
+        let foo = fn <T: number>(x: T) -> T => x;
+        let bar = foo("bar");
         """
 
       let! ctx, env = inferScript src
@@ -67,8 +67,8 @@ let InferCallGenericFuncWithComplexReturnAndWrongArg () =
     result {
       let src =
         """
-        let foo = fn <T: number>(x: T) => {value: x}
-        let bar = foo("hello")
+        let foo = fn <T: number>(x: T) => {value: x};
+        let bar = foo("hello");
         """
 
       let! ctx, env = inferScript src
@@ -85,9 +85,9 @@ let InferFuncTypeAnnotation () =
     result {
       let src =
         """
-        let foo: fn <T: number>(x: T) -> T = fn (x) => x
-        let x = foo(5)
-        let y = foo("hello")
+        let foo: fn <T: number>(x: T) -> T = fn (x) => x;
+        let x = foo(5);
+        let y = foo("hello");
         """
 
       let! ctx, env = inferScript src
@@ -106,8 +106,8 @@ let PassingTooManyArgsIsOkay () =
     result {
       let src =
         """
-        let add = fn (x, y) => x + y
-        let sum = add(5, 10, "hello")
+        let add = fn (x, y) => x + y;
+        let sum = add(5, 10, "hello");
         """
 
       let! _, env = inferScript src
@@ -123,8 +123,8 @@ let PassingTooFewArgsIsAnError () =
     result {
       let src =
         """
-        let add = fn (x, y) => x + y
-        let sum = add(5)
+        let add = fn (x, y) => x + y;
+        let sum = add(5);
         """
 
       let! _, _ = inferScript src
@@ -142,7 +142,7 @@ let InferBasicFunction () =
     result {
       let src =
         """
-        let add = fn (a, b) => a + b
+        let add = fn (a, b) => a + b;
         """
 
       let! _, env = inferScript src
@@ -158,9 +158,9 @@ let InferFunctionWithOptionalParms () =
     result {
       let src =
         """
-        let foo = fn (a: number, b?: string) => a
-        let a = foo(5)
-        let b = foo(10, "hello")
+        let foo = fn (a: number, b?: string) => a;
+        let a = foo(5);
+        let b = foo(10, "hello");
         """
 
       let! _, env = inferScript src
@@ -177,9 +177,9 @@ let CheckOptionalParmsErrorsWithIncorrectType () =
     result {
       let src =
         """
-        let foo = fn (a: number, b?: string) => a
-        let a = foo(5)
-        let b = foo(10, true)
+        let foo = fn (a: number, b?: string) => a;
+        let a = foo(5);
+        let b = foo(10, true);
         """
 
       let! ctx, env = inferScript src
@@ -198,10 +198,10 @@ let InferFunctionWithRestParms () =
     result {
       let src =
         """
-        let foo = fn (a: number, ...b: string[]) => a
-        let a = foo(5)
-        let b = foo(10, "hello")
-        let c = foo(10, "hello", "world")
+        let foo = fn (a: number, ...b: string[]) => a;
+        let a = foo(5);
+        let b = foo(10, "hello");
+        let c = foo(10, "hello", "world");
         """
 
       let! _, env = inferScript src
@@ -219,8 +219,8 @@ let PassingIncorrectArgsAsRestParm () =
     result {
       let src =
         """
-        let foo = fn (a: number, ...b: string[]) => a
-        let c = foo(10, "hello", true)
+        let foo = fn (a: number, ...b: string[]) => a;
+        let c = foo(10, "hello", true);
         """
 
       let! _ = inferScript src
@@ -233,7 +233,7 @@ let PassingIncorrectArgsAsRestParm () =
 let InferFuncGeneralization () =
   let result =
     result {
-      let src = "let fst = fn (x, y) => x"
+      let src = "let fst = fn (x, y) => x;"
 
       let! _, env = inferScript src
 
@@ -252,7 +252,7 @@ let InferFactorial () =
       let src =
         """
         let factorial = fn (n) =>
-          if (n == 0) { 1 } else { n * factorial(n - 1) } 
+          if (n == 0) { 1 } else { n * factorial(n - 1) };
         """
 
       let! _, env = inferScript src
@@ -271,7 +271,7 @@ let InferRecursiveFunc () =
 
       let src =
         """
-        let rec = fn () => rec()
+        let rec = fn () => rec();
         """
 
       let! _, env = inferScript src
@@ -290,7 +290,7 @@ let InferRecursiveSequence () =
 
       let src =
         """
-        let seq = fn () => seq() + 1
+        let seq = fn () => seq() + 1;
         """
 
       let! _, env = inferScript src
@@ -310,16 +310,16 @@ let InferTypeAliasOfTypeParam () =
       let src =
         """
         let foo = fn <A>(x: A) {
-          type B = A
-          let y: B = x
-          return y
-        }
+          type B = A;
+          let y: B = x;
+          return y;
+        };
         let bar = fn <A>(x: A) -> A {
-          type B = A
-          let y: B = x
-          return y
-        }
-        let z = foo(5)
+          type B = A;
+          let y: B = x;
+          return y;
+        };
+        let z = foo(5);
         """
 
       // let w: number = z
@@ -339,7 +339,7 @@ let InferTypeAliasOfTypeParam () =
 let InferLambda () =
   let result =
     result {
-      let src = "let add = fn (x, y) => x + y"
+      let src = "let add = fn (x, y) => x + y;"
 
       let! _, env = inferScript src
 
@@ -354,9 +354,9 @@ let InferSKK () =
     result {
       let src =
         """
-          let S = fn (f) => fn (g) => fn (x) => f(x)(g(x))
-          let K = fn (x) => fn (y) => x
-          let I = S(K)(K)
+          let S = fn (f) => fn (g) => fn (x) => f(x)(g(x));
+          let K = fn (x) => fn (y) => x;
+          let I = S(K)(K);
         """
 
       let! _, env = inferScript src
@@ -381,14 +381,14 @@ let InferFuncParams () =
       let src =
         """
           let addNums = fn (x, y) {
-            return x + y
-          }
+            return x + y;
+          };
           let addStrs = fn (x, y) {
-            return x ++ y
-          }
-          let msg = addStrs("Hello, ", "world!")
-          let greeting: string = "Bonjour, "
-          let frMsg = addStrs(greeting, "monde!")
+            return x ++ y;
+          };
+          let msg = addStrs("Hello, ", "world!");
+          let greeting: string = "Bonjour, ";
+          let frMsg = addStrs(greeting, "monde!");
           """
 
       let! _, env = inferScript src
@@ -418,17 +418,17 @@ let InferBinaryOpStressTest () =
       let src =
         """
           let foo = fn (a, b, c) {
-            return a * b + c
-          }
+            return a * b + c;
+          };
           let double = fn (x) {
-            return 2 * x
-          }
+            return 2 * x;
+          };
           let inc = fn (x) {
-            return x + 1
-          }
-          let bar = foo(double(1), inc(2), 3)
-          let baz: number = 5
-          let qux = double(baz)
+            return x + 1;
+          };
+          let bar = foo(double(1), inc(2), 3);
+          let baz: number = 5;
+          let qux = double(baz);
           """
 
       let! _, env = inferScript src
@@ -455,11 +455,11 @@ let InferFuncParamsWithTypeAnns () =
       let src =
         """
           let addNums = fn (x: number, y: number) -> number {
-            return x + y
-          }
+            return x + y;
+          };
           let addStrs = fn (x: string, y: string) -> string {
-            return x ++ y
-          }
+            return x ++ y;
+          };
           """
 
       let! _, env = inferScript src
@@ -479,11 +479,11 @@ let InferFuncWithMultipleReturns () =
         """
           let foo = fn <A: number>(x: A, y: string) {
             if (x > 0) {
-              return x
+              return x;
             }
-            return y
-          }
-          let bar = foo(5, "hello")
+            return y;
+          };
+          let bar = foo(5, "hello");
           """
 
       let! _, env = inferScript src
@@ -502,10 +502,10 @@ let InferFuncGenericFunc () =
       let src =
         """
           let foo = fn (x) {
-            return x
-          }
-          let bar = foo(5)
-          let baz = foo("hello")
+            return x;
+          };
+          let bar = foo(5);
+          let baz = foo("hello");
           """
 
       let! _, env = inferScript src
@@ -524,9 +524,9 @@ let ApplyGenericTypeArgWithoutCallingFunction () =
       let src =
         """
         let foo = fn (x) {
-          return x
-        }
-        let bar = foo<number>
+          return x;
+        };
+        let bar = foo<number>;
         """
 
       let! _, env = inferScript src
@@ -543,9 +543,9 @@ let ApplyGenericTypeArgWithoutCallingFunctionWithTypeAlias () =
     result {
       let src =
         """
-        type Identity = fn <A>(x: A) -> A
+        type Identity = fn <A>(x: A) -> A;
         declare let foo: Identity
-        let bar = foo<number>
+        let bar = foo<number>;
         """
 
       let! _, env = inferScript src
@@ -564,10 +564,10 @@ let InferFuncGenericFuncWithExplicitTypeParams () =
       let src =
         """
           let foo = fn <T>(x: T) -> T {
-            return x
-          }
-          let bar = foo(5)
-          let baz = foo("hello")
+            return x;
+          };
+          let bar = foo(5);
+          let baz = foo("hello");
           """
 
       let! _, env = inferScript src

--- a/src/Escalier.TypeChecker.Tests/Functions.fs
+++ b/src/Escalier.TypeChecker.Tests/Functions.fs
@@ -544,7 +544,7 @@ let ApplyGenericTypeArgWithoutCallingFunctionWithTypeAlias () =
       let src =
         """
         type Identity = fn <A>(x: A) -> A;
-        declare let foo: Identity
+        declare let foo: Identity;
         let bar = foo<number>;
         """
 

--- a/src/Escalier.TypeChecker.Tests/Modules.fs
+++ b/src/Escalier.TypeChecker.Tests/Modules.fs
@@ -96,7 +96,7 @@ let InferImports () =
   let res =
     result {
       let files = Dictionary<string, MockFileData>()
-      let src = "import \"./foo.esc\" {foo}"
+      let src = "import \"./foo.esc\" {foo};"
       files.Add("/input.esc", MockFileData(src))
       files.Add("/foo.esc", MockFileData("let foo = 5;"))
       let mockFileSystem = MockFileSystem(files, "/")

--- a/src/Escalier.TypeChecker.Tests/Modules.fs
+++ b/src/Escalier.TypeChecker.Tests/Modules.fs
@@ -13,8 +13,8 @@ let InferBasicModule () =
     result {
       let src =
         """
-        let add = fn(a, b) => a + b
-        let sub = fn(a, b) => a - b
+        let add = fn(a, b) => a + b;
+        let sub = fn(a, b) => a - b;
         """
 
       let! _, env = inferModule src
@@ -31,8 +31,8 @@ let InferMutuallyRecursiveFunctions () =
     result {
       let src =
         """
-        let foo = fn() => bar() + 1
-        let bar = fn() => foo() - 1
+        let foo = fn() => bar() + 1;
+        let bar = fn() => foo() - 1;
         """
 
       let! _, env = inferModule src
@@ -54,13 +54,13 @@ let InferMutualRecursion () =
             true
         } else {
             !odd(x - 1)
-        }
+        };
 
         let odd = fn (x) => if (x == 1) {
             true
         } else {
             !even(x - 1)
-        }
+        };
         """
 
       let! _, env = inferModule src
@@ -78,8 +78,8 @@ let InferMutuallyRecursiveTypes () =
     result {
       let src =
         """
-        type Foo<T> = {bar: Bar<T>}
-        type Bar<T> = {foo: Foo<T>}
+        type Foo<T> = {bar: Bar<T>};
+        type Bar<T> = {foo: Foo<T>};
         """
 
       let! _, env = inferModule src
@@ -98,7 +98,7 @@ let InferImports () =
       let files = Dictionary<string, MockFileData>()
       let src = "import \"./foo.esc\" {foo}"
       files.Add("/input.esc", MockFileData(src))
-      files.Add("/foo.esc", MockFileData("let foo = 5"))
+      files.Add("/foo.esc", MockFileData("let foo = 5;"))
       let mockFileSystem = MockFileSystem(files, "/")
 
       let! _, env = inferModules mockFileSystem src

--- a/src/Escalier.TypeChecker.Tests/Mutability.fs
+++ b/src/Escalier.TypeChecker.Tests/Mutability.fs
@@ -34,8 +34,8 @@ let InferBasicMutability () =
     result {
       let src =
         """
-        let mut x: number = 5
-        x = 10
+        let mut x: number = 5;
+        x = 10;
         """
 
       let! _, _ = inferScript src
@@ -50,10 +50,10 @@ let InferBasicObjectMutability () =
     result {
       let src =
         """
-        type Point = {x: number, y: number}
-        let mut p: Point = {x: 0, y: 0}
-        p.x = 5
-        p.y = 10
+        type Point = {x: number, y: number};
+        let mut p: Point = {x: 0, y: 0};
+        p.x = 5;
+        p.y = 10;
         """
 
       let! _, _ = inferScript src
@@ -68,8 +68,8 @@ let InferBasicArrayMutability () =
     result {
       let src =
         """
-        let mut array: number[] = [1, 2, 3]
-        array[3] = 4
+        let mut array: number[] = [1, 2, 3];
+        array[3] = 4;
         """
 
       let! _, _ = inferScript src
@@ -84,8 +84,8 @@ let DisallowAssigningToImmutableBindings () =
     result {
       let src =
         """
-        let x: number = 5
-        x = 10
+        let x: number = 5;
+        x = 10;
         """
 
       let! _, _ = inferScript src
@@ -101,9 +101,9 @@ let InferFnWithMutableParam () =
       let src =
         """
         let foo = fn (mut array: (number | string)[]) {
-          array[0] = 5
-          array[1] = "hello"
-        }
+          array[0] = 5;
+          array[1] = "hello";
+        };
         """
 
       let! _, env = inferScript src
@@ -124,11 +124,11 @@ let MutableParamsAreInvariant () =
       let src =
         """
         let foo = fn (mut array: (number | string)[]) {
-          array[0] = 5
-          array[1] = "hello"
-        }
-        let mut numbers: (number | string)[] = [1, 2, 3]
-        foo(numbers)
+          array[0] = 5;
+          array[1] = "hello";
+        };
+        let mut numbers: (number | string)[] = [1, 2, 3];
+        foo(numbers);
         """
 
       let! _, env = inferScript src
@@ -149,11 +149,11 @@ let MutableParamsCantBeCovariant () =
       let src =
         """
         let foo = fn (mut array: (number | string)[]) {
-          array[0] = 5
-          array[1] = "hello"
-        }
-        let mut numbers: number[] = [1, 2, 3]
-        foo(numbers)
+          array[0] = 5;
+          array[1] = "hello";
+        };
+        let mut numbers: number[] = [1, 2, 3];
+        foo(numbers);
         """
 
       let! ctx, _ = inferScript src
@@ -169,8 +169,8 @@ let ImmutableAssignmentIsBeCovariant () =
     result {
       let src =
         """
-        let foo: number[] = [1, 2, 3]
-        let bar: (number | string)[] = foo
+        let foo: number[] = [1, 2, 3];
+        let bar: (number | string)[] = foo;
         """
 
       let! ctx, _ = inferScript src
@@ -186,8 +186,8 @@ let MutableAssignmentIsInvariant () =
     result {
       let src =
         """
-        let mut foo: number[] = [1, 2, 3]
-        let mut bar: number[] = foo
+        let mut foo: number[] = [1, 2, 3];
+        let mut bar: number[] = foo;
         """
 
       let! _ = inferScript src
@@ -202,8 +202,8 @@ let MutableAssignmentCantBeCovariant () =
     result {
       let src =
         """
-        let mut foo: number[] = [1, 2, 3]
-        let mut bar: (number | string)[] = foo
+        let mut foo: number[] = [1, 2, 3];
+        let mut bar: (number | string)[] = foo;
         """
 
       let! _ = inferScript src
@@ -218,9 +218,9 @@ let MutableTupleAssignmentCantBeCovariant () =
     result {
       let src =
         """
-        let mut foo: number[] = [5, 10]
-        let mut bar: string[] = ["hello", "world"]
-        let mut foobar: [(number | string)[], (number | string)[]] = [foo, bar]
+        let mut foo: number[] = [5, 10];
+        let mut bar: string[] = ["hello", "world"];
+        let mut foobar: [(number | string)[], (number | string)[]] = [foo, bar];
         """
 
       let! _ = inferScript src
@@ -236,11 +236,11 @@ let CantPassImmutableArgsToMutableParams () =
       let src =
         """
         let foo = fn (mut array: number[]) {
-          array[0] = 5
-          array[1] = "hello"
-        }
-        let numbers: number[] = [1, 2, 3]
-        foo(numbers)
+          array[0] = 5;
+          array[1] = "hello";
+        };
+        let numbers: number[] = [1, 2, 3];
+        foo(numbers);
         """
 
       let! _ = inferScript src
@@ -258,10 +258,10 @@ let ImmutableParamsAreCovariant () =
       let src =
         """
         let foo = fn (array: (number | string)[]) {
-          return array.length
-        }
-        let numbers: number[] = [1, 2, 3]
-        foo(numbers)
+          return array.length;
+        };
+        let numbers: number[] = [1, 2, 3];
+        foo(numbers);
         """
 
       let! _, env = inferScript src
@@ -281,16 +281,16 @@ let MutableObjectPartialInitialization () =
     result {
       let src =
         """
-        type Point = {x:number, y:number}
-        type Line = {p0: Point, p1: Point}
+        type Point = {x:number, y:number};
+        type Line = {p0: Point, p1: Point};
         
-        let mut p0: Point = {x: 0, y: 0}
-        let mut p1: Point = {x: 5, y: 10}
+        let mut p0: Point = {x: 0, y: 0};
+        let mut p1: Point = {x: 5, y: 10};
         
-        let line: Line = {p0, p1}
-        let {p0: mut start, p1: mut end}: Line = {p0, p1}
-        let {p0: start, p1: mut end}: Line = {p0, p1}
-        let {p0: mut start, p1: end}: Line = {p0, p1}
+        let line: Line = {p0, p1};
+        let {p0: mut start, p1: mut end}: Line = {p0, p1};
+        let {p0: start, p1: mut end}: Line = {p0, p1};
+        let {p0: mut start, p1: end}: Line = {p0, p1};
         """
 
       let! _ = inferScript src
@@ -306,16 +306,16 @@ let MutableArrayPartialInitialization () =
     result {
       let src =
         """
-        type Point = [number, number]
-        type Line = [Point, Point]
+        type Point = [number, number];
+        type Line = [Point, Point];
         
-        let mut p0: Point = [0, 0]
-        let mut p1: Point = [5, 10]
+        let mut p0: Point = [0, 0];
+        let mut p1: Point = [5, 10];
         
-        let line: Line = [p0, p1]
-        let [mut start, mut end]: Line = [p0, p1]
-        let [start, mut end]: Line = [p0, p1]
-        let [mut start, end]: Line = [p0, p1]
+        let line: Line = [p0, p1];
+        let [mut start, mut end]: Line = [p0, p1];
+        let [start, mut end]: Line = [p0, p1];
+        let [mut start, end]: Line = [p0, p1];
         """
 
       let! _ = inferScript src
@@ -331,13 +331,13 @@ let MutableObjectInitializationError () =
     result {
       let src =
         """
-        type Point = {x:number, y:number}
-        type Line = {p0: Point, p1: Point}
+        type Point = {x:number, y:number};
+        type Line = {p0: Point, p1: Point};
         
-        let mut p0 = {x: 0, y: 0}
-        let p1 = {x: 5, y: 5}
+        let mut p0 = {x: 0, y: 0};
+        let p1 = {x: 5, y: 5};
         
-        let mut line: Line = {p0, p1}
+        let mut line: Line = {p0, p1};
         """
 
       let! _ = inferScript src
@@ -352,13 +352,13 @@ let MutableArrayInitializationError () =
     result {
       let src =
         """
-        type Point = [number, number]
-        type Line = [Point, Point]
+        type Point = [number, number];
+        type Line = [Point, Point];
         
-        let mut p0 = [0, 0]
-        let p1 = [5, 10]
+        let mut p0 = [0, 0];
+        let p1 = [5, 10];
         
-        let mut line: Line = [p0, p1]
+        let mut line: Line = [p0, p1];
         """
 
       let! _ = inferScript src
@@ -373,13 +373,13 @@ let MutableObjectPartialInitializationError () =
     result {
       let src =
         """
-        type Point = {x:number, y:number}
-        type Line = {p0: Point, p1: Point}
+        type Point = {x:number, y:number};
+        type Line = {p0: Point, p1: Point};
         
-        let mut p0 = {x: 0, y: 0}
-        let p1 = {x: 5, y: 5}
+        let mut p0 = {x: 0, y: 0};
+        let p1 = {x: 5, y: 5};
         
-        let {p0: start, p1: mut end}: Line = {p0, p1}
+        let {p0: start, p1: mut end}: Line = {p0, p1};
         """
 
       let! _ = inferScript src
@@ -394,13 +394,13 @@ let MutableArrayPartialInitializationError () =
     result {
       let src =
         """
-        type Point = [number, number]
-        type Line = [Point, Point]
+        type Point = [number, number];
+        type Line = [Point, Point];
         
-        let mut p0 = [0, 0]
-        let p1 = [5, 10]
+        let mut p0 = [0, 0];
+        let p1 = [5, 10];
         
-        let [start, mut end]: Line = [p0, p1]
+        let [start, mut end]: Line = [p0, p1];
         """
 
       let! _ = inferScript src

--- a/src/Escalier.TypeChecker.Tests/PatternMatching.fs
+++ b/src/Escalier.TypeChecker.Tests/PatternMatching.fs
@@ -17,7 +17,7 @@ let BasicPatternMatching () =
             | 1 => "one"
             | n if n < 0 => "negative"
             | _ => "other"
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -44,7 +44,7 @@ let BasicPatternMatchingInferExpr () =
             | 1 => "one"
             | n if n < 0 => "negative"
             | _ => "other"
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -71,7 +71,7 @@ let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
             | {x is number, y: 0} => "x-axis"
             | {x: 0, y is number} => "y-axis"
             | _ => "other"
-          }
+          };
           
         let bar = fn (x, y) =>
           match {x, y} {
@@ -79,7 +79,7 @@ let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
             | {x is number, y: 0} => "x-axis"
             | {x: 0, y is number} => "y-axis"
             | {x is number, y is number} => "other"
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -105,7 +105,7 @@ let PatternMatchingObjects () =
     result {
       let src =
         """
-        type Point = {x: number, y: number}
+        type Point = {x: number, y: number};
         type Shape = {
           type: "circle",
           radius: number,
@@ -114,7 +114,7 @@ let PatternMatchingObjects () =
           type: "line",
           start: Point,
           end: Point
-        }
+        };
         
         declare let shape: Shape
         
@@ -125,7 +125,7 @@ let PatternMatchingObjects () =
               x: (start.x + end.x) / 2,
               y: (start.y + end.y) / 2
             })
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -149,7 +149,7 @@ let PatternMatchingObjectsWithBlockBody () =
     result {
       let src =
         """
-        type Point = {x: number, y: number}
+        type Point = {x: number, y: number};
         type Shape = {
           type: "circle",
           radius: number,
@@ -158,7 +158,7 @@ let PatternMatchingObjectsWithBlockBody () =
           type: "line",
           start: Point,
           end: Point
-        }
+        };
         
         declare let shape: Shape
         
@@ -166,11 +166,11 @@ let PatternMatchingObjectsWithBlockBody () =
           match shape {
             | {type: "circle", ...rest} => rest.center
             | {type: "line", start, end} => {
-              let x = (start.x + end.x) / 2
-              let y = (start.y + end.y) / 2
+              let x = (start.x + end.x) / 2;
+              let y = (start.y + end.y) / 2;
               {x, y}
             }
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -195,7 +195,7 @@ let PatternMatchingArrays () =
             | [x, y] => x + y
             | [x, y, z] => x + y + z
             | [x, y, z, ...rest] => x + y + z + sum(rest)
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -219,7 +219,7 @@ let PatternMatchingPrimitiveAssertions () =
             | n is number => n + 1
             | s is string => s ++ "!"
             | _ is boolean => true
-          }
+          };
         """
 
       let! _, env = inferScript src
@@ -239,7 +239,7 @@ let PartialPatternMatchingObject () =
         let result = match value {
           | [a, _] => a
           | {b} => b
-        }
+        };
         """
 
       let! _, env = inferScript src
@@ -263,7 +263,7 @@ let PatternMatchingImmutableTypes () =
         let result = match value {
           | #[a, b] => a
           | #{a, b} => a
-        }
+        };
         """
 
       let! _, env = inferScript src
@@ -284,7 +284,7 @@ let PatternMatchingDisallowsExtraProperties () =
         declare let value: {a: number, b: string}
         let result = match value {
           | {a, b: _, c: _} => a
-        }
+        };
         """
 
       let! _ = inferScript src
@@ -307,7 +307,7 @@ let PatternMatchingDisallowsPartialMappingOfTuples () =
         declare let value: [number, string]
         let result = match value {
           | [a] => a
-        }
+        };
         """
 
       let! _ = inferScript src

--- a/src/Escalier.TypeChecker.Tests/PatternMatching.fs
+++ b/src/Escalier.TypeChecker.Tests/PatternMatching.fs
@@ -116,7 +116,7 @@ let PatternMatchingObjects () =
           end: Point
         };
         
-        declare let shape: Shape
+        declare let shape: Shape;
         
         let centroid =
           match shape {
@@ -160,7 +160,7 @@ let PatternMatchingObjectsWithBlockBody () =
           end: Point
         };
         
-        declare let shape: Shape
+        declare let shape: Shape;
         
         let centroid =
           match shape {
@@ -212,7 +212,7 @@ let PatternMatchingPrimitiveAssertions () =
     result {
       let src =
         """
-        declare let value: number | string | boolean
+        declare let value: number | string | boolean;
         
         let result =
           match value {
@@ -235,7 +235,7 @@ let PartialPatternMatchingObject () =
     result {
       let src =
         """
-        declare let value: {a: number, b: string} | [number, string]
+        declare let value: {a: number, b: string} | [number, string];
         let result = match value {
           | [a, _] => a
           | {b} => b
@@ -259,7 +259,7 @@ let PatternMatchingImmutableTypes () =
     result {
       let src =
         """
-        declare let value: #[number, string] | #{a: number, b: string}
+        declare let value: #[number, string] | #{a: number, b: string};
         let result = match value {
           | #[a, b] => a
           | #{a, b} => a
@@ -281,7 +281,7 @@ let PatternMatchingDisallowsExtraProperties () =
     result {
       let src =
         """
-        declare let value: {a: number, b: string}
+        declare let value: {a: number, b: string};
         let result = match value {
           | {a, b: _, c: _} => a
         };
@@ -304,7 +304,7 @@ let PatternMatchingDisallowsPartialMappingOfTuples () =
     result {
       let src =
         """
-        declare let value: [number, string]
+        declare let value: [number, string];
         let result = match value {
           | [a] => a
         };

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -12,7 +12,7 @@ let InferBasicStruct () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point = Point {x: 5, y: 10}
+        let point = Point {x: 5, y: 10};
         """
 
       let! _, env = inferScript src
@@ -29,7 +29,7 @@ let InferBasicStructIncorrectTypes () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point = Point {x: "hello", y: true}
+        let point = Point {x: "hello", y: true};
         """
 
       let! _ = inferScript src
@@ -45,7 +45,7 @@ let InferGenericStruct () =
       let src =
         """
         struct Point<T> {x: T, y: T}
-        let point = Point<number> {x: 5, y: 10}
+        let point = Point<number> {x: 5, y: 10};
         """
 
       let! _, env = inferScript src
@@ -62,7 +62,7 @@ let StructsAreSubtypesOfObjects () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point: {x: number, y: number} = Point {x: 5, y: 10}
+        let point: {x: number, y: number} = Point {x: 5, y: 10};
         """
 
       let! _, env = inferScript src
@@ -79,8 +79,8 @@ let PropertyAccessOnStructs () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point = Point {x: 5, y: 10}
-        let x = point.x
+        let point = Point {x: 5, y: 10};
+        let x = point.x;
         """
 
       let! _, env = inferScript src
@@ -97,8 +97,8 @@ let SettingPropertiesOnMutableStructs () =
       let src =
         """
         struct Point {x: number, y: number}
-        let mut point = Point {x: 5, y: 10}
-        point.x = 0
+        let mut point = Point {x: 5, y: 10};
+        point.x = 0;
         """
 
       let! _ = inferScript src
@@ -114,8 +114,8 @@ let SettingPropertiesOnNonmutableStructsFails () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point = Point {x: 5, y: 10}
-        point.x = 0
+        let point = Point {x: 5, y: 10};
+        point.x = 0;
         """
 
       let! _ = inferScript src
@@ -132,10 +132,10 @@ let PropertyAccessOnPrivateStructs () =
         """
         let makePoint = fn (x, y) {
           struct Point {x: number, y: number}
-          return Point {x, y}
-        }
-        let point = makePoint(5, 10)
-        let x = point.x
+          return Point {x, y};
+        };
+        let point = makePoint(5, 10);
+        let x = point.x;
         """
 
       let! _, env = inferScript src
@@ -154,10 +154,10 @@ let PropertyAccessOnPrivateStructsWrongKey () =
         """
         let makePoint = fn (x, y) {
           struct Point {x: number, y: number}
-          return Point {x, y}
-        }
-        let point = makePoint(5, 10)
-        let z = point.z
+          return Point {x, y};
+        };
+        let point = makePoint(5, 10);
+        let z = point.z;
         """
 
       let! _ = inferScript src
@@ -173,8 +173,8 @@ let ObjectDestructuringOfStructs () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point = Point {x: 5, y: 10}
-        let {x, y} = point
+        let point = Point {x: 5, y: 10};
+        let {x, y} = point;
         """
 
       let! _, env = inferScript src
@@ -191,8 +191,8 @@ let StructDestructuring () =
       let src =
         """
         struct Point {x: number, y: number}
-        let point = Point {x: 5, y: 10}
-        let Point {x, y} = point
+        let point = Point {x: 5, y: 10};
+        let Point {x, y} = point;
         """
 
       let! _, env = inferScript src
@@ -212,20 +212,20 @@ let BasicStructAndImpl () =
 
         impl Foo {
           fn bar(self) {
-            return self.x
+            return self.x;
           }
         }
 
         impl Foo {
           fn baz(self) {
-            return self.y
+            return self.y;
           }
         }
 
-        let foo = Foo {x: 5, y: "hello"}
-        let {x, y} = foo
-        let bar = foo.bar()
-        let baz = foo.baz()
+        let foo = Foo {x: 5, y: "hello"};
+        let {x, y} = foo;
+        let bar = foo.bar();
+        let baz = foo.baz();
         """
 
       let! _, env = inferScript src
@@ -248,19 +248,19 @@ let CallingMethodInPreviousImpl () =
 
         impl Foo {
           fn bar(self) {
-            return self.x
+            return self.x;
           }
         }
 
         impl Foo {
           fn baz(self) {
-            return self.bar()
+            return self.bar();
           }
         }
 
-        let foo = Foo {x: 5}
-        let bar = foo.bar()
-        let baz = foo.baz()
+        let foo = Foo {x: 5};
+        let bar = foo.bar();
+        let baz = foo.baz();
         """
 
       let! _, env = inferScript src
@@ -281,16 +281,16 @@ let GetterSetterImpl () =
 
         impl Foo {
           get bar(self) {
-            return self.x
+            return self.x;
           }
           set baz(mut self, y) {
-            self.y = y
+            self.y = y;
           }
         }
 
-        let mut foo = Foo {x: 5, y: "hello"}
-        let bar = foo.bar
-        foo.baz = "world"
+        let mut foo = Foo {x: 5, y: "hello"};
+        let bar = foo.bar;
+        foo.baz = "world";
         """
 
       let! _, env = inferScript src
@@ -311,17 +311,17 @@ let CallingMethodInSameImpl () =
 
         impl Foo {
           fn bar(self) {
-            return self.x
+            return self.x;
           }
           
           fn baz(self) {
-            return self.bar()
+            return self.bar();
           }
         }
 
-        let foo = Foo {x: 5}
-        let bar = foo.bar()
-        let baz = foo.baz()
+        let foo = Foo {x: 5};
+        let bar = foo.bar();
+        let baz = foo.baz();
         """
 
       let! _, env = inferScript src
@@ -342,12 +342,12 @@ let InferGenericImpls () =
         
         impl Point<T> {
           fn bar(self) -> T {
-            return self.x
+            return self.x;
           }
         }
         
-        let point = Point<number> {x: 5, y: 10}
-        let bar = point.bar()
+        let point = Point<number> {x: 5, y: 10};
+        let bar = point.bar();
         """
 
       let! _, env = inferScript src
@@ -369,22 +369,22 @@ let InferGenericImplsWithParams () =
 
         impl Foo<T> {
           fn bar(mut self, x) {
-            return self.x = x
+            return self.x = x;
           }
           
           fn baz(mut self, x) {
-            return self.bar(x)
+            return self.bar(x);
           }
 
           get qux(self) -> T {
-            return self.x
+            return self.x;
           }
         }
 
-        let mut foo = Foo<number>{x: 5}
-        foo.bar(10)
-        foo.baz(15)
-        let qux = foo.qux 
+        let mut foo = Foo<number>{x: 5};
+        foo.bar(10);
+        foo.baz(15);
+        let qux = foo.qux; 
         """
 
       let! _, env = inferScript src
@@ -437,7 +437,7 @@ let InferRecursiveStructType () =
           right: Node<number> {
             value: 15
           }
-        }
+        };
         """
 
       let! _, env = inferScript src
@@ -466,7 +466,7 @@ let InferGenericRecursiveStructWithImpls () =
               value: mapper(self.value),
               left: self.left?.map(mapper),
               right: self.right?.map(mapper)
-            }
+            };
           }
         }
         """
@@ -492,13 +492,13 @@ let RecursiveMethodsCanBeInferred () =
               1
             } else {
               n * self.fact(n - 1)
-            }
+            };
           }
         }
 
-        let foo = Foo {}
-        let res = foo.fact(5)
-        let fact = foo.fact
+        let foo = Foo {};
+        let res = foo.fact(5);
+        let fact = foo.fact;
         """
 
       let! _, env = inferScript src
@@ -519,19 +519,19 @@ let MutMethodsCanCallOtherMutMethods () =
 
         impl Foo {
           fn bar(mut self, x) {
-            return self.x = x
+            return self.x = x;
           }
           
           fn baz(mut self, x) {
-            return self.bar(x)
+            return self.bar(x);
           }
         }
 
-        let mut foo = Foo {x: 5}
-        foo.bar(10)
-        foo.baz(15)
-        let bar = foo.bar
-        let baz = foo.baz
+        let mut foo = Foo {x: 5};
+        foo.bar(10);
+        foo.baz(15);
+        let bar = foo.bar;
+        let baz = foo.baz;
         """
 
       let! _, env = inferScript src
@@ -551,12 +551,12 @@ let CannotCallMutatingMethodOnNonMutableBinding () =
 
         impl Foo {
           fn bar(mut self, x) {
-            return self.x = x
+            return self.x = x;
           }
         }
 
-        let foo = Foo {x: 5}
-        foo.bar(10)
+        let foo = Foo {x: 5};
+        foo.bar(10);
         """
 
       let! _ = inferScript src
@@ -575,17 +575,17 @@ let NonMutatingMethodsCannotCallOtherMutMethods () =
 
         impl Foo {
           fn bar(mut self, x) {
-            return self.x = x
+            return self.x = x;
           }
           
           fn baz(self, x) {
-            return self.bar(x)
+            return self.bar(x);
           }
         }
 
-        let mut foo = Foo {x: 5}
-        foo.bar(10)
-        foo.baz(15)
+        let mut foo = Foo {x: 5};
+        foo.bar(10);
+        foo.baz(15);
         """
 
       let! _ = inferScript src
@@ -604,16 +604,16 @@ let StaticMethods () =
 
         impl Point {
           fn make(x, y) {
-            return Self { x, y }
+            return Self { x, y };
           }
           fn default() {
-            return Point { x: 0, y: 0 }
+            return Point { x: 0, y: 0 };
           }
         }
 
-        let p = Point.make(5, 10)
-        let q = Point.default()
-        let {x, y} = p
+        let p = Point.make(5, 10);
+        let q = Point.default();
+        let {x, y} = p;
         """
 
       let! _, env = inferScript src

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -30,7 +30,7 @@ let inferScript src =
       """
         type RangeIterator<Min: number, Max: number> = {
           next: fn () -> { done: boolean, value: Min..Max }
-        }
+        };
       """
 
     let! ast =
@@ -55,7 +55,7 @@ let InfersTypeofWellknownSymbol () =
     result {
       let src =
         """
-        let iterator: typeof Symbol.iterator = Symbol.iterator
+        let iterator: typeof Symbol.iterator = Symbol.iterator;
         """
 
       let! _, env = inferScript src
@@ -71,7 +71,7 @@ let InfersSymbolsAreUnique () =
     result {
       let src =
         """
-        let iterator: Symbol.match = Symbol.iterator
+        let iterator: Symbol.match = Symbol.iterator;
         """
 
       let! _, _ = inferScript src

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -70,8 +70,8 @@ let InferSimpleTypeError () =
     result {
       let src =
         """
-        let y: string = "hello"
-        let x: number = y
+        let y: string = "hello";
+        let x: number = y;
         """
 
       let! ctx, env = inferScript src
@@ -108,7 +108,7 @@ let InferBinaryOperators () =
 let InferIfElse () =
   let result =
     result {
-      let! t = infer "if (true) { let x = 5\nx } else { \"hello\" }"
+      let! t = infer "if (true) { let x = 5;\nx } else { \"hello\" }"
       Assert.Equal("5 | \"hello\"", t.ToString())
     }
 
@@ -126,7 +126,7 @@ let InferIfElseChaining () =
         "hello"
       } else {
         true
-      }
+      };
       """
 
       let! _, env = inferScript src
@@ -163,7 +163,7 @@ let InferIdentifier () =
 let InferLetStatements () =
   let result =
     result {
-      let! _, env = inferScript "let foo = 5\nlet bar =\"hello\""
+      let! _, env = inferScript "let foo = 5;\nlet bar =\"hello\";"
 
       Assert.Value(env, "foo", "5")
       Assert.Value(env, "bar", "\"hello\"")
@@ -177,9 +177,9 @@ let InferBinOpsOnPrimitives () =
     result {
       let src =
         """
-          let x = 5
-          let y = 10
-          let sum = x + y
+          let x = 5;
+          let y = 10;
+          let sum = x + y;
           """
 
       let! _, env = inferScript src
@@ -195,11 +195,11 @@ let InferTypeDecls () =
     result {
       let src =
         """
-          type A = number
-          type B = [string, boolean]
-          type C = 5 | "hello"
-          type D = fn (x: number) -> number
-          type Nullable<T> = T | undefined
+          type A = number;
+          type B = [string, boolean];
+          type C = 5 | "hello";
+          type D = fn (x: number) -> number;
+          type Nullable<T> = T | undefined;
           """
 
       let! _, env = inferScript src
@@ -222,12 +222,12 @@ let InferPrivateDecl () =
       let src =
         """
           let makePoint = fn (x, y) {
-            type Point = {x: number, y: number}
-            let point: Point = {x, y}
-            return point
-          }
-          let p = makePoint(5, 10)
-          let {x, y} = p
+            type Point = {x: number, y: number};
+            let point: Point = {x, y};
+            return point;
+          };
+          let p = makePoint(5, 10);
+          let {x, y} = p;
           """
 
       let! _, env = inferScript src
@@ -247,8 +247,8 @@ let InferTypeAliasOfPrimtiveType () =
     result {
       let src =
         """
-        type Bar = number
-        let x: Bar = 5
+        type Bar = number;
+        let x: Bar = 5;
         """
 
       let! _, env = inferScript src
@@ -265,10 +265,10 @@ let InferTypeAnn () =
     result {
       let src =
         """
-        let a: number = 5
-        let [b, c]: [string, boolean] = ["hello", true]
-        type Point = {x: number, y: number}
-        let {x, y}: Point = {x: 5, y: 10}
+        let a: number = 5;
+        let [b, c]: [string, boolean] = ["hello", true];
+        type Point = {x: number, y: number};
+        let {x, y}: Point = {x: 5, y: 10};
         """
 
       let! _, env = inferScript src
@@ -288,12 +288,12 @@ let InferObjectDestructuring () =
     result {
       let src =
         """
-        type Point = {x: number, y: number}
-        let {x, y}: Point = {x: 5, y: 10}
-        let p: Point = {x, y}
-        let foo = fn ({x, y}: Point) => x + y
-        let sum = foo({x: 5, y: 10})
-        foo({x, y})
+        type Point = {x: number, y: number};
+        let {x, y}: Point = {x: 5, y: 10};
+        let p: Point = {x, y};
+        let foo = fn ({x, y}: Point) => x + y;
+        let sum = foo({x: 5, y: 10});
+        foo({x, y});
         """
 
       let! _, env = inferScript src
@@ -312,11 +312,11 @@ let InferObjectRestSpread () =
     result {
       let src =
         """
-        let obj1 = {a: 5, b: "hello", c: true}
-        let {a, ...rest} = obj1
-        let obj2 = {a, ...rest}
-        let foo = fn({a, ...rest}: {a: number, b: string, c: boolean}) => a
-        foo(obj2)
+        let obj1 = {a: 5, b: "hello", c: true};
+        let {a, ...rest} = obj1;
+        let obj2 = {a, ...rest};
+        let foo = fn({a, ...rest}: {a: number, b: string, c: boolean}) => a;
+        foo(obj2);
         """
 
       let! _, env = inferScript src
@@ -334,9 +334,9 @@ let InferObjProps () =
     result {
       let src =
         """
-        let obj = {a: {b: 5, c: "hello"}}
-        let b = obj.a.b
-        let c = obj.a.c
+        let obj = {a: {b: 5, c: "hello"}};
+        let b = obj.a.b;
+        let c = obj.a.c;
         """
 
       let! _, env = inferScript src
@@ -353,14 +353,14 @@ let InferOptionalChaining () =
     result {
       let src =
         """
-        type Obj = {a?: {b?: {c: number}}}
-        let obj: Obj = {a: {b: undefined}}
-        let a = obj.a
-        let b = obj.a?.b
-        let c = obj.a?.b?.c
-        type Point = {x: number, y: number}
-        let p: Point = {x: 5, y: 10}
-        let x = p?.x
+        type Obj = {a?: {b?: {c: number}}};
+        let obj: Obj = {a: {b: undefined}};
+        let a = obj.a;
+        let b = obj.a?.b;
+        let c = obj.a?.b?.c;
+        type Point = {x: number, y: number};
+        let p: Point = {x: 5, y: 10};
+        let x = p?.x;
         """
 
       let! _, env = inferScript src
@@ -383,10 +383,10 @@ let InferRecursiveType () =
 
       let src =
         """
-        type Foo = number | Foo[]
-        let x: Foo = 5
-        let y: Foo = [5, 10]
-        let z: Foo = [5, [10, 15]]
+        type Foo = number | Foo[];
+        let x: Foo = 5;
+        let y: Foo = [5, 10];
+        let z: Foo = [5, [10, 15]];
         """
 
       let! _, env = inferScript src
@@ -407,9 +407,9 @@ let InferRecursiveTypeUnifyWithDefn () =
 
       let src =
         """
-        type Foo = number | Foo[]
-        let foo: Foo = 5
-        let bar: number | Foo[] = foo
+        type Foo = number | Foo[];
+        let foo: Foo = 5;
+        let bar: number | Foo[] = foo;
         """
 
       let! _, env = inferScript src
@@ -431,7 +431,7 @@ let InferRecursiveObjectType () =
           value: number,
           left?: Node,
           right?: Node
-        }
+        };
         
         let node: Node = {
           value: 5,
@@ -441,7 +441,7 @@ let InferRecursiveObjectType () =
           right: {
             value: 15
           }
-        }
+        };
         """
 
       let! _, env = inferScript src
@@ -463,7 +463,7 @@ let InferRecursiveGenericObjectType () =
           value: T,
           left?: Node<T>,
           right?: Node<T>
-        }
+        };
 
         let node: Node<number> = {
           value: 5,
@@ -476,7 +476,7 @@ let InferRecursiveGenericObjectType () =
               value: 20
             }
           }
-        }
+        };
         """
 
       let! _, env = inferScript src
@@ -498,7 +498,7 @@ let ReturnRecursivePrivateGenericObjectType () =
             value: T,
             left?: Node<T>,
             right?: Node<T>
-          }
+          };
 
           let node: Node<number> = {
             value: 5,
@@ -508,12 +508,12 @@ let ReturnRecursivePrivateGenericObjectType () =
             right: {
               value: 15
             }
-          }
+          };
           
-          return node
-        }
-        let node = makeTree()
-        let x = node.left?.value
+          return node;
+        };
+        let node = makeTree();
+        let x = node.left?.value;
         """
 
       let! _, env = inferScript src
@@ -535,7 +535,7 @@ let ReturnRecursiveGenericObjectType () =
           value: T,
           left?: Node<T>,
           right?: Node<T>
-        }
+        };
         
         let makeTree = fn () {
           let node: Node<number> = {
@@ -546,12 +546,12 @@ let ReturnRecursiveGenericObjectType () =
             right: {
               value: 15
             }
-          }
+          };
           
-          return node
-        }
-        let node = makeTree()
-        let x = node.left?.value
+          return node;
+        };
+        let node = makeTree();
+        let x = node.left?.value;
         """
 
       let! _, env = inferScript src
@@ -569,9 +569,9 @@ let InferTuple () =
     result {
       let src =
         """
-        let foo = [1, 2, 3]
-        let bar = fn(nums: number[]) => nums
-        let baz = bar(foo)
+        let foo = [1, 2, 3];
+        let bar = fn(nums: number[]) => nums;
+        let baz = bar(foo);
         """
 
       let! _, env = inferScript src
@@ -605,13 +605,13 @@ let InferTemplateLiteralType () =
 
       let src =
         """
-        type Foo = `foo${number}`
-        let x: Foo = "foo123"
-        type Bar = `A${string}B`
-        let y: Bar = "A1B"
-        type Baz = `A${string}B${string}C`
-        let z: Baz = "A1B2C"
-        let w: Baz = "ABCBC"
+        type Foo = `foo${number}`;
+        let x: Foo = "foo123";
+        type Bar = `A${string}B`;
+        let y: Bar = "A1B";
+        type Baz = `A${string}B${string}C`;
+        let z: Baz = "A1B2C";
+        let w: Baz = "ABCBC";
         """
 
       let! _, env = inferScript src
@@ -632,11 +632,11 @@ let InferTemplateLiteralTypeWithUnions () =
 
       let src =
         """
-        type Dir = `${"top" | "bottom"}-${"left" | "right"}`
-        let a: Dir = "top-left"
-        let b: Dir = "top-right"
-        let c: Dir = "bottom-right"
-        let d: Dir = "bottom-left"
+        type Dir = `${"top" | "bottom"}-${"left" | "right"}`;
+        let a: Dir = "top-left";
+        let b: Dir = "top-right";
+        let c: Dir = "bottom-right";
+        let d: Dir = "bottom-left";
         """
 
       let! _, env = inferScript src
@@ -682,8 +682,8 @@ let InferTemplateLiteralTypeError () =
     result {
       let src =
         """
-        type Foo = `foo${number}`
-        let x: Foo = "foo123abc"
+        type Foo = `foo${number}`;
+        let x: Foo = "foo123abc";
         """
 
       let! _, _ = inferScript src
@@ -698,8 +698,8 @@ let InferTemplateLiteralTypeErrorWithUnion () =
     result {
       let src =
         """
-        type Dir = `${"top" | "bottom"}-${"left" | "right"}`
-        let x: Dir = "top-bottom"
+        type Dir = `${"top" | "bottom"}-${"left" | "right"}`;
+        let x: Dir = "top-bottom";
         """
 
       let! _, _ = inferScript src
@@ -715,10 +715,10 @@ let InferUnaryOperations () =
 
       let src =
         """
-        let x = 5
-        let y = -x
-        let z = !x
-        let w = +x
+        let x = 5;
+        let y = -x;
+        let z = !x;
+        let w = +x;
         """
 
       let! _, env = inferScript src
@@ -741,7 +741,7 @@ let InferEnum () =
           | Bar([number, number])
           | Baz(number | string)
         }
-        let value = MyEnum.Foo(5, "hello", true)
+        let value = MyEnum.Foo(5, "hello", true);
         """
 
       let! _, env = inferScript src
@@ -770,7 +770,7 @@ let InferEnumVariantIsSubtypeOfEnum () =
           | Bar([number, number])
           | Baz(number | string)
         }
-        let value: MyEnum = MyEnum.Foo(5, "hello", true)
+        let value: MyEnum = MyEnum.Foo(5, "hello", true);
         """
 
       let! _, env = inferScript src
@@ -797,7 +797,7 @@ let InferGenericEnum () =
           | Bar(B)
           | Baz(C)
         }
-        let value = MyEnum.Foo(5)
+        let value = MyEnum.Foo(5);
         """
 
       let! _, env = inferScript src
@@ -822,12 +822,12 @@ let InferGenericEnumWithSubtyping () =
           | Bar(B)
           | Baz(C)
         }
-        let value: MyEnum<number, string, boolean> = MyEnum.Foo(5)
+        let value: MyEnum<number, string, boolean> = MyEnum.Foo(5);
         let x = match value {
           | MyEnum.Foo(a) => a
           | MyEnum.Bar(b) => b
           | MyEnum.Baz(c) => c
-        }
+        };
         """
 
       let! _, env = inferScript src
@@ -850,13 +850,13 @@ let InferEnumPatternMatching () =
           | Bar([number, number])
           | Baz({x: number, y: number})
         }
-        let value: MyEnum = MyEnum.Foo(5, "hello", true)
+        let value: MyEnum = MyEnum.Foo(5, "hello", true);
 
         let x = match value {
           | MyEnum.Foo(x, y, z) => x
           | MyEnum.Bar([x, y]) => x
           | MyEnum.Baz({x, y}) => x
-        }
+        };
         """
 
       let! _, env = inferScript src

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -588,7 +588,7 @@ let InferTuple () =
 let InferDeclare () =
   let result =
     result {
-      let src = "declare let [x, y]: [number, string, boolean]"
+      let src = "declare let [x, y]: [number, string, boolean];"
       let! _, env = inferScript src
       Assert.Value(env, "x", "number")
       Assert.Value(env, "y", "string")

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -14,10 +14,10 @@ let InferCollaspingNever () =
     result {
       let src =
         """
-        type Foo = string | never
-        type Bar = string | number | never
-        type Baz = string | number | never | never
-        type Qux = never | never
+        type Foo = string | never;
+        type Bar = string | number | never;
+        type Baz = string | number | never | never;
+        type Qux = never | never;
         """
 
       let! _, env = inferScript src
@@ -42,10 +42,10 @@ let InferSimpleConditionalType () =
           "number"
         } else {
           "other"
-        }
-        type A = Foo<string>
-        type B = Foo<number>
-        type C = Foo<boolean>
+        };
+        type A = Foo<string>;
+        type B = Foo<number>;
+        type C = Foo<boolean>;
         """
 
       let! ctx, env = inferScript src
@@ -86,10 +86,10 @@ let InferNestedConditionalTypes () =
           }
         } else {
           "other"
-        }
-        type A = Foo<string>
-        type B = Foo<number>
-        type C = Foo<boolean>
+        };
+        type A = Foo<string>;
+        type B = Foo<number>;
+        type C = Foo<boolean>;
         """
 
       let! ctx, env = inferScript src
@@ -122,8 +122,8 @@ let InferExclude () =
     result {
       let src =
         """
-        type Exclude<T, U> = if T: U { never } else { T }
-        type Result = Exclude<"a" | "b" | "c" | "d" | "e", "a" | "e">
+        type Exclude<T, U> = if T: U { never } else { T };
+        type Result = Exclude<"a" | "b" | "c" | "d" | "e", "a" | "e">;
         """
 
       let! ctx, env = inferScript src
@@ -143,9 +143,9 @@ let InferExtract () =
     result {
       let src =
         """
-        type Point = {x: number, y: number}
-        type Extract<T, U> = if T: Point { T } else { never }
-        type Result = Extract<{x: 5, y: 10} | number | string, Point>
+        type Point = {x: number, y: number};
+        type Extract<T, U> = if T: Point { T } else { never };
+        type Result = Extract<{x: 5, y: 10} | number | string, Point>;
         """
 
       let! ctx, env = inferScript src
@@ -174,8 +174,8 @@ let InferCartesianProdType () =
             }
           } else {
             never
-          }
-        type Cells = CartesianProduct<"A" | "B", 1 | 2>
+          };
+        type Cells = CartesianProduct<"A" | "B", 1 | 2>;
         """
 
       let! ctx, env = inferScript src
@@ -200,10 +200,10 @@ let InfersPickUnionOfKey () =
         """
         type Pick<T, K: keyof T> = {
           [P]: T[P] for P in K
-        }
+        };
 
-        type Foo = {a: number, b: string, c: boolean}
-        type Bar = Pick<Foo, "a" | "c">
+        type Foo = {a: number, b: string, c: boolean};
+        type Bar = Pick<Foo, "a" | "c">;
         """
 
       let! ctx, env = inferScript src
@@ -225,10 +225,10 @@ let InfersPickSingleKey () =
         """
         type Pick<T, K: keyof T> = {
           [P]: T[P] for P in K
-        }
+        };
 
-        type Foo = {a: number, b: string, c: boolean}
-        type Bar = Pick<Foo, "a" | "c">
+        type Foo = {a: number, b: string, c: boolean};
+        type Bar = Pick<Foo, "a" | "c">;
         """
 
       let! ctx, env = inferScript src
@@ -250,10 +250,10 @@ let InfersPickWrongKeyType () =
         """
         type Pick<T, K: keyof T> = {
           [P]: T[P] for P in K
-        }
+        };
 
-        type Foo = {a: number, b: string, c: boolean}
-        type Bar = Pick<Foo, 5 | 10>
+        type Foo = {a: number, b: string, c: boolean};
+        type Bar = Pick<Foo, 5 | 10>;
         """
 
       let! ctx, env = inferScript src
@@ -276,13 +276,13 @@ let InfersOmit () =
         """
         type Pick<T, K: keyof T> = {
           [P]: T[P] for P in K
-        }
-        type Exclude<T, U> = if T : U { never } else { T }
-        type AnyKey = string | number | symbol
-        type Omit<T, K: AnyKey> = Pick<T, Exclude<keyof T, K>>
+        };
+        type Exclude<T, U> = if T : U { never } else { T };
+        type AnyKey = string | number | symbol;
+        type Omit<T, K: AnyKey> = Pick<T, Exclude<keyof T, K>>;
         
-        type Foo = {a: number, b: string, c: boolean}
-        type Bar = Omit<Foo, "b">
+        type Foo = {a: number, b: string, c: boolean};
+        type Bar = Omit<Foo, "b">;
         """
 
       let! ctx, env = inferScript src
@@ -302,12 +302,12 @@ let InfersRecord () =
     result {
       let src =
         """
-        type AnyKey = string | number | symbol
+        type AnyKey = string | number | symbol;
         type Record<K: AnyKey, T> = {
           [P]: T for P in K
-        }
-        type Point = Record<"x" | "y", number>
-        let p: Point = {x: 5, y: 10}
+        };
+        type Point = Record<"x" | "y", number>;
+        let p: Point = {x: 5, y: 10};
         """
 
       let! _, env = inferScript src
@@ -324,8 +324,8 @@ let InfersNestedConditionals () =
     result {
       let src =
         """
-        type Extends<X, Y, Z> = if X : Y { X } else { if Y : Z { Y } else { never } }
-        type Foo = Extends<5 | 10, 2 | 3 | 5 | 7, 3 | 6 | 9>
+        type Extends<X, Y, Z> = if X : Y { X } else { if Y : Z { Y } else { never } };
+        type Foo = Extends<5 | 10, 2 | 3 | 5 | 7, 3 | 6 | 9>;
         """
 
       let! ctx, env = inferScript src
@@ -346,9 +346,9 @@ let InfersReturnType () =
     result {
       let src =
         """
-        type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never }
-        type Foo = ReturnType<fn () -> number>
-        type Bar = ReturnType<fn (a: string, b: boolean) -> number>
+        type ReturnType<T> = if T: fn (...args: _) -> infer R { R } else { never };
+        type Foo = ReturnType<fn () -> number>;
+        type Bar = ReturnType<fn (a: string, b: boolean) -> number>;
         """
 
       let! ctx, env = inferScript src
@@ -374,9 +374,9 @@ let InfersParameters () =
     result {
       let src =
         """
-        type Parameters<T> = if T: fn (...args: infer P) -> _ { P } else { never }
-        type Foo = Parameters<fn () -> number>
-        type Bar = Parameters<fn (a: string, b: boolean) -> number>
+        type Parameters<T> = if T: fn (...args: infer P) -> _ { P } else { never };
+        type Foo = Parameters<fn () -> number>;
+        type Bar = Parameters<fn (a: string, b: boolean) -> number>;
         """
 
       let! ctx, env = inferScript src


### PR DESCRIPTION
Semi-colons are now required to terminate the following things:
- var decls
- type decls
- return statements
- expression statements (excluding if-else, try-catch, match, and do expressions)

TODO:
- [x] imports
- [x] declare-let