### PR TITLE
Update SyntaxVisitor to provide path specific state to the callbacks

### DIFF
--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -122,22 +122,22 @@ module Prelude =
 
     let visitor =
       { ExprVisitor.VisitExpr =
-          fun expr ->
+          fun (expr, state) ->
             match expr.Kind with
-            | Syntax.ExprKind.Function _ -> false
-            | _ -> true
-        ExprVisitor.VisitStmt = fun _ -> false
+            | Syntax.ExprKind.Function _ -> (false, state)
+            | _ -> (true, state)
+        ExprVisitor.VisitStmt = fun (_, state) -> (false, state)
         ExprVisitor.VisitPattern =
-          fun pat ->
+          fun (pat, state) ->
             match pat.Kind with
             | Syntax.PatternKind.Ident { Name = name } ->
               names <- name :: names
-              false
-            | _ -> true
-        ExprVisitor.VisitTypeAnn = fun _ -> false
-        ExprVisitor.VisitTypeAnnObjElem = fun _ -> false }
+              (false, state)
+            | _ -> (true, state)
+        ExprVisitor.VisitTypeAnn = fun (_, state) -> (false, state)
+        ExprVisitor.VisitTypeAnnObjElem = fun (_, state) -> (false, state) }
 
-    walkPattern visitor p
+    walkPattern visitor () p
 
     List.rev names
 

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -166,7 +166,7 @@ let ParseAndInferMappedType () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
-        Infer.inferModule ctx env "input.esc" ast
+        Infer.inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(env, "Partial", "<T>({[P]+?: T[P] for P in keyof T})")

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -235,7 +235,7 @@ let ParseAndInferFuncDecl () =
 
   Assert.True(Result.isOk res)
 
-[<Fact(Skip = "TODO")>]
+[<Fact>]
 let ParseAndInferClassDecl () =
   let res =
     result {

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -66,7 +66,7 @@ let ParseAndInferBasicDecls () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
-        Infer.inferModule ctx env "input.esc" ast
+        Infer.inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "a", "number")
@@ -98,7 +98,7 @@ let ParseAndInferTypeAliases () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
-        Infer.inferModule ctx env "input.esc" ast
+        Infer.inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(env, "Foo", "string")
@@ -132,7 +132,7 @@ let ParseAndInferInterface () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
-        Infer.inferModule ctx env "input.esc" ast
+        Infer.inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -195,7 +195,7 @@ let ParseAndInferUnorderedTypeParams () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
-        Infer.inferModule ctx env "input.esc" ast
+        Infer.inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -227,7 +227,7 @@ let ParseAndInferFuncDecl () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let! env =
-        Infer.inferModule ctx env "input.esc" ast
+        Infer.inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "foo", "fn (mut x: number, mut y: string) -> boolean")

--- a/src/Escalier.TypeChecker.Tests/Graph.fs
+++ b/src/Escalier.TypeChecker.Tests/Graph.fs
@@ -563,7 +563,7 @@ let MutuallyRecursiveGraph () =
       let decls = Infer.getDeclsFromModule ast
 
       let! graph =
-        Infer.buildGraph decls |> Result.mapError CompileError.TypeError
+        Infer.buildGraph env decls |> Result.mapError CompileError.TypeError
 
       printfn "graph.Edges = %A" graph.Edges
 

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -256,38 +256,41 @@ module rec ExprVisitor =
     (state: 'S)
     (elem: ObjTypeAnnElem)
     : unit =
-    let walk = walkTypeAnn visitor state
+    let cont, state = visitor.VisitTypeAnnObjElem(elem, state)
 
-    match elem with
-    | Callable f ->
-      walk f.ReturnType
-      Option.iter walk f.Throws
+    if cont then
+      let walk = walkTypeAnn visitor state
 
-      List.iter
-        (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
-        f.ParamList
-    | Constructor f ->
-      walk f.ReturnType
-      Option.iter walk f.Throws
+      match elem with
+      | Callable f ->
+        walk f.ReturnType
+        Option.iter walk f.Throws
 
-      List.iter
-        (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
-        f.ParamList
-    | Method { Type = f } ->
-      walk f.ReturnType
-      Option.iter walk f.Throws
+        List.iter
+          (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
+          f.ParamList
+      | Constructor f ->
+        walk f.ReturnType
+        Option.iter walk f.Throws
 
-      List.iter
-        (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
-        f.ParamList
-    | Getter { ReturnType = retType } -> walk retType
-    | Setter { Param = { TypeAnn = paramType } } -> walk paramType
-    | Property { TypeAnn = typeAnn } -> walk typeAnn
-    | Mapped { TypeParam = typeParam
-               TypeAnn = typeAnn } ->
-      printfn "typeParam = %A" typeParam
-      walk typeParam.Constraint
-      walk typeAnn
+        List.iter
+          (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
+          f.ParamList
+      | Method { Type = f } ->
+        walk f.ReturnType
+        Option.iter walk f.Throws
+
+        List.iter
+          (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
+          f.ParamList
+      | Getter { ReturnType = retType } -> walk retType
+      | Setter { Param = { TypeAnn = paramType } } -> walk paramType
+      | Property { TypeAnn = typeAnn } -> walk typeAnn
+      | Mapped { TypeParam = typeParam
+                 TypeAnn = typeAnn } ->
+        printfn "typeParam = %A" typeParam
+        walk typeParam.Constraint
+        walk typeAnn
 
 module rec TypeVisitor =
   open Escalier.Data.Type


### PR DESCRIPTION
In addition to updating the SyntaxVisitor, this PR also updates the new graph-based decl dept code to handle the rest of the declarations as well as a bunch of edge cases.  One of the primary changes was to pass a list of top-level declaration identifiers to both `findCaptures` and `findTypeRefIdents`.  This helps differentiating between using a top-level declaration vs something else (a global, function param, type param, etc.)