### PR TITLE
Always parse and infer official .d.ts files in Prelude

### DIFF
--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -324,18 +324,6 @@ module Prelude =
       return ctx
     }
 
-  // TODO: add memoization
-  // This is hard to memoize without reusing the filesystem
-  let getEnvAndCtx (baseDir: string) : Result<Ctx * Env, CompileError> =
-
-    result {
-      let env = getGlobalEnvMemoized ()
-      let! ctx = getCtx baseDir env
-
-      return ctx, env
-    }
-
-
   let mutable memoizedNodeModulesDir: Map<string, string> = Map.empty
 
   let rec findNearestAncestorWithNodeModules (currentDir: string) =
@@ -384,7 +372,7 @@ module Prelude =
   let mutable memoizedEnvAndCtx: Map<string, Result<Ctx * Env, CompileError>> =
     Map.empty
 
-  let getEnvAndCtxWithES5 (baseDir: string) : Result<Ctx * Env, CompileError> =
+  let getEnvAndCtx (baseDir: string) : Result<Ctx * Env, CompileError> =
     result {
       match memoizedEnvAndCtx.TryFind baseDir with
       | Some(result) ->

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -35,7 +35,7 @@ let inferScript src =
     let! ast = Parser.parseScript src |> Result.mapError CompileError.ParseError
 
     let filename = Path.Combine(projectRoot, "input.src")
-    let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let! env =
       Infer.inferScript ctx env filename ast
@@ -354,7 +354,7 @@ let InferTypeDecls () =
 let InferLibES5 () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
       // let! newEnv = prelude.loadTypeDefinitions ctx env
 
       // printfn "---- Schemes ----"
@@ -376,7 +376,7 @@ let InferLibES5 () =
 let InferArrayPrototype () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let scheme = Map.find "Array" env.Schemes
       // printfn $"Array = {scheme}"
@@ -393,7 +393,7 @@ let InferArrayPrototype () =
 let InferInt8ArrayPrototype () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let scheme = Map.find "Int8Array" env.Schemes
 

--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -23,7 +23,7 @@ type CompileError = Prelude.CompileError
 let inferScript src =
   result {
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let prelude =
       """

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -23,7 +23,7 @@ type CompileError = Prelude.CompileError
 let inferScript src =
   result {
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtxWithES5 projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let prelude =
       """


### PR DESCRIPTION
Most of the tests were not using the official .d.ts type definitions because they take a long time to parse and infer.  Now that that process is memoized we can use the official type definitions for all tests.