### PR TITLE
Update existing TypeChecker tests to assert that ctx.Diagnostics is empty

### DIFF
--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -59,12 +59,12 @@ let InferTupleLength () =
         let length = tuple.length;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "length", "3")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -77,12 +77,12 @@ let InferArrayLength () =
         let length = array.length;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "length", "unique number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -98,15 +98,15 @@ let InferTupleIndexing () =
         let fourth = tuple[3];
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "first", "5")
       Assert.Value(env, "second", "\"hello\"")
       Assert.Value(env, "third", "true")
       Assert.Value(env, "fourth", "undefined")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -122,13 +122,13 @@ let InferArrayIndexing () =
         let fourth = array[3];
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "first", "number | undefined")
       Assert.Value(env, "fourth", "number | undefined")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -233,8 +233,9 @@ let InferRangeWithNegativeStart () =
         declare let range: -1..1;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "range", "-1..1")
     }
 
@@ -253,8 +254,9 @@ let InferRangeMath () =
         let range_plus_range = range + range;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "inc_range", "1..4")
       Assert.Value(env, "dec_range", "-1..2")
       Assert.Value(env, "mul_range", "0..6")
@@ -282,14 +284,14 @@ let InferRangeWithArrayLength () =
         let first = array[0];
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "length", "unique number")
       Assert.Value(env, "first", "number | undefined")
       Assert.Value(env, "elem", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -311,8 +313,9 @@ let InferRangeWithDifferentArrayLengths () =
         let elem2 = array2[range2];
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "elem1", "number")
       Assert.Value(env, "elem2", "string")
     }
@@ -338,8 +341,7 @@ let InferRangeWithDifferentArrayLengthsAreIncompatible () =
         let elem2 = array2[range1];
         """
 
-      let! _, env = inferScript src
-
+      let! _ = inferScript src
       ()
     }
 
@@ -357,13 +359,13 @@ let InferDestructureArray () =
         let [a, ...rest] = array;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "number | undefined")
       Assert.Value(env, "rest", "number[]")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -377,8 +379,9 @@ let InferDestructureTuple () =
         let [a, ...rest] = tuple;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "rest", "[string, boolean]")
     }
 
@@ -394,8 +397,9 @@ let InferBasicImmutableTypes () =
         let record = #{ a: 5, b: "hello", c: true };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "tuple", "#[5, \"hello\", true]")
       Assert.Value(env, "record", "#{a: 5, b: \"hello\", c: true}")
     }
@@ -415,8 +419,9 @@ let DestructuringImmutableTypes () =
         let #{g, h} = #{g: 5, h: "hello"};
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "5")
       Assert.Value(env, "b", "\"hello\"")
       Assert.Value(env, "c", "5")
@@ -439,8 +444,9 @@ let PartialDestructuring () =
         let {b} = {a: 5, b: "hello"};
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "5")
       Assert.Value(env, "b", "\"hello\"")
     }
@@ -457,7 +463,7 @@ let ImmutableTuplesAreIncompatibleWithRegularTuples () =
         foo([5, 10]);
         """
 
-      let! ctx, env = inferScript src
+      let! ctx, _ = inferScript src
 
       Assert.Equal(ctx.Diagnostics.Length, 1)
     }
@@ -474,12 +480,11 @@ let ImmutableObjectsAreIncompatibleWithRegularObjects () =
         foo({x:5, y:10});
         """
 
-      let! ctx, env = inferScript src
+      let! ctx, _ = inferScript src
 
       Assert.Equal(ctx.Diagnostics.Length, 1)
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -492,10 +497,10 @@ let DescructuringArray () =
         let [a, b] = array;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "number | undefined")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
+++ b/src/Escalier.TypeChecker.Tests/AsyncAwait.fs
@@ -20,8 +20,9 @@ let InfersAsyncFunc () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "fn () -> Promise<5, never>")
       Assert.Value(env, "bar", "fn () -> Promise<15, never>")
     }
@@ -37,7 +38,9 @@ let InfersAsyncError () =
         let foo = async fn (x) => if x < 0 { throw "RangeError" } else { x };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -61,7 +64,9 @@ let InfersPropagateAsyncError () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -94,7 +99,9 @@ let InfersTryCatchAsync () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -109,5 +116,4 @@ let InfersTryCatchAsync () =
       )
     }
 
-  printfn "res: %A" res
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Exceptions.fs
+++ b/src/Escalier.TypeChecker.Tests/Exceptions.fs
@@ -19,7 +19,9 @@ let InfersExplicitThrow () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -28,7 +30,6 @@ let InfersExplicitThrow () =
       )
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -41,7 +42,9 @@ let InfersThrowExpression () =
           if x < 0 { throw "RangeError" } else { x };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -61,8 +64,9 @@ let InfersJustThrowExpression () =
         let foo = fn <T: string>(exc: T) => throw exc;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "fn <T: string>(exc: T) -> never throws T")
     }
 
@@ -78,7 +82,9 @@ let InfersThrowingMultipleExpressions () =
           if x < 0 { throw "RangeError" } else { throw "BoundsError" };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -101,7 +107,9 @@ let InfersThrowsFromCall () =
         let bar = fn (x) => foo(x);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -135,8 +143,9 @@ let InferCatchesException () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "fn <A: number>(x: A) -> A | 0")
     }
 
@@ -160,12 +169,12 @@ let InferCatchesMultipleExceptions () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "fn <A: number>(x: A) -> 0")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -185,7 +194,9 @@ let InferCatchesOneOfManyExceptions () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -194,7 +205,6 @@ let InferCatchesOneOfManyExceptions () =
       )
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -216,6 +226,8 @@ let InferTryFinally () =
         """
 
       let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -248,8 +260,8 @@ let InferTryCatchFinally () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "fn <A: number>(x: A) -> A | 0")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Modules.fs
+++ b/src/Escalier.TypeChecker.Tests/Modules.fs
@@ -17,8 +17,9 @@ let InferBasicModule () =
         let sub = fn(a, b) => a - b;
         """
 
-      let! _, env = inferModule src
+      let! ctx, env = inferModule src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "add", "fn <A: number, B: number>(a: A, b: B) -> A + B")
       Assert.Value(env, "sub", "fn <A: number, B: number>(a: A, b: B) -> A - B")
     }
@@ -35,13 +36,13 @@ let InferMutuallyRecursiveFunctions () =
         let bar = fn() => foo() - 1;
         """
 
-      let! _, env = inferModule src
+      let! ctx, env = inferModule src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "fn () -> number")
       Assert.Value(env, "bar", "fn () -> number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -63,13 +64,13 @@ let InferMutualRecursion () =
         };
         """
 
-      let! _, env = inferModule src
+      let! ctx, env = inferModule src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "even", "fn (x: number) -> true | !boolean")
       Assert.Value(env, "odd", "fn (x: number) -> true | !(true | !boolean)")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -82,13 +83,13 @@ let InferMutuallyRecursiveTypes () =
         type Bar<T> = {foo: Foo<T>};
         """
 
-      let! _, env = inferModule src
+      let! ctx, env = inferModule src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "Foo", "<T>({bar: Bar<T>})")
       Assert.Type(env, "Bar", "<T>({foo: Foo<T>})")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -101,10 +102,10 @@ let InferImports () =
       files.Add("/foo.esc", MockFileData("let foo = 5;"))
       let mockFileSystem = MockFileSystem(files, "/")
 
-      let! _, env = inferModules mockFileSystem src
+      let! ctx, env = inferModules mockFileSystem src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "5")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Mutability.fs
+++ b/src/Escalier.TypeChecker.Tests/Mutability.fs
@@ -106,7 +106,9 @@ let InferFnWithMutableParam () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -131,7 +133,9 @@ let MutableParamsAreInvariant () =
         foo(numbers);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -264,7 +268,9 @@ let ImmutableParamsAreCovariant () =
         foo(numbers);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -297,7 +303,6 @@ let MutableObjectPartialInitialization () =
       ()
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -322,7 +327,6 @@ let MutableArrayPartialInitialization () =
       ()
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -407,5 +411,4 @@ let MutableArrayPartialInitializationError () =
       ()
     }
 
-  printfn "result = %A" result
   Assert.True(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/PatternMatching.fs
+++ b/src/Escalier.TypeChecker.Tests/PatternMatching.fs
@@ -20,7 +20,9 @@ let BasicPatternMatching () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -47,7 +49,9 @@ let BasicPatternMatchingInferExpr () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -82,7 +86,9 @@ let BasicPatternMatchingInferExprWithMultipleTypeVariables () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Value(
         env,
@@ -128,8 +134,9 @@ let PatternMatchingObjects () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       // TODO: Simplify all binary type in a type
       // {x: number / 2, y: number / 2} -> {x: number, y: number}
       // TODO: figure out how to have a type alias subsume a type that's the
@@ -173,8 +180,9 @@ let PatternMatchingObjectsWithBlockBody () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       // The `number / 2` was simplified to `number` in this case because
       // it's assigned to a variable before being used in the object
       Assert.Value(env, "centroid", "Point | {x: number, y: number}")
@@ -198,12 +206,12 @@ let PatternMatchingArrays () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "sum", "fn (arg0: number[]) -> number")
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -222,8 +230,9 @@ let PatternMatchingPrimitiveAssertions () =
           };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "result", "number | string | true")
     }
 
@@ -242,8 +251,9 @@ let PartialPatternMatchingObject () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "result", "number | string")
     }
 
@@ -266,12 +276,12 @@ let PatternMatchingImmutableTypes () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "result", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 

--- a/src/Escalier.TypeChecker.Tests/Structs.fs
+++ b/src/Escalier.TypeChecker.Tests/Structs.fs
@@ -15,8 +15,9 @@ let InferBasicStruct () =
         let point = Point {x: 5, y: 10};
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "point", "Point")
     }
 
@@ -48,8 +49,9 @@ let InferGenericStruct () =
         let point = Point<number> {x: 5, y: 10};
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "point", "Point<number>")
     }
 
@@ -65,8 +67,9 @@ let StructsAreSubtypesOfObjects () =
         let point: {x: number, y: number} = Point {x: 5, y: 10};
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "point", "{x: number, y: number}")
     }
 
@@ -83,8 +86,9 @@ let PropertyAccessOnStructs () =
         let x = point.x;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
     }
 
@@ -138,12 +142,12 @@ let PropertyAccessOnPrivateStructs () =
         let x = point.x;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact(Skip = "update getPropType to return an Result")>]
@@ -177,8 +181,9 @@ let ObjectDestructuringOfStructs () =
         let {x, y} = point;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
     }
 
@@ -195,8 +200,9 @@ let StructDestructuring () =
         let Point {x, y} = point;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
     }
 
@@ -228,8 +234,9 @@ let BasicStructAndImpl () =
         let baz = foo.baz();
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
       Assert.Value(env, "y", "string")
       Assert.Value(env, "bar", "number")
@@ -263,8 +270,9 @@ let CallingMethodInPreviousImpl () =
         let baz = foo.baz();
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "number")
       Assert.Value(env, "baz", "number")
     }
@@ -293,12 +301,12 @@ let GetterSetterImpl () =
         foo.baz = "world";
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -324,8 +332,9 @@ let CallingMethodInSameImpl () =
         let baz = foo.baz();
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "number")
       Assert.Value(env, "baz", "number")
     }
@@ -350,13 +359,13 @@ let InferGenericImpls () =
         let bar = point.bar();
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "point", "Point<number>")
       Assert.Value(env, "bar", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -387,13 +396,13 @@ let InferGenericImplsWithParams () =
         let qux = foo.qux; 
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "Foo<number>")
       Assert.Value(env, "qux", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -409,11 +418,12 @@ let InferGenericRecursiveStruct () =
         }
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "Node", "<T>(Node)")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact(Skip = "TODO: Stack overflow")>]
@@ -440,12 +450,12 @@ let InferRecursiveStructType () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "node", "Node<number>")
     }
 
-  printf "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact(Skip = "TODO: Stack overflow")>]
@@ -471,11 +481,10 @@ let InferGenericRecursiveStructWithImpls () =
         }
         """
 
-      let! _, env = inferScript src
+      let! _ = inferScript src
       ()
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -501,8 +510,9 @@ let RecursiveMethodsCanBeInferred () =
         let fact = foo.fact;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "res", "number")
       Assert.Value(env, "fact", "fn (self: Self, n: number) -> number")
     }
@@ -534,7 +544,9 @@ let MutMethodsCanCallOtherMutMethods () =
         let baz = foo.baz;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "bar", "fn (mut self: Self, x: number) -> number")
       Assert.Value(env, "baz", "fn (mut self: Self, x: number) -> number")
     }
@@ -616,12 +628,13 @@ let StaticMethods () =
         let {x, y} = p;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "p", "Self") // TODO: should be Point
       Assert.Value(env, "q", "Point")
       Assert.Value(env, "x", "number")
       Assert.Value(env, "y", "number")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -58,8 +58,9 @@ let InfersTypeofWellknownSymbol () =
         let iterator: typeof Symbol.iterator = Symbol.iterator;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "iterator", "symbol()")
     }
 

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -79,7 +79,6 @@ let InferSimpleTypeError () =
       printDiagnostics ctx.Diagnostics
     }
 
-  printfn "result = %A" result
   Assert.True(Result.isError result)
 
 [<Fact>]
@@ -129,8 +128,9 @@ let InferIfElseChaining () =
       };
       """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "5 | \"hello\" | true")
     }
 
@@ -163,8 +163,9 @@ let InferIdentifier () =
 let InferLetStatements () =
   let result =
     result {
-      let! _, env = inferScript "let foo = 5;\nlet bar =\"hello\";"
+      let! ctx, env = inferScript "let foo = 5;\nlet bar =\"hello\";"
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "5")
       Assert.Value(env, "bar", "\"hello\"")
     }
@@ -182,8 +183,9 @@ let InferBinOpsOnPrimitives () =
           let sum = x + y;
           """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "sum", "15")
     }
 
@@ -202,8 +204,9 @@ let InferTypeDecls () =
           type Nullable<T> = T | undefined;
           """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "A", "number")
       Assert.Type(env, "B", "[string, boolean]")
       Assert.Type(env, "C", "5 | \"hello\"")
@@ -211,7 +214,6 @@ let InferTypeDecls () =
       Assert.Type(env, "Nullable", "<T>(T | undefined)")
     }
 
-  printfn "result = %A" result
 
   Assert.False(Result.isError result)
 
@@ -230,15 +232,15 @@ let InferPrivateDecl () =
           let {x, y} = p;
           """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "makePoint", "fn (x: number, y: number) -> Point")
       Assert.Value(env, "p", "Point")
       Assert.Value(env, "x", "number")
       Assert.Value(env, "y", "number")
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -251,12 +253,12 @@ let InferTypeAliasOfPrimtiveType () =
         let x: Bar = 5;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "Bar")
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -271,8 +273,9 @@ let InferTypeAnn () =
         let {x, y}: Point = {x: 5, y: 10};
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "number")
       Assert.Value(env, "b", "string")
       Assert.Value(env, "c", "boolean")
@@ -296,8 +299,9 @@ let InferObjectDestructuring () =
         foo({x, y});
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
       Assert.Value(env, "y", "number")
       Assert.Value(env, "p", "Point")
@@ -319,8 +323,9 @@ let InferObjectRestSpread () =
         foo(obj2);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "5")
       Assert.Value(env, "rest", "{b: \"hello\", c: true}")
       Assert.Value(env, "obj2", "{a: 5} & {b: \"hello\", c: true}")
@@ -339,8 +344,9 @@ let InferObjProps () =
         let c = obj.a.c;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "b", "5")
       Assert.Value(env, "c", "\"hello\"")
     }
@@ -363,8 +369,9 @@ let InferOptionalChaining () =
         let x = p?.x;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "obj", "Obj")
       Assert.Value(env, "a", "{b?: {c: number}} | undefined")
       Assert.Value(env, "b", "{c: number} | undefined")
@@ -373,7 +380,6 @@ let InferOptionalChaining () =
       Assert.Value(env, "x", "number")
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -389,8 +395,9 @@ let InferRecursiveType () =
         let z: Foo = [5, [10, 15]];
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "Foo", "number | Foo[]")
       Assert.Value(env, "x", "Foo")
       Assert.Value(env, "y", "Foo")
@@ -412,8 +419,9 @@ let InferRecursiveTypeUnifyWithDefn () =
         let bar: number | Foo[] = foo;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "Foo", "number | Foo[]")
     }
 
@@ -444,12 +452,12 @@ let InferRecursiveObjectType () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "node", "Node")
     }
 
-  printf "result = %A" result
   Assert.False(Result.isError result)
 
 
@@ -479,12 +487,12 @@ let InferRecursiveGenericObjectType () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "node", "Node<number>")
     }
 
-  printf "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -516,13 +524,13 @@ let ReturnRecursivePrivateGenericObjectType () =
         let x = node.left?.value;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "node", "Node<number>")
       Assert.Value(env, "x", "number | undefined")
     }
 
-  printf "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -554,13 +562,13 @@ let ReturnRecursiveGenericObjectType () =
         let x = node.left?.value;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "node", "Node<number>")
       Assert.Value(env, "x", "number | undefined")
     }
 
-  printf "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact(Skip = "TODO: unify tuples and arrays")>]
@@ -574,14 +582,14 @@ let InferTuple () =
         let baz = bar(foo);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "[1, 2, 3]")
       Assert.Value(env, "bar", "fn (nums: number[]) -> number[]")
       Assert.Value(env, "baz", "number[]")
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]
@@ -589,12 +597,14 @@ let InferDeclare () =
   let result =
     result {
       let src = "declare let [x, y]: [number, string, boolean];"
-      let! _, env = inferScript src
+
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "number")
       Assert.Value(env, "y", "string")
     }
 
-  printfn "result = %A" result
 
   Assert.False(Result.isError result)
 
@@ -614,14 +624,15 @@ let InferTemplateLiteralType () =
         let w: Baz = "ABCBC";
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "Foo")
       Assert.Value(env, "y", "Bar")
       Assert.Value(env, "z", "Baz")
       Assert.Value(env, "w", "Baz")
     }
 
-  printfn "result = %A" result
 
   Assert.False(Result.isError result)
 
@@ -639,7 +650,9 @@ let InferTemplateLiteralTypeWithUnions () =
         let d: Dir = "bottom-left";
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "a", "Dir")
       Assert.Value(env, "b", "Dir")
       Assert.Value(env, "c", "Dir")
@@ -721,7 +734,9 @@ let InferUnaryOperations () =
         let w = +x;
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "5")
       Assert.Value(env, "y", "-5")
       Assert.Value(env, "z", "!5")
@@ -744,7 +759,9 @@ let InferEnum () =
         let value = MyEnum.Foo(5, "hello", true);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Type(
         env,
@@ -773,7 +790,9 @@ let InferEnumVariantIsSubtypeOfEnum () =
         let value: MyEnum = MyEnum.Foo(5, "hello", true);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       Assert.Type(
         env,
@@ -800,8 +819,9 @@ let InferGenericEnum () =
         let value = MyEnum.Foo(5);
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "MyEnum", "<A, B, C>(Foo(A) | Bar(B) | Baz(C))")
 
       // TODO: how do we include `MyEnum.` in the type?
@@ -830,8 +850,9 @@ let InferGenericEnumWithSubtyping () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       Assert.Type(env, "MyEnum", "<A, B, C>(Foo(A) | Bar(B) | Baz(C))")
       Assert.Value(env, "value", "MyEnum<number, string, boolean>")
       Assert.Value(env, "x", "number | string | boolean")
@@ -933,8 +954,9 @@ let InferIfLetWithShadowing () =
         };
         """
 
-      let! _, env = inferScript src
+      let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
       // TODO: fix this shadowing issue
       Assert.Value(env, "y", "t3:number + 1 | 0")
     }
@@ -1029,7 +1051,6 @@ let InferLetElseEarlyReturn () =
       Assert.Value(env, "foo", "fn (x: number | undefined) -> number")
     }
 
-  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -69,7 +69,6 @@ let InferSimpleConditionalType () =
       Assert.Equal("\"other\"", c.ToString())
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -94,6 +93,8 @@ let InferNestedConditionalTypes () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
+
       let! a =
         expandScheme ctx env None (Map.find "A" env.Schemes) Map.empty None
         |> Result.mapError CompileError.TypeError
@@ -113,7 +114,6 @@ let InferNestedConditionalTypes () =
       Assert.Equal("\"other\"", c.ToString())
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -127,6 +127,8 @@ let InferExclude () =
         """
 
       let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       let! result =
         expandScheme ctx env None (Map.find "Result" env.Schemes) Map.empty None
@@ -149,6 +151,8 @@ let InferExtract () =
         """
 
       let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       let! result =
         expandScheme ctx env None (Map.find "Result" env.Schemes) Map.empty None
@@ -180,6 +184,8 @@ let InferCartesianProdType () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
+
       let! result =
         expandScheme ctx env None (Map.find "Cells" env.Schemes) Map.empty None
         |> Result.mapError CompileError.TypeError
@@ -208,6 +214,8 @@ let InfersPickUnionOfKey () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
+
       let! result =
         expandScheme ctx env None (Map.find "Bar" env.Schemes) Map.empty None
         |> Result.mapError CompileError.TypeError
@@ -233,6 +241,8 @@ let InfersPickSingleKey () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
+
       let! result =
         expandScheme ctx env None (Map.find "Bar" env.Schemes) Map.empty None
         |> Result.mapError CompileError.TypeError
@@ -257,6 +267,8 @@ let InfersPickWrongKeyType () =
         """
 
       let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       let! result =
         expandScheme ctx env None (Map.find "Bar" env.Schemes) Map.empty None
@@ -287,6 +299,8 @@ let InfersOmit () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
+
       let! result =
         expandScheme ctx env None (Map.find "Bar" env.Schemes) Map.empty None
         |> Result.mapError CompileError.TypeError
@@ -315,7 +329,6 @@ let InfersRecord () =
       Assert.Value(env, "p", "Point")
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -330,6 +343,8 @@ let InfersNestedConditionals () =
 
       let! ctx, env = inferScript src
 
+      Assert.Empty(ctx.Diagnostics)
+
       let! result =
         expandScheme ctx env None (Map.find "Foo" env.Schemes) Map.empty None
         |> Result.mapError CompileError.TypeError
@@ -337,7 +352,6 @@ let InfersNestedConditionals () =
       Assert.Equal("5 | 3", result.ToString())
     }
 
-  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]
@@ -352,6 +366,8 @@ let InfersReturnType () =
         """
 
       let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       let! result =
         expandScheme ctx env None (Map.find "Foo" env.Schemes) Map.empty None
@@ -380,6 +396,8 @@ let InfersParameters () =
         """
 
       let! ctx, env = inferScript src
+
+      Assert.Empty(ctx.Diagnostics)
 
       let! result =
         expandScheme ctx env None (Map.find "Foo" env.Schemes) Map.empty None

--- a/src/Escalier.TypeChecker/TemplateLiteral.fs
+++ b/src/Escalier.TypeChecker/TemplateLiteral.fs
@@ -85,7 +85,5 @@ module TemplateLiteral =
       parser <- (pstring firstPart |>> ignore) .>> parser
 
     match run parser s with
-    | Success((), _, pos) ->
-      printfn "pos = %A" pos
-      true
+    | Success((), _, pos) -> true
     | Failure _ -> false


### PR DESCRIPTION
This ensures that we're always check to see whether there are any recoverable errors (diagnostics) or not.