### PR TITLE
Fix some more issues with `inferModuleUsingTree`

### DIFF
--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -20,7 +20,10 @@ module rec ExprVisitor =
         | ExprKind.Identifier _ -> ()
         | ExprKind.Literal _ -> ()
         | ExprKind.Function f ->
-          // TODO: walk type annotations
+          for p in f.Sig.ParamList do
+            walkPattern visitor state p.Pattern
+            Option.iter (walkTypeAnn visitor state) p.TypeAnn
+
           match f.Body with
           | BlockOrExpr.Block block ->
             List.iter (walkStmt visitor state) block.Stmts


### PR DESCRIPTION
There's still some work to do before we can use `inferModuleUsingTree`.  In particular, inference of `interfaces` needs to be updated so that we're unifying object types with object types instead of type variables with object types.