### PR TITLE
Start work to allow importing types from node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,20 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@types/node": "^20.11.28",
         "@types/prop-types": "^15.7.11",
         "@types/react": "^18.2.66",
         "@types/scheduler": "^0.16.8",
         "csstype": "^3.1.3",
         "typescript": "^5.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
+      "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/prop-types": {
@@ -52,9 +61,22 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     }
   },
   "dependencies": {
+    "@types/node": {
+      "version": "20.11.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
+      "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
@@ -84,6 +106,11 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
       "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ=="
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/escalier-lang/escalier-next#readme",
   "dependencies": {
+    "@types/node": "^20.11.28",
     "@types/prop-types": "^15.7.11",
     "@types/react": "^18.2.66",
     "@types/scheduler": "^0.16.8",

--- a/src/Escalier.Compiler/Escalier.Compiler.fsproj
+++ b/src/Escalier.Compiler/Escalier.Compiler.fsproj
@@ -19,6 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="FSharp.Data" Version="6.4.0"/>
         <PackageReference Include="FSharpPlus" Version="1.5.0"/>
         <PackageReference Include="FsToolkit.ErrorHandling" Version="4.10.0"/>
     </ItemGroup>

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -548,3 +548,38 @@ let AcessNamespaceValue () =
 
   printfn "result = %A" result
   Assert.False(Result.isError result)
+
+[<Fact(Skip = "TODO: update `inferLib` to also output just the new symbols")>]
+let LoadingThirdPartyModules () =
+  let result =
+    result {
+      let src =
+        """
+        import "csstype" as csstype;
+        """
+
+      let! ctx, env = inferScript src
+
+      Assert.Type(env, "BoxSizing", "fn (string, string) -> string")
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact(Skip = "TODO")>]
+let LoadingNodeModules () =
+  let result =
+    result {
+      let src =
+        """
+        import * as path from "node:path";
+       
+        let join = path.join;
+        """
+
+      let! ctx, env = inferScript src
+
+      Assert.Value(env, "join", "fn (string, string) -> string")
+    }
+
+  Assert.False(Result.isError result)

--- a/src/Escalier.Interop/Infer.fs
+++ b/src/Escalier.Interop/Infer.fs
@@ -720,8 +720,11 @@ module rec Infer =
 
             for item in tsModuleBlock.Body do
               match item with
-              | ModuleDecl _moduleDecl ->
-                failwith "TODO: inferDecl - ModuleDecl"
+              | ModuleDecl moduleDecl ->
+                let! newNsEnv = inferModuleDecl ctx nsEnv moduleDecl
+
+                // TODO: merge newNsEnv into nsEnv
+                ()
               | Stmt(Stmt.Decl decl) ->
                 match decl with
                 | Decl.Class _classDecl ->
@@ -774,29 +777,62 @@ module rec Infer =
       | _ -> return env // .d.ts files shouldn't have any other statement kinds
     }
 
-  let inferModuleDecl (env: Env) (decl: ModuleDecl) : Result<Env, TypeError> =
+  let inferModuleDecl
+    (ctx: Ctx)
+    (env: Env)
+    (decl: ModuleDecl)
+    : Result<Env, TypeError> =
     result {
       match decl with
       | ModuleDecl.Import importDecl ->
-        failwith "TODO: inferModuleDecl - importDecl"
-      | ModuleDecl.ExportDecl exportDecl ->
-        failwith "TODO: inferModuleDecl - exportDecl"
+        return!
+          Error(TypeError.NotImplemented "TODO: inferModuleDecl - importDecl")
+      | ModuleDecl.ExportDecl { Decl = decl } -> return! inferDecl ctx env decl
+      // TODO: add visibility modifiers to module decls so that we can
+      // hide decls that haven't been exported from .d.ts modules.
       | ModuleDecl.ExportNamed namedExport ->
-        failwith "TODO: inferModuleDecl - namedExport"
-      | ModuleDecl.ExportDefaultDecl exportDefaultDecl ->
-        failwith "TODO: inferModuleDecl - exportDefaultDecl"
-      | ModuleDecl.ExportDefaultExpr exportDefaultExpr ->
-        failwith "TODO: inferModuleDecl - exportDefaultExpr"
-      | ModuleDecl.ExportAll exportAll ->
-        failwith "TODO: inferModuleDecl - exportAll"
-      | ModuleDecl.TsImportEquals tsImportEqualsDecl ->
-        failwith "TODO: inferModuleDecl - tsImportEqualsDecl"
-      | ModuleDecl.TsExportAssignment tsExportAssignment ->
-        failwith "TODO: inferModuleDecl - tsExportAssignment"
-      | ModuleDecl.TsNamespaceExport tsNamespaceExportDecl ->
-        failwith "TODO: inferModuleDecl - tsNamespaceExportDecl"
+        for specifier in namedExport.Specifiers do
+          match specifier with
+          | Namespace exportNamespaceSpecifier ->
+            failwith "TODO: inferModuleItem - exportNamespaceSpecifier"
+          | Default exportDefaultSpecifier ->
+            failwith "TODO: inferModuleItem - exportDefaultSpecifier"
+          | Named exportNamedSpecifier ->
+            // TODO: handle named exports
+            ()
 
-      return env
+        return env
+      | ModuleDecl.ExportDefaultDecl exportDefaultDecl ->
+        return!
+          Error(
+            TypeError.NotImplemented "TODO: inferModuleDecl - exportDefaultDecl"
+          )
+      | ModuleDecl.ExportDefaultExpr exportDefaultExpr ->
+        return!
+          Error(
+            TypeError.NotImplemented "TODO: inferModuleDecl - exportDefaultExpr"
+          )
+      | ModuleDecl.ExportAll exportAll ->
+        return!
+          Error(TypeError.NotImplemented "TODO: inferModuleDecl - exportAll")
+      | ModuleDecl.TsImportEquals tsImportEqualsDecl ->
+        return!
+          Error(
+            TypeError.NotImplemented
+              "TODO: inferModuleDecl - tsImportEqualsDecl"
+          )
+      | ModuleDecl.TsExportAssignment tsExportAssignment ->
+        return!
+          Error(
+            TypeError.NotImplemented
+              "TODO: inferModuleDecl - tsExportAssignment"
+          )
+      | ModuleDecl.TsNamespaceExport tsNamespaceExportDecl ->
+        return!
+          Error(
+            TypeError.NotImplemented
+              "TODO: inferModuleDecl - tsNamespaceExportDecl"
+          )
     }
 
   let inferModuleItem
@@ -807,7 +843,7 @@ module rec Infer =
     result {
       match item with
       | ModuleItem.Stmt stmt -> return! inferStmt ctx env stmt
-      | ModuleItem.ModuleDecl decl -> return env
+      | ModuleItem.ModuleDecl decl -> return! inferModuleDecl ctx env decl
     }
 
   let mergeType (imutType: Type) (mutType: Type) : Type =

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -51,6 +51,7 @@ module rec Env =
 
     member this.Diagnostics = diagnostics
     member this.GetExports = getExports this
+    // Used by `inferImport` in Escalier.TypeChecerk/Infer.fs
     member this.ResolvePath = resolvePath this
 
     member this.Clone =


### PR DESCRIPTION
I'm going to merge this PR even thought it isn't complete because I need to do some refactoring of how `Env` and `Namespace` is configured.  I want to be able to have `inferModule` return a `Namespace` instead of `Env` so that it contains only the symbols that the module added/exported instead of including everything in the environment.