### PR TITLE
Use filesystem directly

### DIFF
--- a/src/Escalier.Codegen.Tests/Escalier.Codegen.Tests.fsproj
+++ b/src/Escalier.Codegen.Tests/Escalier.Codegen.Tests.fsproj
@@ -16,7 +16,6 @@
     <ItemGroup>
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4"/>
         <PackageReference Include="Verify.Xunit" Version="22.1.4"/>
         <PackageReference Include="xunit" Version="2.5.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Escalier.Codegen.Tests/Tests.fs
+++ b/src/Escalier.Codegen.Tests/Tests.fs
@@ -5,7 +5,6 @@ open Xunit
 open VerifyXunit
 open VerifyTests
 open FsToolkit.ErrorHandling
-open System.IO.Abstractions
 
 open Escalier.Compiler
 open Escalier.Data
@@ -272,9 +271,8 @@ let CodegenDtsBasics () =
       let! escAst =
         Parser.parseScript src |> Result.mapError CompileError.ParseError
 
-      let fs = FileSystem()
       let projectRoot = __SOURCE_DIRECTORY__
-      let! ctx, env = Prelude.getEnvAndCtx fs projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
         Infer.inferScript ctx env "input.esc" escAst
@@ -305,9 +303,8 @@ let CodegenDtsGeneric () =
       let! ast =
         Parser.parseScript src |> Result.mapError CompileError.ParseError
 
-      let fs = FileSystem()
       let projectRoot = __SOURCE_DIRECTORY__
-      let! ctx, env = Prelude.getEnvAndCtx fs projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       // TODO: as part of generalization, we need to update the function's
       // inferred type

--- a/src/Escalier.Compiler.Tests/Escalier.Compiler.Tests.fsproj
+++ b/src/Escalier.Compiler.Tests/Escalier.Compiler.Tests.fsproj
@@ -15,7 +15,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Escalier.Compiler.Tests/Tests.fs
+++ b/src/Escalier.Compiler.Tests/Tests.fs
@@ -3,7 +3,6 @@ module Tests
 open FsToolkit.ErrorHandling
 open Xunit
 open System.IO
-open System.IO.Abstractions
 
 open Escalier.Compiler
 open Escalier.TypeChecker.Env
@@ -83,10 +82,8 @@ let BasicsTests (fixtureDir: string) =
           Some(content)
         | false -> None
 
-
-      let filesystem = FileSystem()
       let mockWriter = new StringWriter()
-      do! Compiler.compileFile filesystem mockWriter fixtureDir entryPath
+      do! Compiler.compileFile mockWriter fixtureDir entryPath
 
       let mutable actual: Map<string, Output> = Map.empty
 

--- a/src/Escalier.Compiler/Compiler.fs
+++ b/src/Escalier.Compiler/Compiler.fs
@@ -2,7 +2,6 @@
 
 open FsToolkit.ErrorHandling
 open System.IO
-open System.IO.Abstractions
 
 open Escalier.Codegen
 open Escalier.Parser
@@ -46,21 +45,15 @@ module Compiler =
   /// <summary>
   /// Compiles the source code located at the specified base directory.
   /// </summary>
-  /// <param name="filesystem">The filesystem to use.</param>
   /// <param name="textwriter">The text writer to use for diagnostics.</param>
   /// <param name="baseDir">The base directory where the source code is located.</param>
   /// <param name="srcFile">The name of the source code file.</param>
   /// <returns>The compiled code.</returns>
-  let compileFile
-    (filesystem: IFileSystem)
-    (textwriter: TextWriter)
-    (baseDir: string)
-    (srcFile: string)
-    =
+  let compileFile (textwriter: TextWriter) (baseDir: string) (srcFile: string) =
     result {
       let filename = srcFile
-      let contents = filesystem.File.ReadAllText filename
-      let! ctx, env = Prelude.getEnvAndCtx filesystem baseDir
+      let contents = File.ReadAllText filename
+      let! ctx, env = Prelude.getEnvAndCtx baseDir
 
       let! ast =
         Parser.parseScript contents |> Result.mapError CompileError.ParseError
@@ -84,23 +77,21 @@ module Compiler =
         |> String.concat "\n"
 
       let outJsName = Path.ChangeExtension(filename, ".js")
-      filesystem.File.WriteAllText(outJsName, js)
+      File.WriteAllText(outJsName, js)
 
       let outDtsName = Path.ChangeExtension(filename, ".d.ts")
-      filesystem.File.WriteAllText(outDtsName, dts)
+      File.WriteAllText(outDtsName, dts)
 
       return ()
     }
 
   let compileFiles
-    (filesystem: IFileSystem)
-    (textwriter: TextWriter)
     (baseDir: string) // e.g. src/ or fixtures/basics/test1/
     (entry: string)
     =
     result {
-      let! ctx, env = Prelude.getEnvAndCtx filesystem baseDir
-      let contents = filesystem.File.ReadAllText(entry)
+      let! ctx, env = Prelude.getEnvAndCtx baseDir
+      let contents = File.ReadAllText(entry)
 
       let! m =
         Parser.parseScript contents |> Result.mapError CompileError.ParseError

--- a/src/Escalier.Compiler/Escalier.Compiler.fsproj
+++ b/src/Escalier.Compiler/Escalier.Compiler.fsproj
@@ -21,7 +21,6 @@
     <ItemGroup>
         <PackageReference Include="FSharpPlus" Version="1.5.0"/>
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="20.0.4"/>
     </ItemGroup>
 
 </Project>

--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -4,7 +4,6 @@ open FParsec.Error
 open FsToolkit.ErrorHandling
 open System
 open System.IO
-open System.IO.Abstractions
 
 open Escalier.Data
 open Escalier.Data.Common
@@ -270,7 +269,6 @@ module Prelude =
       env
 
   let getCtx
-    (filesystem: IFileSystem)
     (projectRoot: string)
     (globalEnv: Env)
     : Result<Ctx, CompileError> =
@@ -285,7 +283,7 @@ module Prelude =
                 ".esc"
               )
 
-            let contents = filesystem.File.ReadAllText(resolvedImportPath)
+            let contents = File.ReadAllText(resolvedImportPath)
 
             let m =
               match Parser.parseScript contents with
@@ -329,14 +327,11 @@ module Prelude =
 
   // TODO: add memoization
   // This is hard to memoize without reusing the filesystem
-  let getEnvAndCtx
-    (filesystem: IFileSystem)
-    (baseDir: string)
-    : Result<Ctx * Env, CompileError> =
+  let getEnvAndCtx (baseDir: string) : Result<Ctx * Env, CompileError> =
 
     result {
       let env = getGlobalEnvMemoized ()
-      let! ctx = getCtx filesystem baseDir env
+      let! ctx = getCtx baseDir env
 
       return ctx, env
     }
@@ -380,10 +375,7 @@ module Prelude =
 
   // TODO: add memoization
   // This is hard to memoize without reusing the filesystem
-  let getEnvAndCtxWithES5
-    (filesystem: IFileSystem)
-    (baseDir: string)
-    : Result<Ctx * Env, CompileError> =
+  let getEnvAndCtxWithES5 (baseDir: string) : Result<Ctx * Env, CompileError> =
 
     let dir = Directory.GetCurrentDirectory()
     let rootDir = findNearestAncestorWithNodeModules dir
@@ -391,7 +383,7 @@ module Prelude =
 
     result {
       let env = getGlobalEnvMemoized ()
-      let! ctx = getCtx filesystem baseDir env
+      let! ctx = getCtx baseDir env
 
       let! env = inferLib ctx env rootDir "typescript/lib/lib.es5.d.ts"
 

--- a/src/Escalier.Interop.Tests/Escalier.Interop.Tests.fsproj
+++ b/src/Escalier.Interop.Tests/Escalier.Interop.Tests.fsproj
@@ -53,7 +53,6 @@
     <ItemGroup>
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4"/>
         <PackageReference Include="Verify.Xunit" Version="22.1.4"/>
         <PackageReference Include="xunit" Version="2.5.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -1,7 +1,6 @@
 [<VerifyXunit.UsesVerify>]
 module Tests
 
-open System.IO.Abstractions
 open FsToolkit.ErrorHandling
 open FParsec.CharParsers
 open System.IO
@@ -35,9 +34,8 @@ let inferScript src =
     printfn $"projectRoot = {projectRoot}"
     let! ast = Parser.parseScript src |> Result.mapError CompileError.ParseError
 
-    let filesystem = FileSystem()
     let filename = Path.Combine(projectRoot, "input.src")
-    let! ctx, env = Prelude.getEnvAndCtxWithES5 filesystem projectRoot
+    let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
 
     let! env =
       Infer.inferScript ctx env filename ast
@@ -303,8 +301,7 @@ let InferBasicVarDecls () =
         | Failure(_, parserError, _) ->
           Result.mapError CompileError.ParseError (Result.Error(parserError))
 
-      let filesystem = FileSystem()
-      let! ctx, env = Prelude.getEnvAndCtx filesystem projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! newEnv =
         inferModule ctx env ast |> Result.mapError CompileError.TypeError
@@ -339,8 +336,7 @@ let InferTypeDecls () =
         | Failure(_, parserError, _) ->
           Result.mapError CompileError.ParseError (Result.Error(parserError))
 
-      let filesystem = FileSystem()
-      let! ctx, env = Prelude.getEnvAndCtx filesystem projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! newEnv =
         inferModule ctx env ast |> Result.mapError CompileError.TypeError
@@ -358,8 +354,7 @@ let InferTypeDecls () =
 let InferLibES5 () =
   let result =
     result {
-      let filesystem = FileSystem()
-      let! ctx, env = Prelude.getEnvAndCtxWithES5 filesystem "/"
+      let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
       // let! newEnv = prelude.loadTypeDefinitions ctx env
 
       // printfn "---- Schemes ----"
@@ -381,8 +376,7 @@ let InferLibES5 () =
 let InferArrayPrototype () =
   let result =
     result {
-      let filesystem = FileSystem()
-      let! ctx, env = Prelude.getEnvAndCtxWithES5 filesystem projectRoot
+      let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
 
       let scheme = Map.find "Array" env.Schemes
       // printfn $"Array = {scheme}"
@@ -399,8 +393,7 @@ let InferArrayPrototype () =
 let InferInt8ArrayPrototype () =
   let result =
     result {
-      let filesystem = FileSystem()
-      let! ctx, env = Prelude.getEnvAndCtxWithES5 filesystem projectRoot
+      let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
 
       let scheme = Map.find "Int8Array" env.Schemes
 

--- a/src/Escalier.Playground/Escalier.Playground.fsproj
+++ b/src/Escalier.Playground/Escalier.Playground.fsproj
@@ -13,7 +13,6 @@
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.*"/>
         <PackageReference Include="System.Net.Http.Json" Version="7.0.*"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Escalier.Codegen\Escalier.Codegen.fsproj"/>

--- a/src/Escalier.Playground/Main.fs
+++ b/src/Escalier.Playground/Main.fs
@@ -4,7 +4,6 @@ open Elmish
 open FsToolkit.ErrorHandling
 open Bolero
 open Bolero.Html
-open System.IO.Abstractions
 
 open Escalier.Compiler
 open Escalier.TypeChecker
@@ -36,9 +35,8 @@ let compile (src: string) : Result<CompilerOutput, CompileError> =
     let js =
       block.Body |> List.map (Printer.printStmt printCtx) |> String.concat "\n"
 
-    let fs = FileSystem()
     let projectRoot = __SOURCE_DIRECTORY__
-    let! tcCtx, env = Prelude.getEnvAndCtx fs projectRoot
+    let! tcCtx, env = Prelude.getEnvAndCtx projectRoot
 
     let! env =
       Infer.inferScript tcCtx env "input.esc" ast

--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -1,7 +1,6 @@
 module ArrayTuple
 
 open FsToolkit.ErrorHandling
-open System.IO.Abstractions
 open Xunit
 
 open Escalier.Compiler
@@ -23,9 +22,8 @@ type CompileError = Prelude.CompileError
 
 let inferScript src =
   result {
-    let fs = FileSystem()
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtxWithES5 fs projectRoot
+    let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
 
     let prelude =
       """

--- a/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
+++ b/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
@@ -28,7 +28,6 @@
     <ItemGroup>
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="20.0.4"/>
         <PackageReference Include="xunit" Version="2.5.2"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Escalier.TypeChecker.Tests/Mutability.fs
+++ b/src/Escalier.TypeChecker.Tests/Mutability.fs
@@ -2,7 +2,6 @@ module Mutability
 
 open FParsec
 open FsToolkit.ErrorHandling
-open System.IO.Abstractions
 open Xunit
 
 open Escalier.Compiler
@@ -20,9 +19,8 @@ let infer src =
       | Failure(_s, parserError, _unit) ->
         Result.mapError CompileError.ParseError (Result.Error(parserError))
 
-    let fs = FileSystem()
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtx fs projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let! t = Result.mapError CompileError.TypeError (inferExpr ctx env ast)
 

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -1,7 +1,6 @@
 module Symbol
 
 open FsToolkit.ErrorHandling
-open System.IO.Abstractions
 open Xunit
 
 open Escalier.Compiler
@@ -23,9 +22,8 @@ type CompileError = Prelude.CompileError
 
 let inferScript src =
   result {
-    let fs = FileSystem()
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtxWithES5 fs projectRoot
+    let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
 
     let prelude =
       """

--- a/src/Escalier.TypeChecker.Tests/TestUtils.fs
+++ b/src/Escalier.TypeChecker.Tests/TestUtils.fs
@@ -1,7 +1,6 @@
 module TestUtils
 
 open FsToolkit.ErrorHandling
-open System.IO.Abstractions
 open Xunit
 
 open Escalier.Compiler
@@ -18,8 +17,7 @@ let inferScript src =
   result {
     let! ast = Parser.parseScript src |> Result.mapError CompileError.ParseError
 
-    let fs = FileSystem()
-    let! ctx, env = Prelude.getEnvAndCtx fs projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let! env =
       Infer.inferScript ctx env "input.esc" ast
@@ -32,8 +30,7 @@ let inferModule src =
   result {
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-    let fs = FileSystem()
-    let! ctx, env = Prelude.getEnvAndCtx fs projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let! env =
       Infer.inferModule ctx env "input.esc" ast

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -2,7 +2,6 @@ module Tests
 
 open FParsec
 open FsToolkit.ErrorHandling
-open System.IO.Abstractions
 open Xunit
 
 open Escalier.Compiler
@@ -23,9 +22,8 @@ let infer src =
       | Failure(_s, parserError, _unit) ->
         Result.mapError CompileError.ParseError (Result.Error(parserError))
 
-    let fs = FileSystem()
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtx fs projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let! t = Result.mapError CompileError.TypeError (inferExpr ctx env ast)
 

--- a/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
+++ b/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
@@ -22,6 +22,5 @@
     <ItemGroup>
         <PackageReference Include="FSharpPlus" Version="1.5.0"/>
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
-        <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="20.0.4"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
The fixture files are on disk already and I've update the test harness to avoid clobbering them when running tests so it should be fine to use `File` methods directly.