### PR TITLE
Generate structural placeholders so that we can handle more cases of mutual recursion

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -119,7 +119,7 @@ module rec Codegen =
       | BlockOrExpr.Block block ->
         let ps: list<Param> =
           s.ParamList
-          |> List.map (fun (p: FuncParam<TypeAnn option>) ->
+          |> List.map (fun (p: Syntax.FuncParam) ->
             let pat = buildPattern ctx p.Pattern
 
             { Pat = pat

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -142,48 +142,48 @@ module Syntax =
       Constraint: option<TypeAnn>
       Default: option<TypeAnn> }
 
-  type FuncParam<'T> =
+  type FuncParam =
     { Pattern: Pattern
-      TypeAnn: 'T
+      TypeAnn: option<TypeAnn>
       Optional: bool }
 
     override this.ToString() = this.Pattern.ToString()
 
-  type FuncSig<'T> =
+  type FuncSig =
     { TypeParams: option<list<TypeParam>>
-      Self: option<FuncParam<'T>>
-      ParamList: list<FuncParam<'T>>
-      ReturnType: 'T
+      Self: option<FuncParam>
+      ParamList: list<FuncParam>
+      ReturnType: option<TypeAnn>
       Throws: option<TypeAnn>
       IsAsync: bool }
 
   // TODO: include optional name
   type Function =
-    { Sig: FuncSig<option<TypeAnn>>
+    { Sig: FuncSig
       Body: BlockOrExpr
       mutable Captures: option<list<string>>
       mutable InferredType: option<Type.Type> }
 
   type Constructor =
-    { Sig: FuncSig<option<TypeAnn>>
+    { Sig: FuncSig
       Body: option<BlockOrExpr> }
 
   type Method =
     { Name: string
-      Sig: FuncSig<option<TypeAnn>>
+      Sig: FuncSig
       Body: option<BlockOrExpr> }
 
   type Getter =
     { Name: string
-      Self: FuncParam<option<TypeAnn>>
+      Self: FuncParam
       Body: option<BlockOrExpr>
       ReturnType: option<TypeAnn>
       Throws: option<TypeAnn> }
 
   type Setter =
     { Name: string
-      Self: FuncParam<option<TypeAnn>>
-      Param: FuncParam<option<TypeAnn>>
+      Self: FuncParam
+      Param: FuncParam
       Body: option<BlockOrExpr>
       Throws: option<TypeAnn> }
 
@@ -421,7 +421,7 @@ module Syntax =
   type FnDecl =
     { Declare: bool
       Name: string
-      Sig: FuncSig<option<TypeAnn>>
+      Sig: FuncSig
       Body: option<BlockOrExpr> }
 
   type ClassDecl =
@@ -487,8 +487,8 @@ module Syntax =
 
   // TODO: add location information
   type ObjTypeAnnElem =
-    | Callable of FunctionType
-    | Constructor of FunctionType
+    | Callable of FuncSig
+    | Constructor of FuncSig
     | Method of MethodType
     | Getter of GetterType
     | Setter of SetterType
@@ -510,20 +510,18 @@ module Syntax =
     | BigInt
     | Any // only used by .d.ts files
 
-  type FunctionType = FuncSig<TypeAnn>
-
-  type MethodType = { Name: PropName; Type: FunctionType }
+  type MethodType = { Name: PropName; Type: FuncSig }
 
   type GetterType =
     { Name: PropName
-      Self: FuncParam<TypeAnn>
-      ReturnType: TypeAnn
+      Self: FuncParam
+      ReturnType: option<TypeAnn>
       Throws: option<TypeAnn> }
 
   type SetterType =
     { Name: PropName
-      Self: FuncParam<TypeAnn>
-      Param: FuncParam<TypeAnn>
+      Self: FuncParam
+      Param: FuncParam
       Throws: option<TypeAnn> }
 
   type ConditionType =
@@ -548,7 +546,7 @@ module Syntax =
     | Union of types: list<TypeAnn>
     | Intersection of types: list<TypeAnn>
     | TypeRef of TypeRef
-    | Function of FunctionType
+    | Function of FuncSig
     | Keyof of target: TypeAnn
     | Rest of target: TypeAnn
     | Typeof of target: Common.QualifiedIdent

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -180,7 +180,7 @@ let ParseAndInferUnorderedTypeParams () =
     result {
       let input =
         """
-        interface ObjectConstructor {
+        interface MyObjectConstructor {
             freeze<T extends { [idx: string]: U | null | undefined | object; }, U extends string | bigint | number | boolean | symbol>(o: T): Readonly<T>;
         }
         """
@@ -200,7 +200,7 @@ let ParseAndInferUnorderedTypeParams () =
 
       Assert.Type(
         env,
-        "ObjectConstructor",
+        "MyObjectConstructor",
         "{freeze fn <T: {[idx]+?: U | null | undefined | object for idx in string}, U: string | bigint | number | boolean | symbol>(self: Self, mut o: T) -> Readonly<T>}"
       )
     }
@@ -334,9 +334,9 @@ let ParseAndInferPropertyKey () =
     result {
       let input =
         """
-        declare type PropertyKey = string | number | symbol;
+        declare type MyPropertyKey = string | number | symbol;
 
-        interface PropertyDescriptor {
+        interface MyPropertyDescriptor {
             configurable?: boolean;
             enumerable?: boolean;
             value?: any;
@@ -345,8 +345,8 @@ let ParseAndInferPropertyKey () =
             set?(v: any): void;
         }
 
-        interface PropertyDescriptorMap {
-            [key: PropertyKey]: PropertyDescriptor;
+        interface MyPropertyDescriptorMap {
+            [key: MyPropertyKey]: MyPropertyDescriptor;
         }
         """
 
@@ -365,8 +365,8 @@ let ParseAndInferPropertyKey () =
 
       Assert.Type(
         env,
-        "PropertyDescriptorMap",
-        "{[key]+?: PropertyDescriptor for key in PropertyKey}"
+        "MyPropertyDescriptorMap",
+        "{[key]+?: MyPropertyDescriptor for key in MyPropertyKey}"
       )
     }
 

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
@@ -21,10 +21,10 @@ output: Ok
                                   Self = None
                                   ParamList = []
                                   ReturnType =
-                                   { Kind = Keyword Symbol
-                                     Span = { Start = (Ln: 3, Col: 20)
-                                              Stop = (Ln: 3, Col: 26) }
-                                     InferredType = None }
+                                   Some { Kind = Keyword Symbol
+                                          Span = { Start = (Ln: 3, Col: 20)
+                                                   Stop = (Ln: 3, Col: 26) }
+                                          InferredType = None }
                                   Throws = None
                                   IsAsync = false };
                               Callable
@@ -32,10 +32,10 @@ output: Ok
                                   Self = None
                                   ParamList = []
                                   ReturnType =
-                                   { Kind = Keyword Symbol
-                                     Span = { Start = (Ln: 4, Col: 16)
-                                              Stop = (Ln: 4, Col: 22) }
-                                     InferredType = None }
+                                   Some { Kind = Keyword Symbol
+                                          Span = { Start = (Ln: 4, Col: 16)
+                                                   Stop = (Ln: 4, Col: 22) }
+                                          InferredType = None }
                                   Throws = None
                                   IsAsync = false }]
                             Immutable = false }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFunctionType.verified.txt
@@ -22,17 +22,17 @@ output: Success: { Kind =
                                   Span = { Start = (Ln: 1, Col: 19)
                                            Stop = (Ln: 1, Col: 20) }
                                   InferredType = None }
-                      TypeAnn = { Kind = TypeRef { Ident = Ident "T"
-                                                   TypeArgs = None }
-                                  Span = { Start = (Ln: 1, Col: 22)
-                                           Stop = (Ln: 1, Col: 23) }
-                                  InferredType = None }
+                      TypeAnn = Some { Kind = TypeRef { Ident = Ident "T"
+                                                        TypeArgs = None }
+                                       Span = { Start = (Ln: 1, Col: 22)
+                                                Stop = (Ln: 1, Col: 23) }
+                                       InferredType = None }
                       Optional = false }]
-       ReturnType = { Kind = TypeRef { Ident = Ident "T"
-                                       TypeArgs = None }
-                      Span = { Start = (Ln: 1, Col: 28)
-                               Stop = (Ln: 1, Col: 30) }
-                      InferredType = None }
+       ReturnType = Some { Kind = TypeRef { Ident = Ident "T"
+                                            TypeArgs = None }
+                           Span = { Start = (Ln: 1, Col: 28)
+                                    Stop = (Ln: 1, Col: 30) }
+                           InferredType = None }
        Throws = Some { Kind = Literal (String "RangeError")
                        Span = { Start = (Ln: 1, Col: 37)
                                 Stop = (Ln: 1, Col: 49) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -36,17 +36,18 @@ output: Ok
                                                     Stop = (Ln: 1, Col: 39) }
                                            InferredType = None }
                                         TypeAnn =
-                                         { Kind = TypeRef { Ident = Ident "_"
-                                                            TypeArgs = None }
-                                           Span = { Start = (Ln: 1, Col: 41)
-                                                    Stop = (Ln: 1, Col: 42) }
-                                           InferredType = None }
+                                         Some
+                                           { Kind = TypeRef { Ident = Ident "_"
+                                                              TypeArgs = None }
+                                             Span = { Start = (Ln: 1, Col: 41)
+                                                      Stop = (Ln: 1, Col: 42) }
+                                             InferredType = None }
                                         Optional = false }]
                                     ReturnType =
-                                     { Kind = Infer "R"
-                                       Span = { Start = (Ln: 1, Col: 47)
-                                                Stop = (Ln: 1, Col: 55) }
-                                       InferredType = None }
+                                     Some { Kind = Infer "R"
+                                            Span = { Start = (Ln: 1, Col: 47)
+                                                     Stop = (Ln: 1, Col: 55) }
+                                            InferredType = None }
                                     Throws = None
                                     IsAsync = false }
                                Span = { Start = (Ln: 1, Col: 28)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
@@ -53,24 +53,26 @@ output: Ok
                                           Self = None
                                           ParamList = []
                                           ReturnType =
-                                           { Kind =
-                                              TypeRef
-                                                { Ident = Ident "Iterator"
-                                                  TypeArgs =
-                                                   Some
-                                                     [{ Kind =
-                                                         TypeRef
-                                                           { Ident = Ident "T"
-                                                             TypeArgs = None }
-                                                        Span =
-                                                         { Start =
-                                                            (Ln: 5, Col: 44)
-                                                           Stop =
-                                                            (Ln: 5, Col: 45) }
-                                                        InferredType = None }] }
-                                             Span = { Start = (Ln: 5, Col: 35)
-                                                      Stop = (Ln: 5, Col: 46) }
-                                             InferredType = None }
+                                           Some
+                                             { Kind =
+                                                TypeRef
+                                                  { Ident = Ident "Iterator"
+                                                    TypeArgs =
+                                                     Some
+                                                       [{ Kind =
+                                                           TypeRef
+                                                             { Ident = Ident "T"
+                                                               TypeArgs = None }
+                                                          Span =
+                                                           { Start =
+                                                              (Ln: 5, Col: 44)
+                                                             Stop =
+                                                              (Ln: 5, Col: 45) }
+                                                          InferredType = None }] }
+                                               Span =
+                                                { Start = (Ln: 5, Col: 35)
+                                                  Stop = (Ln: 5, Col: 46) }
+                                               InferredType = None }
                                           Throws = None
                                           IsAsync = false }
                                      Span = { Start = (Ln: 5, Col: 26)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
@@ -24,69 +24,70 @@ output: Ok
                                           Self = None
                                           ParamList = []
                                           ReturnType =
-                                           { Kind =
-                                              Object
-                                                { Elems =
-                                                   [Property
-                                                      { Name = String "done"
-                                                        TypeAnn =
-                                                         { Kind =
-                                                            Keyword Boolean
-                                                           Span =
-                                                            { Start =
-                                                               (Ln: 3, Col: 32)
-                                                              Stop =
-                                                               (Ln: 3, Col: 39) }
-                                                           InferredType = None }
-                                                        Optional = false
-                                                        Readonly = false };
-                                                    Property
-                                                      { Name = String "value"
-                                                        TypeAnn =
-                                                         { Kind =
-                                                            Range
-                                                              { Min =
-                                                                 { Kind =
-                                                                    TypeRef
-                                                                      { Ident =
-                                                                         Ident
-                                                                           "Min"
-                                                                        TypeArgs =
-                                                                         None }
-                                                                   Span =
-                                                                    { Start =
-                                                                       (Ln: 3, Col: 48)
-                                                                      Stop =
-                                                                       (Ln: 3, Col: 51) }
-                                                                   InferredType =
-                                                                    None }
-                                                                Max =
-                                                                 { Kind =
-                                                                    TypeRef
-                                                                      { Ident =
-                                                                         Ident
-                                                                           "Max"
-                                                                        TypeArgs =
-                                                                         None }
-                                                                   Span =
-                                                                    { Start =
-                                                                       (Ln: 3, Col: 53)
-                                                                      Stop =
-                                                                       (Ln: 3, Col: 57) }
-                                                                   InferredType =
-                                                                    None } }
-                                                           Span =
-                                                            { Start =
-                                                               (Ln: 3, Col: 48)
-                                                              Stop =
-                                                               (Ln: 3, Col: 57) }
-                                                           InferredType = None }
-                                                        Optional = false
-                                                        Readonly = false }]
-                                                  Immutable = false }
-                                             Span = { Start = (Ln: 3, Col: 24)
-                                                      Stop = (Ln: 4, Col: 7) }
-                                             InferredType = None }
+                                           Some
+                                             { Kind =
+                                                Object
+                                                  { Elems =
+                                                     [Property
+                                                        { Name = String "done"
+                                                          TypeAnn =
+                                                           { Kind =
+                                                              Keyword Boolean
+                                                             Span =
+                                                              { Start =
+                                                                 (Ln: 3, Col: 32)
+                                                                Stop =
+                                                                 (Ln: 3, Col: 39) }
+                                                             InferredType = None }
+                                                          Optional = false
+                                                          Readonly = false };
+                                                      Property
+                                                        { Name = String "value"
+                                                          TypeAnn =
+                                                           { Kind =
+                                                              Range
+                                                                { Min =
+                                                                   { Kind =
+                                                                      TypeRef
+                                                                        { Ident =
+                                                                           Ident
+                                                                             "Min"
+                                                                          TypeArgs =
+                                                                           None }
+                                                                     Span =
+                                                                      { Start =
+                                                                         (Ln: 3, Col: 48)
+                                                                        Stop =
+                                                                         (Ln: 3, Col: 51) }
+                                                                     InferredType =
+                                                                      None }
+                                                                  Max =
+                                                                   { Kind =
+                                                                      TypeRef
+                                                                        { Ident =
+                                                                           Ident
+                                                                             "Max"
+                                                                          TypeArgs =
+                                                                           None }
+                                                                     Span =
+                                                                      { Start =
+                                                                         (Ln: 3, Col: 53)
+                                                                        Stop =
+                                                                         (Ln: 3, Col: 57) }
+                                                                     InferredType =
+                                                                      None } }
+                                                             Span =
+                                                              { Start =
+                                                                 (Ln: 3, Col: 48)
+                                                                Stop =
+                                                                 (Ln: 3, Col: 57) }
+                                                             InferredType = None }
+                                                          Optional = false
+                                                          Readonly = false }]
+                                                    Immutable = false }
+                                               Span = { Start = (Ln: 3, Col: 24)
+                                                        Stop = (Ln: 4, Col: 7) }
+                                               InferredType = None }
                                           Throws = None
                                           IsAsync = false }
                                      Span = { Start = (Ln: 3, Col: 15)

--- a/src/Escalier.TypeChecker.Tests/GraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/GraphTests.fs
@@ -4,7 +4,6 @@ open FsToolkit.ErrorHandling
 open Xunit
 
 open Escalier.Parser
-open Escalier.TypeChecker
 open Escalier.TypeChecker.Graph
 open Escalier.Compiler
 open Escalier.TypeChecker.Error
@@ -660,17 +659,13 @@ let MutuallyRecursiveGraphInDeppObjects () =
   Assert.True(Result.isOk res)
 
 [<Fact>]
-let MutuallyRecursiveGraphInTuples () =
+let MutuallyRecursiveTypeDecl () =
   let res =
     result {
       let src =
         """
-        let foo = [
-          fn (n) => if n == 0 { true } else { bar[0](n - 1) }
-        ];
-        let bar = [
-          fn (n) => if n == 0 { false } else { foo[0](n - 1) } 
-        ];
+        type Foo = {foo: number | Bar["bar"][]};
+        type Bar = {bar: string | Foo["foo"][]};
         """
 
       let! ast =
@@ -682,63 +677,22 @@ let MutuallyRecursiveGraphInTuples () =
         inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
-      // TODO: simplify return types to `boolean`
-      Assert.Value(
-        env,
-        "foo",
-        "[fn (n: number) -> true | false | true | false]"
-      )
-
-      Assert.Value(env, "bar", "[fn (n: number) -> false | true | false]")
-    }
-
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let AcyclicFunctionDepsBuildTreeFirst () =
-  let res =
-    result {
-      let src =
-        """
-        let poly = fn() => add() * sub();
-        let add = fn () => x + y;
-        let sub = fn () => x - y;
-        let x = 5;
-        let y = 10;
-        let result = poly();
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Value(env, "x", "5")
-      Assert.Value(env, "y", "10")
-      Assert.Value(env, "add", "fn () -> 15")
-      Assert.Value(env, "sub", "fn () -> -5")
-      Assert.Value(env, "poly", "fn () -> -75")
+      Assert.Type(env, "Foo", "{foo: number | Bar[\"bar\"][]}")
+      Assert.Type(env, "Bar", "{bar: string | Foo[\"foo\"][]}")
     }
 
   printfn "res = %A" res
   Assert.True(Result.isOk res)
 
+
 [<Fact>]
-let AcyclicFunctionDepsBuildTreeFirstWithTypeAnnotations () =
+let MergeInterfaceBetweenFiles () =
   let res =
     result {
       let src =
         """
-        let poly = fn() => add() * sub();
-        let add = fn () => x + y;
-        let sub = fn () => x - y;
-        let x = 5;
-        let y = 10;
-        let result = poly();
+        interface Keys {foo: "foo"}
+        declare let keys: Keys;
         """
 
       let! ast =
@@ -750,527 +704,28 @@ let AcyclicFunctionDepsBuildTreeFirstWithTypeAnnotations () =
         inferModuleUsingTree ctx env ast
         |> Result.mapError CompileError.TypeError
 
-      Assert.Value(env, "x", "5")
-      Assert.Value(env, "y", "10")
-      Assert.Value(env, "add", "fn () -> 15")
-      Assert.Value(env, "sub", "fn () -> -5")
-      Assert.Value(env, "poly", "fn () -> -75")
+      Assert.Type(env, "Keys", "{foo: \"foo\"}")
+
+      let src =
+        """
+        interface Keys { bar: "bar"}
+        interface Obj {
+          [keys.foo]: number,
+          [keys.bar]: number,
+        }
+        """
+
+      let! ast =
+        Parser.parseModule src |> Result.mapError CompileError.ParseError
+
+      let! env =
+        inferModuleUsingTree ctx env ast
+        |> Result.mapError CompileError.TypeError
+
+      Assert.Type(env, "Keys", "{foo: \"foo\", bar: \"bar\"}")
+
+      Assert.Type(env, "Obj", "{foo: number, bar: number}")
     }
 
   printfn "res = %A" res
   Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferMutuallyRecursiveFunctions () =
-  let res =
-    result {
-      let src =
-        """
-        let isEven = fn (n) => if n == zero { true } else { isOdd(n - one) };
-        let isOdd = fn (n) => if n == zero { false } else { isEven(n - one) };
-        let zero = 0;
-        let one = 1;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      // TODO: simplify return types to `boolean`
-      Assert.Value(env, "isEven", "fn (n: number) -> true | false | true")
-
-      Assert.Value(
-        env,
-        "isOdd",
-        "fn (n: number) -> false | true | false | true"
-      )
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferMutuallyRecursiveTypes () =
-  let res =
-    result {
-      let src =
-        """
-        type Foo = string | Bar[];
-        type Bar = number | Foo[];
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Type(env, "Foo", "string | Bar[]")
-      Assert.Type(env, "Bar", "number | Foo[]")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferTypeofType () =
-  let res =
-    result {
-      let src =
-        """
-        let msg = "hello";
-        type T = typeof msg;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Value(env, "msg", "\"hello\"")
-      Assert.Type(env, "T", "\"hello\"")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferTypeofTypeForObjectProperty () =
-  let res =
-    result {
-      let src =
-        """
-        let obj = {msg: "hello"};
-        type T = typeof obj.msg;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Value(env, "obj", "{msg: \"hello\"}")
-      Assert.Type(env, "T", "\"hello\"")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferIndexedAccessTypes () =
-  let res =
-    result {
-      let src =
-        """
-        type Obj = {foo: string, bar: number};
-        type Foo = Obj["foo"];
-        type Bar = Obj["bar"];
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Type(env, "Foo", "Obj[\"foo\"]")
-      Assert.Type(env, "Bar", "Obj[\"bar\"]")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferMutuallyRecursiveIndexedAccessTypes () =
-  let res =
-    result {
-      let src =
-        """
-        type Foo = {foo: number, bar: Bar["bar"]};
-        type Bar = {foo: Foo["foo"], bar: string};
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Type(env, "Foo", "{foo: number, bar: Bar[\"bar\"]}")
-      Assert.Type(env, "Bar", "{foo: Foo[\"foo\"], bar: string}")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferObjectTypeWithComputedKeys () =
-  let res =
-    result {
-      let src =
-        """
-        let foo = "foo";
-        let bar = "bar";
-        type Obj = {
-          [foo]: string,
-          [bar]: number,
-        };
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Type(env, "Obj", "{foo: string, bar: number}")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferObjectTypeWithQualifiedComputedKeys () =
-  let res =
-    result {
-      let src =
-        """
-        let Keys = {FOO: "foo", BAR: "bar"};
-        type Obj = {
-          [Keys.FOO]: string,
-          [Keys.BAR]: number,
-        };
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Type(env, "Obj", "{foo: string, bar: number}")
-    }
-
-  printfn "res = %A" res
-  Assert.True(Result.isOk res)
-
-[<Fact>]
-let InferFuncDecl () =
-  let result =
-    result {
-      let src =
-        """
-        fn fst (x, y) {
-          return x;
-        }
-        declare fn snd<A, B>(x: A, y: B) -> B;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Value(env, "fst", "fn <A, B>(x: A, y: B) -> A")
-      Assert.Value(env, "snd", "fn <A, B>(x: A, y: B) -> B")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferFuncDeclInModule () =
-  let result =
-    result {
-      let src =
-        """
-        fn fst (x, y) {
-          return x;
-        }
-        declare fn snd<A, B>(x: A, y: B) -> B;
-        fn makePoint (x, y) -> Point {
-          return {x, y};
-        }
-        type Point = {x: number, y: number};
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Value(env, "fst", "fn <A, B>(x: A, y: B) -> A")
-      Assert.Value(env, "snd", "fn <A, B>(x: A, y: B) -> B")
-      Assert.Value(env, "makePoint", "fn (x: number, y: number) -> Point")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferInterfaceInModule () =
-  let result =
-    result {
-      let src =
-        """
-        let p: Point = {x: 5, y: 10};
-        interface Point {
-          x: number,
-        }
-        interface Point {
-          y: number,
-        }
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-      Assert.Type(env, "Point", "{x: number, y: number}")
-      Assert.Value(env, "p", "Point")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferNamespaceInModule () =
-  let result =
-    result {
-      let src =
-        """
-        type Baz = Foo.Baz;
-        namespace Foo {
-          namespace Bar {
-            let x = 5;
-          }
-          let y = Bar.x;
-          type Baz = string;
-        }
-        let x = Foo.Bar.x;
-        let y = Foo.y;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "x", "5")
-      Assert.Value(env, "y", "5")
-      Assert.Type(env, "Baz", "Foo.Baz")
-
-      let! t =
-        Unify.expandScheme ctx env None (env.FindScheme "Baz") Map.empty None
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Equal(t.ToString(), "string")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferNamespaceInModuleWithCaptures () =
-  let result =
-    result {
-      let src =
-        """
-        type Bar = string;
-        let bar: Bar = "hello";
-        namespace Foo {
-          let baz: Bar = bar;
-        }
-        let baz = Foo.baz;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "baz", "Bar")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferNamespaceInModuleWithInterfaceCapture () =
-  let result =
-    result {
-      let src =
-        """
-        interface Point {
-          x: number,
-        }
-        interface Point {
-          y: number,
-        }
-        namespace Foo {
-          let bar = fn (p: Point) -> undefined {};
-        }
-        let bar = Foo.bar;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "bar", "fn (p: Point) -> undefined")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-// NOTE: requires updating inferDeclDefinitions to take pairs of declarations
-// and placeholder types instead of `placeholderTypes` and `decls`.
-[<Fact(Skip = "TODO")>]
-let MultipleFuncDecls () =
-  let result =
-    result {
-      let src =
-        """
-        fn add(x: number, y: number) -> number {
-          return x + y;
-        }
-        fn add(x: string, y: string) -> string {
-          return x ++ y;
-        }
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "add", "fn (x: string, y: string) -> string")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferNestedFunctionsWithNestedCaptures () =
-  let result =
-    result {
-      let src =
-        """
-        let x = 5;
-        let y = 10;
-        let add = fn (a) => fn (b) => a * x + b * y;
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-
-      Assert.Value(
-        env,
-        "add",
-        "fn <A: number, B: number>(a: A) -> fn (b: B) -> A * 5 + B * 10"
-      )
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)
-
-[<Fact>]
-let InferFunctionWithTypeParams () =
-  let result =
-    result {
-      let src =
-        """
-        let add = fn <A: number, B: number>(x: A, y: B) {
-          let a: A = x;
-          let b: B = y;
-          return a + b;
-        };
-        """
-
-      let! ast =
-        Parser.parseModule src |> Result.mapError CompileError.ParseError
-
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
-
-      let! env =
-        inferModuleUsingTree ctx env ast
-        |> Result.mapError CompileError.TypeError
-
-      Assert.Empty(ctx.Diagnostics)
-
-      Assert.Value(env, "add", "fn <A: number, B: number>(x: A, y: B) -> A + B")
-    }
-
-  printfn "result = %A" result
-  Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
+++ b/src/Escalier.TypeChecker/Escalier.TypeChecker.fsproj
@@ -13,6 +13,7 @@
         <Compile Include="Poly.fs"/>
         <Compile Include="TemplateLiteral.fs"/>
         <Compile Include="Unify.fs"/>
+        <Compile Include="Helpers.fs"/>
         <Compile Include="Infer.fs"/>
         <Compile Include="Graph.fs"/>
     </ItemGroup>

--- a/src/Escalier.TypeChecker/Graph.fs
+++ b/src/Escalier.TypeChecker/Graph.fs
@@ -8,6 +8,7 @@ open Escalier.Data.Common
 open Escalier.Data.Syntax
 open Escalier.Data.Type
 
+open Helpers
 open Error
 open Env
 
@@ -819,7 +820,7 @@ module rec Graph =
 
         // TODO: update `inferDeclDefinitions` to take a `generalize` flag
         // so that we can avoid generalizing here.
-        let bindings = Infer.generalizeBindings inferredNS.Values
+        let bindings = generalizeBindings inferredNS.Values
         let newEnv = newEnv.AddBindings bindings
 
         return newEnv
@@ -841,7 +842,7 @@ module rec Graph =
 
         // TODO: update `inferDeclDefinitions` to take a `generalize` flag
         // so that we can avoid generalizing here.
-        let bindings = Infer.generalizeBindings inferredNS.Values
+        let bindings = generalizeBindings inferredNS.Values
         let newEnv = newEnv.AddBindings bindings
 
         return newEnv

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -15,10 +15,15 @@ let rec generalizeFunctionsInType (t: Type) : Type =
       elems
       |> List.map (fun elem ->
         match elem with
+        | ObjTypeElem.Callable fn -> ObjTypeElem.Callable(generalizeFunc fn)
+        | ObjTypeElem.Constructor fn ->
+          ObjTypeElem.Constructor(generalizeFunc fn)
         | ObjTypeElem.Method(name, fn) ->
-          let fn = generalizeFunc fn
-          ObjTypeElem.Method(name, fn)
-        // TODO: handle the other function like element types
+          ObjTypeElem.Method(name, (generalizeFunc fn))
+        | ObjTypeElem.Getter(name, fn) ->
+          ObjTypeElem.Getter(name, (generalizeFunc fn))
+        | ObjTypeElem.Setter(name, fn) ->
+          ObjTypeElem.Setter(name, (generalizeFunc fn))
         | ObjTypeElem.Property { Name = name
                                  Optional = optional
                                  Readonly = readonly

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -1,0 +1,49 @@
+module rec Escalier.TypeChecker.Helpers
+
+open Escalier.Data.Common
+open Escalier.Data.Type
+
+open Poly
+
+let rec generalizeFunctionsInType (t: Type) : Type =
+  match (prune t).Kind with
+  | TypeKind.Function f ->
+    { t with
+        Kind = generalizeFunc f |> TypeKind.Function }
+  | TypeKind.Object({ Elems = elems } as objectKind) ->
+    let elems =
+      elems
+      |> List.map (fun elem ->
+        match elem with
+        | ObjTypeElem.Method(name, fn) ->
+          let fn = generalizeFunc fn
+          ObjTypeElem.Method(name, fn)
+        // TODO: handle the other function like element types
+        | ObjTypeElem.Property { Name = name
+                                 Optional = optional
+                                 Readonly = readonly
+                                 Type = t } ->
+          ObjTypeElem.Property
+            { Name = name
+              Optional = optional
+              Readonly = readonly
+              Type = generalizeFunctionsInType t }
+        | _ -> elem)
+
+    { t with
+        Kind = TypeKind.Object { objectKind with Elems = elems } }
+  | TypeKind.Tuple({ Elems = elems } as tupleKind) ->
+    let elems = elems |> List.map generalizeFunctionsInType
+
+    { t with
+        Kind = TypeKind.Tuple { tupleKind with Elems = elems } }
+  | _ -> t
+
+let generalizeBindings (bindings: Map<string, Binding>) : Map<string, Binding> =
+  let mutable newBindings = Map.empty
+
+  for KeyValue(name, (t, isMut)) in bindings do
+    let t = generalizeFunctionsInType t
+    newBindings <- newBindings.Add(name, (t, isMut))
+
+  newBindings

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -203,6 +203,8 @@ module rec Unify =
                     Immutable = false }
               Provenance = None }
 
+          printfn $"restParam2.Type = {restParam2.Type}"
+          printfn $"restParam1 = {restParam1}"
           do! unify ctx env ips restParam2.Type restParam1
         | _ -> return! Error(TypeError.SemanticError("Too many rest params!"))
 

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -128,7 +128,7 @@ module rec ExprVisitor =
     | DeclKind.FnDecl { Sig = fnSig; Body = body } ->
       // TODO: walk type params
       List.iter
-        (fun (param: FuncParam<option<TypeAnn>>) ->
+        (fun (param: FuncParam) ->
           Option.iter (walkTypeAnn visitor state) param.TypeAnn)
         fnSig.ParamList
 
@@ -224,11 +224,11 @@ module rec ExprVisitor =
         | TypeAnnKind.TypeRef { TypeArgs = typeArgs } ->
           Option.iter (List.iter (walk state)) typeArgs
         | TypeAnnKind.Function f ->
-          walk state f.ReturnType
+          Option.iter (walk state) f.ReturnType
           Option.iter (walk state) f.Throws
 
           List.iter
-            (fun (param: FuncParam<TypeAnn>) -> walk state param.TypeAnn)
+            (fun (param: FuncParam) -> Option.iter (walk state) param.TypeAnn)
             f.ParamList
         | TypeAnnKind.Keyof target -> walk state target
         | TypeAnnKind.Rest target -> walk state target
@@ -267,28 +267,28 @@ module rec ExprVisitor =
 
       match elem with
       | Callable f ->
-        walk f.ReturnType
+        Option.iter walk f.ReturnType
         Option.iter walk f.Throws
 
         List.iter
-          (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
+          (fun (param: FuncParam) -> Option.iter walk param.TypeAnn)
           f.ParamList
       | Constructor f ->
-        walk f.ReturnType
+        Option.iter walk f.ReturnType
         Option.iter walk f.Throws
 
         List.iter
-          (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
+          (fun (param: FuncParam) -> Option.iter walk param.TypeAnn)
           f.ParamList
       | Method { Type = f } ->
-        walk f.ReturnType
+        Option.iter walk f.ReturnType
         Option.iter walk f.Throws
 
         List.iter
-          (fun (param: FuncParam<TypeAnn>) -> walk param.TypeAnn)
+          (fun (param: FuncParam) -> Option.iter walk param.TypeAnn)
           f.ParamList
-      | Getter { ReturnType = retType } -> walk retType
-      | Setter { Param = { TypeAnn = paramType } } -> walk paramType
+      | Getter { ReturnType = retType } -> Option.iter walk retType
+      | Setter { Param = { TypeAnn = paramType } } -> Option.iter walk paramType
       | Property { TypeAnn = typeAnn } -> walk typeAnn
       | Mapped { TypeParam = typeParam
                  TypeAnn = typeAnn } ->


### PR DESCRIPTION
- infer structural placeholder types for object and tuple literals
- make type annotations always option in FuncSig and remove FuncType and inferFunctionType
- merge interfaces between files