### PR TITLE
Support namespace declarations

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -438,12 +438,15 @@ module Syntax =
       TypeParams: option<list<TypeParam>>
       Variants: list<EnumVariant> }
 
+  type NamespaceDecl = { Name: string; Body: list<Decl> }
+
   type DeclKind =
     | VarDecl of VarDecl
     | FnDecl of FnDecl
     | ClassDecl of ClassDecl
     | TypeDecl of TypeDecl
     | EnumDecl of EnumDecl
+    | NamespaceDecl of NamespaceDecl
 
   type Decl = { Kind: DeclKind; Span: Span }
 

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -854,3 +854,39 @@ let ParseFragment () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseNamespaceInScript () =
+  let src =
+    """
+    namespace Foo {
+      namespace Bar {
+        let x = 5;
+      }
+      let y = 10;
+      type Baz = number;
+    }
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseNamespaceInModule () =
+  let src =
+    """
+    namespace Foo {
+      namespace Bar {
+        let x = 5;
+      }
+      let y = 10;
+      type Baz = number;
+    }
+    """
+
+  let ast = Parser.parseModule src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
@@ -13,11 +13,11 @@ output: Ok
         { Kind =
            NamespaceDecl
              { Name = "Foo"
-               Decls =
+               Body =
                 [{ Kind =
                     NamespaceDecl
                       { Name = "Bar"
-                        Decls =
+                        Body =
                          [{ Kind =
                              VarDecl
                                { Declare = false

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
@@ -1,0 +1,67 @@
+﻿input: 
+    namespace Foo {
+      namespace Bar {
+        let x = 5;
+      }
+      let y = 10;
+      type Baz = number;
+    }
+    
+output: Ok
+  { Items =
+     [Decl
+        { Kind =
+           NamespaceDecl
+             { Name = "Foo"
+               Decls =
+                [{ Kind =
+                    NamespaceDecl
+                      { Name = "Bar"
+                        Decls =
+                         [{ Kind =
+                             VarDecl
+                               { Declare = false
+                                 Pattern = { Kind = Ident { Name = "x"
+                                                            IsMut = false
+                                                            Assertion = None }
+                                             Span = { Start = (Ln: 4, Col: 13)
+                                                      Stop = (Ln: 4, Col: 15) }
+                                             InferredType = None }
+                                 TypeAnn = None
+                                 Init =
+                                  Some { Kind = Literal (Number (Int 5))
+                                         Span = { Start = (Ln: 4, Col: 17)
+                                                  Stop = (Ln: 4, Col: 18) }
+                                         InferredType = None }
+                                 Else = None }
+                            Span = { Start = (Ln: 4, Col: 9)
+                                     Stop = (Ln: 5, Col: 7) } }] }
+                   Span = { Start = (Ln: 3, Col: 7)
+                            Stop = (Ln: 6, Col: 7) } };
+                 { Kind =
+                    VarDecl { Declare = false
+                              Pattern = { Kind = Ident { Name = "y"
+                                                         IsMut = false
+                                                         Assertion = None }
+                                          Span = { Start = (Ln: 6, Col: 11)
+                                                   Stop = (Ln: 6, Col: 13) }
+                                          InferredType = None }
+                              TypeAnn = None
+                              Init = Some { Kind = Literal (Number (Int 10))
+                                            Span = { Start = (Ln: 6, Col: 15)
+                                                     Stop = (Ln: 6, Col: 17) }
+                                            InferredType = None }
+                              Else = None }
+                   Span = { Start = (Ln: 6, Col: 7)
+                            Stop = (Ln: 7, Col: 7) } };
+                 { Kind =
+                    TypeDecl { Name = "Baz"
+                               TypeAnn = { Kind = Keyword Number
+                                           Span = { Start = (Ln: 7, Col: 18)
+                                                    Stop = (Ln: 7, Col: 24) }
+                                           InferredType = None }
+                               TypeParams = None }
+                   Span = { Start = (Ln: 7, Col: 7)
+                            Stop = (Ln: 8, Col: 5) } }] }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 9, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
@@ -15,11 +15,11 @@ output: Ok
              { Kind =
                 NamespaceDecl
                   { Name = "Foo"
-                    Decls =
+                    Body =
                      [{ Kind =
                          NamespaceDecl
                            { Name = "Bar"
-                             Decls =
+                             Body =
                               [{ Kind =
                                   VarDecl
                                     { Declare = false

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
@@ -1,0 +1,74 @@
+﻿input: 
+    namespace Foo {
+      namespace Bar {
+        let x = 5;
+      }
+      let y = 10;
+      type Baz = number;
+    }
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                NamespaceDecl
+                  { Name = "Foo"
+                    Decls =
+                     [{ Kind =
+                         NamespaceDecl
+                           { Name = "Bar"
+                             Decls =
+                              [{ Kind =
+                                  VarDecl
+                                    { Declare = false
+                                      Pattern =
+                                       { Kind = Ident { Name = "x"
+                                                        IsMut = false
+                                                        Assertion = None }
+                                         Span = { Start = (Ln: 4, Col: 13)
+                                                  Stop = (Ln: 4, Col: 15) }
+                                         InferredType = None }
+                                      TypeAnn = None
+                                      Init =
+                                       Some { Kind = Literal (Number (Int 5))
+                                              Span = { Start = (Ln: 4, Col: 17)
+                                                       Stop = (Ln: 4, Col: 18) }
+                                              InferredType = None }
+                                      Else = None }
+                                 Span = { Start = (Ln: 4, Col: 9)
+                                          Stop = (Ln: 5, Col: 7) } }] }
+                        Span = { Start = (Ln: 3, Col: 7)
+                                 Stop = (Ln: 6, Col: 7) } };
+                      { Kind =
+                         VarDecl
+                           { Declare = false
+                             Pattern = { Kind = Ident { Name = "y"
+                                                        IsMut = false
+                                                        Assertion = None }
+                                         Span = { Start = (Ln: 6, Col: 11)
+                                                  Stop = (Ln: 6, Col: 13) }
+                                         InferredType = None }
+                             TypeAnn = None
+                             Init = Some { Kind = Literal (Number (Int 10))
+                                           Span = { Start = (Ln: 6, Col: 15)
+                                                    Stop = (Ln: 6, Col: 17) }
+                                           InferredType = None }
+                             Else = None }
+                        Span = { Start = (Ln: 6, Col: 7)
+                                 Stop = (Ln: 7, Col: 7) } };
+                      { Kind =
+                         TypeDecl
+                           { Name = "Baz"
+                             TypeAnn = { Kind = Keyword Number
+                                         Span = { Start = (Ln: 7, Col: 18)
+                                                  Stop = (Ln: 7, Col: 24) }
+                                         InferredType = None }
+                             TypeParams = None }
+                        Span = { Start = (Ln: 7, Col: 7)
+                                 Stop = (Ln: 8, Col: 5) } }] }
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 9, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 9, Col: 5) } }] }

--- a/src/Escalier.TypeChecker.Tests/Functions.fs
+++ b/src/Escalier.TypeChecker.Tests/Functions.fs
@@ -642,7 +642,7 @@ let InferFuncDeclInModule () =
 
       let! _, env = inferModule src
 
-      Assert.Value(env, "fst", "fn <B, A>(x: A, y: B) -> A")
+      Assert.Value(env, "fst", "fn <A, B>(x: A, y: B) -> A")
       Assert.Value(env, "snd", "fn <A, B>(x: A, y: B) -> B")
     }
 

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -454,6 +454,41 @@ let InferRecursiveGenericObjectType () =
   Assert.False(Result.isError result)
 
 [<Fact>]
+let InferRecursiveGenericObjectTypeInModule () =
+  let result =
+    result {
+      let src =
+        """
+        type Node<T> = {
+          value: T,
+          left?: Node<T>,
+          right?: Node<T>
+        };
+
+        let node: Node<number> = {
+          value: 5,
+          left: {
+            value: 10
+          },
+          right: {
+            value: 15,
+            left: {
+              value: 20
+            }
+          }
+        };
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Diagnostics)
+      Assert.Value(env, "node", "Node<number>")
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact>]
 let ReturnRecursivePrivateGenericObjectType () =
   let result =
     result {

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -1122,10 +1122,11 @@ let InferNamespaceInScript () =
           namespace Bar {
             let x = 5;
           }
-          let y = 10;
+          let y = Bar.x;
           type Baz = string;
         }
         let x = Foo.Bar.x;
+        let y = Foo.y;
         type Baz = Foo.Baz;
         """
 
@@ -1133,6 +1134,7 @@ let InferNamespaceInScript () =
 
       Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "5")
+      Assert.Value(env, "y", "5")
       Assert.Type(env, "Baz", "Foo.Baz")
 
       let! t =
@@ -1151,12 +1153,13 @@ let InferNamespaceInModule () =
       let src =
         """
         let x = Foo.Bar.x;
+        let y = Foo.y;
         type Baz = Foo.Baz;
         namespace Foo {
+          let y = Bar.x;
           namespace Bar {
             let x = 5;
           }
-          let y = 10;
           type Baz = string;
         }
         """
@@ -1165,6 +1168,7 @@ let InferNamespaceInModule () =
 
       Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "x", "5")
+      Assert.Value(env, "y", "5")
       Assert.Type(env, "Baz", "Foo.Baz")
 
       let! t =


### PR DESCRIPTION
This is a requirement to all converting TypeScript AST from .d.ts files to Escalier AST in order to infer types in .d.ts files.