### PR TITLE
Fix bug in addScheme

### DIFF
--- a/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
@@ -59,16 +59,6 @@ let NamespaceShadowingOfVariables () =
 
       let graph = buildGraph env ast
 
-      printfn "graph.Edges = "
-
-      for KeyValue(key, value) in graph.Edges do
-        printfn $"{key} -> {value}"
-
-      printfn "graph.Nodes.Keys = "
-
-      for key in graph.Nodes.Keys do
-        printfn $"{key}"
-
       let! env =
         inferGraph ctx env graph |> Result.mapError CompileError.TypeError
 

--- a/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
@@ -78,7 +78,7 @@ let NamespaceShadowingOfVariables () =
 
   Assert.True(Result.isOk res)
 
-[<Fact(Skip = "TODO: make this pass")>]
+[<Fact>]
 let NamespaceShadowingOfTypes () =
   let res =
     result {
@@ -100,16 +100,6 @@ let NamespaceShadowingOfTypes () =
       let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
       let graph = buildGraph env ast
-
-      printfn "graph.Edges = "
-
-      for KeyValue(key, value) in graph.Edges do
-        printfn $"{key} -> {value}"
-
-      printfn "graph.Nodes.Keys = "
-
-      for key in graph.Nodes.Keys do
-        printfn $"{key}"
 
       let! env =
         inferGraph ctx env graph |> Result.mapError CompileError.TypeError
@@ -190,6 +180,7 @@ let NamespaceBasicValues () =
   printfn "res = %A" res
   Assert.True(Result.isOk res)
 
+[<Fact>]
 let NamespaceBasicTypes () =
   let res =
     result {


### PR DESCRIPTION
The bug was causing the `NamespaceShadowingOfVariables` test case to fail but was also resulting in schemes from the root namespace of the environment to be added to other namespaces.