### PR TITLE
Update inferDecl* in QualifiedGraph.fs to use a QualifiedNamespace to keep track of inferred symbols

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -423,8 +423,7 @@ module Syntax =
     { Declare: bool
       Name: string
       Sig: FuncSig
-      Body: option<BlockOrExpr>
-      mutable Inferred: option<Type.Type> }
+      Body: option<BlockOrExpr> }
 
   type ClassDeclInferredTypes =
     { Instance: Type.Scheme
@@ -433,20 +432,17 @@ module Syntax =
   type ClassDecl =
     { Declare: bool
       Name: string
-      Class: Class
-      mutable Inferred: option<ClassDeclInferredTypes> }
+      Class: Class }
 
   type TypeDecl =
     { Name: string
       TypeAnn: TypeAnn
-      TypeParams: option<list<TypeParam>>
-      mutable Inferred: option<Type.Scheme> }
+      TypeParams: option<list<TypeParam>> }
 
   type InterfaceDecl =
     { Name: string
       TypeParams: option<list<TypeParam>>
-      Elems: list<ObjTypeAnnElem>
-      mutable Inferred: option<Type.Scheme> }
+      Elems: list<ObjTypeAnnElem> }
 
   type EnumVariant =
     { Name: string

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -805,8 +805,7 @@ module rec Migrate =
 
     { Declare = declare
       Name = name
-      Class = cls
-      Inferred = None }
+      Class = cls }
 
   // This function returns a list of declarations because a single TypeScript
   // variable declaration can declare multiple variables.
@@ -852,8 +851,7 @@ module rec Migrate =
             { Declare = true // Some .d.ts files do `export function foo();`
               Name = ident.Name
               Sig = fnSig
-              Body = None
-              Inferred = None }
+              Body = None }
 
         [ { Kind = kind; Span = DUMMY_SPAN } ]
       | Decl.Var { Declare = declare; Decls = decls } ->
@@ -874,8 +872,7 @@ module rec Migrate =
         let decl: InterfaceDecl =
           { Name = ident.Name
             TypeParams = typeParams
-            Elems = elems
-            Inferred = None }
+            Elems = elems }
 
         let kind = DeclKind.InterfaceDecl decl
         [ { Kind = kind; Span = DUMMY_SPAN } ]
@@ -892,8 +889,7 @@ module rec Migrate =
         let decl: TypeDecl =
           { Name = ident.Name
             TypeParams = typeParams
-            TypeAnn = migrateType typeAnn
-            Inferred = None }
+            TypeAnn = migrateType typeAnn }
 
         let kind = DeclKind.TypeDecl decl
         [ { Kind = kind; Span = DUMMY_SPAN } ]

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
@@ -42,8 +42,7 @@ output: Ok
                        Span = { Start = (Ln: 2, Col: 21)
                                 Stop = (Ln: 5, Col: 6) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 6, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
@@ -58,8 +58,7 @@ output: Ok
                                                   Stop = (Ln: 2, Col: 15) }
                                          Name = "T"
                                          Constraint = None
-                                         Default = None }]
-                    Inferred = None }
+                                         Default = None }] }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
@@ -44,8 +44,7 @@ output: Ok
                                                        Stop = (Ln: 2, Col: 22) }
                                               Name = "U"
                                               Constraint = None
-                                              Default = None }]
-                    Inferred = None }
+                                              Default = None }] }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDecl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDecl.verified.txt
@@ -60,8 +60,7 @@ output: Ok
                                                     Stop = (Ln: 1, Col: 38) }
                                            InferredType = None })
                                 Span = { Start = (Ln: 1, Col: 30)
-                                         Stop = (Ln: 1, Col: 40) } }] })
-                    Inferred = None }
+                                         Stop = (Ln: 1, Col: 40) } }] }) }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 41) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
@@ -22,8 +22,7 @@ output: Ok
                        Span = { Start = (Ln: 1, Col: 12)
                                 Stop = (Ln: 1, Col: 22) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 23) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -69,8 +69,7 @@ output: Ok
                                                   Stop = (Ln: 1, Col: 18) }
                                          Name = "T"
                                          Constraint = None
-                                         Default = None }]
-                    Inferred = None }
+                                         Default = None }] }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 76) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterface.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterface.verified.txt
@@ -20,8 +20,7 @@ output: Ok
                                                  Stop = (Ln: 3, Col: 16) }
                                         InferredType = None }
                             Optional = false
-                            Readonly = false }]
-               Inferred = None }
+                            Readonly = false }] }
           Span = { Start = (Ln: 2, Col: 5)
                    Stop = (Ln: 5, Col: 5) } };
       Decl
@@ -36,7 +35,6 @@ output: Ok
                                                  Stop = (Ln: 6, Col: 16) }
                                         InferredType = None }
                             Optional = false
-                            Readonly = false }]
-               Inferred = None }
+                            Readonly = false }] }
           Span = { Start = (Ln: 5, Col: 5)
                    Stop = (Ln: 8, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterfaceWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterfaceWithTypeParam.verified.txt
@@ -29,7 +29,6 @@ output: Ok
                                           Stop = (Ln: 3, Col: 14) }
                                  InferredType = None }
                      Optional = None
-                     Readonly = None }]
-               Inferred = None }
+                     Readonly = None }] }
           Span = { Start = (Ln: 2, Col: 5)
                    Stop = (Ln: 5, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
@@ -39,8 +39,7 @@ output: Ok
                        Span = { Start = (Ln: 1, Col: 14)
                                 Stop = (Ln: 1, Col: 46) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 47) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
@@ -38,8 +38,7 @@ output: Ok
                        Span = { Start = (Ln: 2, Col: 18)
                                 Stop = (Ln: 2, Col: 40) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
@@ -78,8 +77,7 @@ output: Ok
                        Span = { Start = (Ln: 3, Col: 17)
                                 Stop = (Ln: 3, Col: 39) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 3, Col: 5)
                         Stop = (Ln: 4, Col: 5) } }
           Span = { Start = (Ln: 3, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
@@ -60,8 +60,7 @@ output: Ok
                                            Span = { Start = (Ln: 7, Col: 18)
                                                     Stop = (Ln: 7, Col: 24) }
                                            InferredType = None }
-                               TypeParams = None
-                               Inferred = None }
+                               TypeParams = None }
                    Span = { Start = (Ln: 7, Col: 7)
                             Stop = (Ln: 8, Col: 5) } }] }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
@@ -65,8 +65,7 @@ output: Ok
                                          Span = { Start = (Ln: 7, Col: 18)
                                                   Stop = (Ln: 7, Col: 24) }
                                          InferredType = None }
-                             TypeParams = None
-                             Inferred = None }
+                             TypeParams = None }
                         Span = { Start = (Ln: 7, Col: 7)
                                  Stop = (Ln: 8, Col: 5) } }] }
                Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedType.verified.txt
@@ -14,8 +14,7 @@ output: Ok
                        Span = { Start = (Ln: 1, Col: 12)
                                 Stop = (Ln: 1, Col: 29) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 30) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
@@ -36,8 +36,7 @@ output: Ok
                        Span = { Start = (Ln: 2, Col: 18)
                                 Stop = (Ln: 2, Col: 40) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
@@ -56,8 +56,7 @@ output: Ok
                        Span = { Start = (Ln: 2, Col: 16)
                                 Stop = (Ln: 2, Col: 40) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
@@ -84,8 +84,7 @@ output: Ok
                        Span = { Start = (Ln: 2, Col: 18)
                                 Stop = (Ln: 6, Col: 6) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
@@ -22,8 +22,7 @@ output: Ok
                        Span = { Start = (Ln: 2, Col: 20)
                                 Stop = (Ln: 2, Col: 24) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 3, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
@@ -116,8 +116,7 @@ output: Ok
                                               Span = { Start = (Ln: 2, Col: 44)
                                                        Stop = (Ln: 2, Col: 50) }
                                               InferredType = None }
-                          Default = None }]
-                    Inferred = None }
+                          Default = None }] }
                Span = { Start = (Ln: 2, Col: 7)
                         Stop = (Ln: 5, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 7)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
@@ -18,8 +18,7 @@ output: Ok
                        Span = { Start = (Ln: 1, Col: 24)
                                 Stop = (Ln: 1, Col: 38) }
                        InferredType = None }
-                    TypeParams = None
-                    Inferred = None }
+                    TypeParams = None }
                Span = { Start = (Ln: 1, Col: 1)
                         Stop = (Ln: 1, Col: 39) } }
           Span = { Start = (Ln: 1, Col: 1)

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -1450,8 +1450,7 @@ module Parser =
           { Declare = false
             Name = name
             Sig = fnSig
-            Body = Some(BlockOrExpr.Block body)
-            Inferred = None }
+            Body = Some(BlockOrExpr.Block body) }
 
       { Kind = kind; Span = span }
 
@@ -1473,8 +1472,7 @@ module Parser =
           TypeDecl
             { Name = id
               TypeAnn = typeAnn
-              TypeParams = typeParams
-              Inferred = None }
+              TypeParams = typeParams }
         Span = span }
 
   let private interfaceDecl: Parser<Decl, unit> =
@@ -1491,8 +1489,7 @@ module Parser =
           InterfaceDecl
             { Name = name
               TypeParams = typeParams
-              Elems = objTypeElems
-              Inferred = None }
+              Elems = objTypeElems }
         Span = span }
 
   let private enumVariant: Parser<EnumVariant, unit> =
@@ -1745,8 +1742,7 @@ module Parser =
         { Declare = true
           Name = name
           Sig = fnSig
-          Body = None
-          Inferred = None }
+          Body = None }
 
   let declare: Parser<Stmt, unit> =
     pipe3

--- a/src/Escalier.TypeChecker/QualifiedGraph.fs
+++ b/src/Escalier.TypeChecker/QualifiedGraph.fs
@@ -38,6 +38,18 @@ type QGraph =
     { Edges = this.Edges.Add(name, deps)
       Nodes = this.Nodes.Add(name, decls) }
 
+type QualifiedNamespace =
+  { Values: Map<QualifiedIdent, Binding>
+    Schemes: Map<QualifiedIdent, Scheme> }
+
+  member this.AddValue (ident: QualifiedIdent) (binding: Binding) =
+    { this with
+        Values = Map.add ident binding this.Values }
+
+  member this.AddScheme (ident: QualifiedIdent) (scheme: Scheme) =
+    { this with
+        Schemes = Map.add ident scheme this.Schemes }
+
 type SyntaxNode = Graph.SyntaxNode
 
 // Find identifiers in an expression excluding function expressions.
@@ -890,11 +902,12 @@ let getAllBindingPatterns (pattern: Pattern) : Map<string, Type> =
 let inferDeclPlaceholders
   (ctx: Ctx)
   (env: Env)
+  (qns: QualifiedNamespace)
   (decls: list<Decl>)
-  : Result<unit, TypeError> =
+  : Result<QualifiedNamespace, TypeError> =
 
   result {
-    let mutable newEnv = env
+    let mutable qns = qns
 
     for decl in decls do
       match decl.Kind with
@@ -914,19 +927,17 @@ let inferDeclPlaceholders
         | None -> ()
 
         for KeyValue(name, binding) in bindings do
-          newEnv <- newEnv.AddValue name binding
+          qns <- qns.AddValue (QualifiedIdent.Ident name) binding
       | FnDecl({ Declare = false
                  Sig = fnSig
                  Name = name } as decl) ->
-        let! f = Infer.inferFuncSig ctx newEnv fnSig
+        let! f = Infer.inferFuncSig ctx env fnSig
 
         let t =
           { Kind = TypeKind.Function f
             Provenance = None }
 
-        newEnv <- newEnv.AddValue name (t, false)
-
-        decl.Inferred <- Some t
+        qns <- qns.AddValue (QualifiedIdent.Ident name) (t, false)
       | FnDecl({ Declare = true
                  Sig = fnSig
                  Name = name } as decl) ->
@@ -940,7 +951,7 @@ let inferDeclPlaceholders
         if fnSig.ReturnType.IsNone then
           failwith "Ambient function declarations must be fully typed"
 
-        let! f = Infer.inferFuncSig ctx newEnv fnSig
+        let! f = Infer.inferFuncSig ctx env fnSig
 
         if fnSig.Throws.IsNone then
           f.Throws <-
@@ -951,9 +962,7 @@ let inferDeclPlaceholders
           { Kind = TypeKind.Function f
             Provenance = None }
 
-        newEnv <- newEnv.AddValue name (t, false)
-
-        decl.Inferred <- Some t
+        qns <- qns.AddValue (QualifiedIdent.Ident name) (t, false)
       | ClassDecl({ Name = name } as decl) ->
         // TODO: treat ClassDecl similar to object types where we create a
         // structural placeholder type instead of an opaque type variable.
@@ -963,42 +972,38 @@ let inferDeclPlaceholders
             TypeParams = None // TODO: handle type params
             IsTypeParam = false }
 
-        newEnv <- newEnv.AddScheme name instance
+        qns <- qns.AddScheme (QualifiedIdent.Ident name) instance
 
         let statics: Type = ctx.FreshTypeVar None
 
-        newEnv <- newEnv.AddValue name (statics, false)
-
-        decl.Inferred <-
-          Some
-            { Instance = instance
-              Statics = statics }
+        qns <- qns.AddValue (QualifiedIdent.Ident name) (statics, false)
       | EnumDecl _ ->
         return!
           Error(
             TypeError.NotImplemented "TODO: inferDeclPlaceholders - EnumDecl"
           )
       | TypeDecl typeDecl ->
+        // TODO: check to make sure we aren't redefining an existing type
+
         // TODO: replace placeholders, with a reference the actual definition
         // once we've inferred the definition
         let! placeholder =
           Infer.inferTypeDeclPlaceholderScheme ctx env typeDecl.TypeParams
 
-        // TODO: update AddScheme to return a Result<Env, TypeError> and
-        // return an error if the name already exists since we can't redefine
-        // types.
-        typeDecl.Inferred <- Some placeholder
-        newEnv <- newEnv.AddScheme typeDecl.Name placeholder
+        qns <- qns.AddScheme (QualifiedIdent.Ident typeDecl.Name) placeholder
       | InterfaceDecl({ Name = name; TypeParams = typeParams } as decl) ->
         // Instead of looking things up in the environment, we need some way to
         // find the existing type on other declarations.
         let! placeholder =
-          match newEnv.TryFindScheme name with
+          match env.TryFindScheme name with
           | Some scheme -> Result.Ok scheme
-          | None -> Infer.inferTypeDeclPlaceholderScheme ctx env typeParams
+          | None ->
+            match qns.Schemes.TryFind(QualifiedIdent.Ident name) with
+            | Some scheme -> Result.Ok scheme
+            | None -> Infer.inferTypeDeclPlaceholderScheme ctx env typeParams
 
-        decl.Inferred <- Some placeholder
-        newEnv <- newEnv.AddScheme name placeholder
+        qns <- qns.AddScheme (QualifiedIdent.Ident name) placeholder
+      // newEnv <- newEnv.AddScheme name placeholder
       | NamespaceDecl nsDecl ->
         return!
           Error(
@@ -1011,16 +1016,19 @@ let inferDeclPlaceholders
     // placeholderNS <- placeholderNS.AddNamespace nsDecl.Name ns
     // newEnv <- newEnv.AddNamespace nsDecl.Name ns
 
-    return ()
+    return qns
   }
 
 let inferDeclDefinitions
   (ctx: Ctx)
   (env: Env)
+  (qns: QualifiedNamespace)
   (decls: list<Decl>)
-  : Result<unit, TypeError> =
+  : Result<QualifiedNamespace, TypeError> =
 
   result {
+    let mutable qns = qns
+
     for decl in decls do
       match decl.Kind with
       | VarDecl varDecl ->
@@ -1042,12 +1050,11 @@ let inferDeclDefinitions
 
           do! Unify.unify ctx env None placeholderType inferredType
 
-      // TODO: handle any schemes that are generated in a similar way to how
-      // we're handling inferred value types.
-      // Schemes can be generated for things like class expressions, e.g.
-      // let Foo = class { ... }
-      // for KeyValue(name, scheme) in newSchemes do
-      //   newEnv <- newEnv.AddScheme name scheme
+        // Schemes can be generated for things like class expressions, e.g.
+        // let Foo = class { ... }
+        for KeyValue(name, scheme) in newSchemes do
+          qns <- qns.AddScheme (QualifiedIdent.Ident name) scheme
+
       | FnDecl({ Declare = false
                  Name = name
                  Sig = fnSig
@@ -1056,13 +1063,14 @@ let inferDeclDefinitions
         // declarations to be able to unify with any free type variables
         // from this declaration.  We generalize things in `inferModule` and
         // `inferTreeRec`.
+        // NOTE: `inferFunction` also calls unify
         let! f = Infer.inferFunction ctx env fnSig body
 
-        let t =
+        let inferredType =
           { Kind = TypeKind.Function f
             Provenance = None }
 
-        decl.Inferred <- Some t
+        qns <- qns.AddValue (QualifiedIdent.Ident name) (inferredType, false)
       | FnDecl { Declare = true } ->
         // Nothing to do since ambient function declarations don't have
         // function bodies.
@@ -1071,8 +1079,7 @@ let inferDeclDefinitions
         return! Error(TypeError.SemanticError "Invalid function declaration")
       | ClassDecl { Declare = declare
                     Name = name
-                    Class = cls
-                    Inferred = placeholders } ->
+                    Class = cls } ->
         let! t, scheme = Infer.inferClass ctx env cls declare
 
         // TODO: update `Statics` and `Instance` on `placeholders`
@@ -1083,17 +1090,15 @@ let inferDeclDefinitions
           Error(
             TypeError.NotImplemented "TODO: inferDeclDefinitions - EnumDecl"
           )
-      | TypeDecl { Name = name
-                   TypeAnn = typeAnn
-                   Inferred = placeholder } ->
+      | TypeDecl { Name = name; TypeAnn = typeAnn } ->
+        let placeholder = qns.Schemes[(QualifiedIdent.Ident name)]
         // TODO: when computing the decl graph, include self-recursive types in
         // the deps set so that we don't have to special case this here.
         // Handles self-recursive types
-        let newEnv = env.AddScheme name placeholder.Value
+        let newEnv = env.AddScheme name placeholder
         let getType = fun env -> Infer.inferTypeAnn ctx env typeAnn
 
-        let! scheme =
-          Infer.inferTypeDeclDefn ctx newEnv placeholder.Value getType
+        let! scheme = Infer.inferTypeDeclDefn ctx newEnv placeholder getType
 
         // Replace the placeholder's type with the actual type.
         // NOTE: This is a bit hacky and we may want to change this later to use
@@ -1101,16 +1106,17 @@ let inferDeclDefinitions
         // Required for the following test cases:
         // - InferRecursiveGenericObjectTypeInModule
         // - InferNamespaceInModule
-        placeholder.Value.Type <- scheme.Type
+        // placeholder.Value.Type <- scheme.Type
+        qns.Schemes[(QualifiedIdent.Ident name)].Type <- scheme.Type
       | InterfaceDecl { Name = name
                         TypeParams = typeParams
-                        Elems = elems
-                        Inferred = placeholder } ->
+                        Elems = elems } ->
+        let placeholder = qns.Schemes[(QualifiedIdent.Ident name)]
 
         // TODO: when computing the decl graph, include self-recursive types in
         // the deps set so that we don't have to special case this here.
         // Handles self-recursive types
-        let newEnv = env.AddScheme name placeholder.Value
+        let newEnv = env.AddScheme name placeholder
 
         let getType (env: Env) : Result<Type, TypeError> =
           result {
@@ -1126,10 +1132,9 @@ let inferDeclDefinitions
             return { Kind = kind; Provenance = None }
           }
 
-        let! newScheme =
-          Infer.inferTypeDeclDefn ctx newEnv placeholder.Value getType
+        let! newScheme = Infer.inferTypeDeclDefn ctx newEnv placeholder getType
 
-        match placeholder.Value.Type.Kind, newScheme.Type.Kind with
+        match placeholder.Type.Kind, newScheme.Type.Kind with
         | TypeKind.Object { Elems = existingElems },
           TypeKind.Object { Elems = newElems } ->
           // TODO: remove duplicates
@@ -1150,12 +1155,14 @@ let inferDeclDefinitions
 
           // We modify the existing scheme in place so that existing values
           // with this type are updated.
-          placeholder.Value.Type <- t
+          placeholder.Type <- t
+          qns.Schemes[(QualifiedIdent.Ident name)].Type <- t
         | _ ->
           // Replace the placeholder's type with the actual type.
           // NOTE: This is a bit hacky and we may want to change this later to use
           // `foldType` to replace any uses of the placeholder with the actual type.
-          placeholder.Value.Type <- newScheme.Type
+          placeholder.Type <- newScheme.Type
+          qns.Schemes[(QualifiedIdent.Ident name)].Type <- newScheme.Type
       | NamespaceDecl { Name = name; Body = decls } ->
         return!
           Error(
@@ -1163,7 +1170,7 @@ let inferDeclDefinitions
               "TODO: inferDeclDefinitions - NamespaceDecl"
           )
 
-    return ()
+    return qns
   }
 
 type QDeclTree =
@@ -1227,19 +1234,10 @@ let rec graphToTree (edges: Map<QDeclIdent, list<QDeclIdent>>) : QDeclTree =
   { CycleMap = cycleMap
     Edges = newEdges }
 
-type InferredLocals =
-  { Values: Map<QualifiedIdent, Binding>
-    Type: Map<QualifiedIdent, Scheme> }
-
-  member this.AddValue (ident: QualifiedIdent) (binding: Binding) =
-    { this with
-        Values = Map.add ident binding this.Values }
-
-  member this.AddScheme (ident: QualifiedIdent) (scheme: Scheme) =
-    { this with
-        Type = Map.add ident scheme this.Type }
-
-let copyInferredLocalsToEnv (inferredLocals: InferredLocals) (env: Env) : Env =
+let updateEnvWithQualifiedNamespace
+  (env: Env)
+  (inferredLocals: QualifiedNamespace)
+  : Env =
   let mutable newEnv = env
 
   for KeyValue(ident, binding) in inferredLocals.Values do
@@ -1248,7 +1246,7 @@ let copyInferredLocalsToEnv (inferredLocals: InferredLocals) (env: Env) : Env =
     | QualifiedIdent.Member(left, right) ->
       failwith "TODO: inferTreeRec - Member"
 
-  for KeyValue(ident, scheme) in inferredLocals.Type do
+  for KeyValue(ident, scheme) in inferredLocals.Schemes do
     match ident with
     | QualifiedIdent.Ident name -> newEnv <- newEnv.AddScheme name scheme
     | QualifiedIdent.Member(left, right) ->
@@ -1256,73 +1254,37 @@ let copyInferredLocalsToEnv (inferredLocals: InferredLocals) (env: Env) : Env =
 
   newEnv
 
-let updateInferredLocals
-  (inferredLocals: InferredLocals)
-  (decls: list<Decl>)
-  : InferredLocals =
-
-  let mutable inferredLocals = inferredLocals
-
-  for decl in decls do
-    match decl.Kind with
-    | VarDecl varDecl ->
-      // TODO: store the binding instead of just the types
-      let valueTypes = getAllBindingPatterns varDecl.Pattern
-
-      for KeyValue(name, t) in valueTypes do
-        let ident = QualifiedIdent.Ident name
-        inferredLocals <- inferredLocals.AddValue ident (t, false)
-    | FnDecl fnDecl ->
-      let ident = QualifiedIdent.Ident fnDecl.Name
-
-      inferredLocals <-
-        inferredLocals.AddValue ident (fnDecl.Inferred.Value, false)
-    | ClassDecl classDecl ->
-      let ident = QualifiedIdent.Ident classDecl.Name
-
-      inferredLocals <-
-        inferredLocals.AddValue ident (classDecl.Inferred.Value.Statics, false)
-
-      inferredLocals <-
-        inferredLocals.AddScheme ident classDecl.Inferred.Value.Instance
-    | TypeDecl typeDecl ->
-      let ident = QualifiedIdent.Ident typeDecl.Name
-
-      inferredLocals <- inferredLocals.AddScheme ident typeDecl.Inferred.Value
-    | InterfaceDecl interfaceDecl ->
-      let ident = QualifiedIdent.Ident interfaceDecl.Name
-
-      inferredLocals <-
-        inferredLocals.AddScheme ident interfaceDecl.Inferred.Value
-    | EnumDecl enumDecl -> failwith "TODO: inferGraph - EnumDecl"
-    | NamespaceDecl namespaceDecl -> failwith "TODO: inferGraph - NamespaceDecl"
-
-  inferredLocals
-
 let rec inferTreeRec
   (ctx: Ctx)
   (env: Env)
   (root: Set<QDeclIdent>)
   (graph: QGraph)
   (tree: QDeclTree)
-  (inferredLocals: InferredLocals)
-  : Result<InferredLocals, TypeError> =
+  (qns: QualifiedNamespace)
+  : Result<QualifiedNamespace, TypeError> =
 
   result {
-    let mutable inferredLocals = inferredLocals
+    let mutable qns = qns
 
     // Infer dependencies
     match tree.Edges.TryFind root with
     | Some deps ->
       for dep in deps do
-        let! newInferredLocals =
-          inferTreeRec ctx env dep graph tree inferredLocals
-
-        inferredLocals <- newInferredLocals
+        // TODO: avoid re-inferring types if they've already been inferred
+        let! newQns = inferTreeRec ctx env dep graph tree qns
+        qns <- newQns
     | None -> ()
 
     // Update environment to include dependencies
-    let newEnv = copyInferredLocalsToEnv inferredLocals env
+    // TODO: minimize the number of updates we have to make each time to newEnv
+    // Right now we're updating we're updating the environment with symbols from
+    // the current deps as well as the symbols from all previous calls to
+    // inferTreeRec.  We still want to pass a QualifiedNamespace that accumulates
+    // inferred symbols over multiple calls so that avoid re-infering the same
+    // symbol, but we only need to add the symbols from the current deps to the
+    // environment.
+    let newEnv = updateEnvWithQualifiedNamespace env qns
+    let newQns = qns
 
     match List.ofSeq root with
     | [] ->
@@ -1334,21 +1296,19 @@ let rec inferTreeRec
       let decls =
         names |> List.map (fun name -> graph.Nodes[name]) |> List.concat
 
-      do! inferDeclPlaceholders ctx newEnv decls
+      let! newQns = inferDeclPlaceholders ctx newEnv newQns decls
       // TODO: add decls to the environment after inferring placeholders so
       // they're available when inferring mutually recursive function definitions
-      do! inferDeclDefinitions ctx newEnv decls
+      let! newQns = inferDeclDefinitions ctx newEnv newQns decls
 
-      inferredLocals <- updateInferredLocals inferredLocals decls
+      qns <- newQns
 
-      let mutable bindings: Map<string, Binding> = Map.empty
-
-      for KeyValue(key, binding) in inferredLocals.Values do
+      for KeyValue(key, binding) in qns.Values do
         let t, isMut = binding
         let t = Helpers.generalizeFunctionsInType t
-        inferredLocals <- inferredLocals.AddValue key (t, isMut)
+        qns <- qns.AddValue key (t, isMut)
 
-      return inferredLocals
+      return qns
   }
 
 let inferGraph (ctx: Ctx) (env: Env) (graph: QGraph) : Result<Env, TypeError> =
@@ -1366,16 +1326,15 @@ let inferGraph (ctx: Ctx) (env: Env) (graph: QGraph) : Result<Env, TypeError> =
         if not (Set.contains key deps) then
           entryPoints <- entryPoints.Add(Set.singleton key)
 
-    let mutable inferredLocals: InferredLocals =
-      { Values = Map.empty; Type = Map.empty }
+    let mutable qns: QualifiedNamespace =
+      { Values = Map.empty
+        Schemes = Map.empty }
 
     // Infer entry points and all their dependencies
     for set in entryPoints do
       try
-        let! newInferredLocals =
-          inferTreeRec ctx env set graph tree inferredLocals
-
-        inferredLocals <- newInferredLocals
+        let! newQns = inferTreeRec ctx env set graph tree qns
+        qns <- newQns
       with e ->
         printfn $"Error: {e}"
         return! Error(TypeError.SemanticError(e.ToString()))
@@ -1385,5 +1344,5 @@ let inferGraph (ctx: Ctx) (env: Env) (graph: QGraph) : Result<Env, TypeError> =
     // environment is when we're dealing with globals.
 
     // Update environment with all new values and types
-    return copyInferredLocalsToEnv inferredLocals env
+    return updateEnvWithQualifiedNamespace env qns
   }


### PR DESCRIPTION
TODO: 
- ~avoid re-inferring things~ I'll tackle this in a separate PR
- [x] avoid copying too many things to the environment when inferring things