### PR TITLE
Make more decl types work with new graph-based decl deps code

### DIFF
--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -134,7 +134,8 @@ module Prelude =
               names <- name :: names
               false
             | _ -> true
-        ExprVisitor.VisitTypeAnn = fun _ -> false }
+        ExprVisitor.VisitTypeAnn = fun _ -> false
+        ExprVisitor.VisitTypeAnnObjElem = fun _ -> false }
 
     walkPattern visitor p
 

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -3,10 +3,7 @@ module Migrate
 
 open FParsec
 open FsToolkit.ErrorHandling
-open FParsec.CharParsers
 open System.IO
-open VerifyTests
-open VerifyXunit
 open Xunit
 
 open Escalier.Compiler

--- a/src/Escalier.TypeChecker.Tests/Functions.fs
+++ b/src/Escalier.TypeChecker.Tests/Functions.fs
@@ -638,12 +638,17 @@ let InferFuncDeclInModule () =
           return x;
         }
         declare fn snd<A, B>(x: A, y: B) -> B;
+        type Point = {x: number, y: number};
+        fn makePoint (x, y) -> Point {
+          return {x, y};
+        }
         """
 
       let! _, env = inferModule src
 
       Assert.Value(env, "fst", "fn <A, B>(x: A, y: B) -> A")
       Assert.Value(env, "snd", "fn <A, B>(x: A, y: B) -> B")
+      Assert.Value(env, "makePoint", "fn (x: number, y: number) -> Point")
     }
 
   printfn "result = %A" result

--- a/src/Escalier.TypeChecker.Tests/Graph.fs
+++ b/src/Escalier.TypeChecker.Tests/Graph.fs
@@ -975,7 +975,7 @@ let InferFuncDeclInModule () =
   printfn "result = %A" result
   Assert.False(Result.isError result)
 
-[<Fact(Skip = "TODO")>]
+[<Fact>]
 let InferInterfaceInModule () =
   let result =
     result {

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -2980,6 +2980,9 @@ module rec Infer =
   let inferDeclDefinitions
     (ctx: Ctx)
     (env: Env)
+    // Instead of placeholders, we can have a pair of placeholder types
+    // and the associated declaration whose types need to be unified
+    // with the placeholder types.
     (placeholderNS: Namespace)
     (decls: list<Decl>)
     : Result<Env * Namespace, TypeError> =


### PR DESCRIPTION
This PR adds support for function decls, interfaces, and namespaces.  There are some issues around type params not being added from function decls or mapped object elems.  Those issues will be resolved in a future PR once I've updated the syntax visitor to support path specific state.