### PR TITLE
Handle importing namespaces from npm modules

### DIFF
--- a/src/Escalier.Interop/Infer.fs
+++ b/src/Escalier.Interop/Infer.fs
@@ -718,13 +718,65 @@ module rec Infer =
           | TsModuleBlock tsModuleBlock ->
             let! nsEnv = inferModuleBlock ctx env tsModuleBlock
 
+            // TODO: dedupe with getExports from Prelude.fs
             for item in tsModuleBlock.Body do
               match item with
-              | ModuleDecl moduleDecl ->
-                let! newNsEnv = inferModuleDecl ctx nsEnv moduleDecl
+              | ModuleDecl decl ->
+                match decl with
+                | ModuleDecl.Import importDecl ->
+                  failwith "TODO: getExports - importDecl"
+                | ModuleDecl.ExportDecl { Decl = decl } ->
+                  match decl with
+                  | Decl.Class classDecl ->
+                    failwith "TODO: getExports - classDecl"
+                  | Decl.Fn fnDecl -> failwith "TODO: getExports - fnDecl"
+                  | Decl.Var varDecl -> failwith "TODO: getExports - varDecl"
+                  | Decl.Using usingDecl ->
+                    failwith "TODO: getExports - usingDecl"
+                  | Decl.TsInterface { Id = ident } ->
+                    let! scheme =
+                      nsEnv.GetScheme(QualifiedIdent.Ident ident.Name)
 
-                // TODO: merge newNsEnv into nsEnv
-                ()
+                    ns <- ns.AddScheme ident.Name scheme
+                  | Decl.TsTypeAlias { Id = ident } ->
+                    let! scheme =
+                      nsEnv.GetScheme(QualifiedIdent.Ident ident.Name)
+
+                    ns <- ns.AddScheme ident.Name scheme
+                  | Decl.TsEnum tsEnumDecl ->
+                    failwith "TODO: getExports - tsEnumDecl"
+                  | Decl.TsModule { Id = ident } ->
+                    let name = ident.ToString
+
+                    match nsEnv.Namespace.Namespaces.TryFind name with
+                    | Some value -> ns <- ns.AddNamespace name value
+                    | None -> failwith $"Couldn't find namespace: '{name}'"
+                | ModuleDecl.ExportNamed namedExport ->
+                  for specifier in namedExport.Specifiers do
+                    match specifier with
+                    | Namespace exportNamespaceSpecifier -> failwith "todo"
+                    | Default exportDefaultSpecifier -> failwith "todo"
+                    | Named { Orig = orig
+                              Exported = exported
+                              IsTypeOnly = isTypeOnly } ->
+                      let! binding = env.GetBinding orig.ToString
+
+                      ns <-
+                        match exported with
+                        | None -> ns.AddBinding orig.ToString binding
+                        | Some value -> ns.AddBinding value.ToString binding
+                | ModuleDecl.ExportDefaultDecl exportDefaultDecl ->
+                  failwith "TODO: getExports - exportDefaultDecl"
+                | ModuleDecl.ExportDefaultExpr exportDefaultExpr ->
+                  failwith "TODO: getExports - exportDefaultExpr"
+                | ModuleDecl.ExportAll exportAll ->
+                  failwith "TODO: getExports - exportAll"
+                | ModuleDecl.TsImportEquals tsImportEqualsDecl ->
+                  failwith "TODO: getExports - tsImportEqualsDecl"
+                | ModuleDecl.TsExportAssignment tsExportAssignment ->
+                  failwith "TODO: getExports - tsExportAssignment"
+                | ModuleDecl.TsNamespaceExport tsNamespaceExportDecl ->
+                  failwith "TODO: getExports - tsNamespaceExportDecl"
               | Stmt(Stmt.Decl decl) ->
                 match decl with
                 | Decl.Class _classDecl ->
@@ -733,7 +785,7 @@ module rec Infer =
                   let t = inferFunction ctx env fnDecl.Fn
                   let name = fnDecl.Id.Name
                   let isMut = false
-                  newEnv <- env.AddValue name (t, isMut)
+                  ns <- ns.AddBinding name (t, isMut)
                 | Decl.Var { Decls = decls } ->
                   for decl in decls do
                     let names = findBindingNames decl.Id
@@ -756,7 +808,7 @@ module rec Infer =
                       IsTypeParam = false }
 
                   // TODO: if decl.Global is true, add to the global env
-                  newEnv <- env.AddScheme decl.Id.Name scheme
+                  ns <- ns.AddScheme decl.Id.Name scheme
                 | Decl.TsEnum _tsEnumDecl ->
                   failwith "TODO: inferModuleBlock - TsEnum"
                 | Decl.TsModule _tsModuleDecl ->

--- a/src/Escalier.Interop/TypeScript.fs
+++ b/src/Escalier.Interop/TypeScript.fs
@@ -298,6 +298,11 @@ module rec TypeScript =
     | Ident of Ident
     | Str of Str
 
+    member this.ToString =
+      match this with
+      | Ident id -> id.Name
+      | Str str -> str.Value
+
   type TsNamespaceBody =
     | TsModuleBlock of TsModuleBlock
     | TsNamespaceDecl of TsNamespaceDecl
@@ -349,6 +354,11 @@ module rec TypeScript =
   type ModuleExportName =
     | Ident of Ident
     | Str of Str
+
+    member this.ToString =
+      match this with
+      | Ident id -> id.Name
+      | Str str -> str.Value
 
   type ImportDefaultSpecifier =
     { Local: Ident

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -2440,10 +2440,17 @@ module rec Infer =
               Ok(())
             | None -> Error("not found")
 
-          match valueLookup, schemeLookup with
+          let namespaceLookup =
+            match exports.Namespace.Namespaces.TryFind source with
+            | Some(ns) ->
+              imports <- imports.AddNamespace target ns
+              Ok(())
+            | None -> Error("not found")
+
+          match valueLookup, schemeLookup, namespaceLookup with
           // If we can't find the symbol in either the values or schemes
           // we report an error
-          | Error _, Error _ ->
+          | Error _, Error _, Error _ ->
             let resolvedPath = ctx.ResolvePath filename import
 
             return!
@@ -2451,7 +2458,7 @@ module rec Infer =
                 TypeError.SemanticError
                   $"{resolvedPath} doesn't export '{name}'"
               )
-          | _, _ -> ()
+          | _, _, _ -> ()
         | ModuleAlias name ->
           let ns: Namespace = { exports.Namespace with Name = name }
 

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -1022,11 +1022,11 @@ module rec Unify =
                   match env.TryFindScheme name with
                   | Some scheme ->
                     expandScheme ctx env ips scheme mapping typeArgs
-                  | None ->
-                    printfn $"t = {t}"
-                    printfn $"scheme = {scheme}"
-                    failwith $"{name} is not in scope"
-            | Member(left, right) -> failwith "TODO: expand qualified ident"
+                  | None -> failwith $"{name} is not in scope"
+            | Member _ ->
+              match env.GetScheme name with
+              | Ok scheme -> expandScheme ctx env ips scheme mapping typeArgs
+              | Error errorValue -> failwith $"{name} is not in scope"
 
           return! expand mapping t
         | _ ->


### PR DESCRIPTION
Escalier is now able to handle imports like this:
```ts
import "csstype" {Globals, Property};

type AccentColor = Property.AccentColor;
```