### PR TITLE
Memoize Prelude

### DIFF
--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -335,15 +335,37 @@ module Prelude =
       return ctx, env
     }
 
+
+  let mutable memoizedNodeModulesDir: Map<string, string> = Map.empty
+
+  let rec findNearestAncestorWithNodeModules (currentDir: string) =
+    match memoizedNodeModulesDir.TryFind currentDir with
+    | Some(nodeModulesDir) -> nodeModulesDir
+    | None ->
+      let nodeModulesDir = Path.Combine(currentDir, "node_modules")
+
+      if Directory.Exists(nodeModulesDir) then
+        currentDir
+      else
+        let parentDir = Directory.GetParent(currentDir)
+
+        match parentDir with
+        | null ->
+          failwith "node_modules directory not found in any ancestor directory."
+        | _ -> findNearestAncestorWithNodeModules parentDir.FullName
+
   let private inferLib
     (ctx: Ctx)
     (env: Env)
-    (rootDir: string)
     (libPath: string)
     : Result<Env, CompileError> =
 
+    // TODO: use the directory of the file we're importing the lib from
+    let dir = Directory.GetCurrentDirectory()
+    let rootDir = findNearestAncestorWithNodeModules dir
+    let nodeModulesDir = Path.Combine(rootDir, "node_modules")
+
     result {
-      let nodeModulesDir = Path.Combine(rootDir, "node_modules")
       let fullPath = Path.Combine(nodeModulesDir, libPath)
       let input = File.ReadAllText(fullPath)
 
@@ -359,19 +381,6 @@ module Prelude =
       return env
     }
 
-  let rec findNearestAncestorWithNodeModules (currentDir: string) =
-    let nodeModulesDir = Path.Combine(currentDir, "node_modules")
-
-    if Directory.Exists(nodeModulesDir) then
-      currentDir
-    else
-      let parentDir = Directory.GetParent(currentDir)
-
-      match parentDir with
-      | null ->
-        failwith "node_modules directory not found in any ancestor directory."
-      | _ -> findNearestAncestorWithNodeModules parentDir.FullName
-
   let mutable memoizedEnvAndCtx: Map<string, Result<Ctx * Env, CompileError>> =
     Map.empty
 
@@ -383,41 +392,26 @@ module Prelude =
         let ctx = ctx.Clone
         return ctx, env
       | None ->
-        let dir = Directory.GetCurrentDirectory()
-        let rootDir = findNearestAncestorWithNodeModules dir
-
         let env = getGlobalEnvMemoized ()
         let! ctx = getCtx baseDir env
 
-        let! env = inferLib ctx env rootDir "typescript/lib/lib.es5.d.ts"
-
-        let! env =
-          inferLib ctx env rootDir "typescript/lib/lib.es2015.core.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.es5.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.es2015.core.d.ts"
         // NOTE: lib.es5.symbol.d.ts and lib.es5.symbol.wellknown.d.ts must be
         // inferred before other .d.ts files since they define `Symbol` which is
         // used by the other .d.ts files.
-        let! env =
-          inferLib ctx env rootDir "typescript/lib/lib.es2015.symbol.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.es2015.symbol.d.ts"
 
         let! env =
-          inferLib
-            ctx
-            env
-            rootDir
-            "typescript/lib/lib.es2015.symbol.wellknown.d.ts"
+          inferLib ctx env "typescript/lib/lib.es2015.symbol.wellknown.d.ts"
 
-        let! env =
-          inferLib ctx env rootDir "typescript/lib/lib.es2015.iterable.d.ts"
-
-        let! env =
-          inferLib ctx env rootDir "typescript/lib/lib.es2015.generator.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.es2015.iterable.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.es2015.generator.d.ts"
         // TODO: modify Promise types to include type param for rejections
-        // let! env = inferLib ctx env rootDir "typescript/lib/lib.es2015.promise.d.ts"
-        let! env =
-          inferLib ctx env rootDir "typescript/lib/lib.es2015.proxy.d.ts"
-        // let! env = inferLib ctx env rootDir "typescript/lib/lib.es2015.reflect.d.ts"
-
-        let! env = inferLib ctx env rootDir "typescript/lib/lib.dom.d.ts"
+        // let! env = inferLib ctx env "typescript/lib/lib.es2015.promise.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.es2015.proxy.d.ts"
+        // let! env = inferLib ctx env  "typescript/lib/lib.es2015.reflect.d.ts"
+        let! env = inferLib ctx env "typescript/lib/lib.dom.d.ts"
 
         let mutable newEnv = env
 

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -16,11 +16,13 @@ module rec Env =
       getExports: Ctx -> string -> Syntax.Import -> Env,
       resolvePath: Ctx -> string -> Syntax.Import -> string
     ) =
-    // let baseDir = baseDir
-    // let filesystem = filesystem
+
     let mutable nextTypeVarId = 0
     let mutable nextUniqueId = 0
     let mutable diagnostics: list<Diagnostic> = []
+
+    member val NextTypeVarId = nextTypeVarId with get, set
+    member val NextUniqueId = nextUniqueId with get, set
 
     member this.FreshTypeVar(bound: option<Type>) =
       let newVar =
@@ -50,6 +52,12 @@ module rec Env =
     member this.Diagnostics = diagnostics
     member this.GetExports = getExports this
     member this.ResolvePath = resolvePath this
+
+    member this.Clone =
+      let clone = Ctx(getExports, resolvePath)
+      clone.NextTypeVarId <- this.NextTypeVarId
+      clone.NextUniqueId <- this.NextUniqueId
+      clone
 
   let makeTypeRefKind name =
     { Name = name


### PR DESCRIPTION
This makes the tests run much faster because we only have to parse the .d.ts files once.