### PR TITLE
Improve inferTreeRec performance issues

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -497,6 +497,7 @@ module rec Codegen =
         | Keyword.Never -> TsKeywordTypeKind.TsNeverKeyword
         | Keyword.Object -> TsKeywordTypeKind.TsObjectKeyword
         | Keyword.Unknown -> TsKeywordTypeKind.TsUnknownKeyword
+        | Keyword.GlobalThis -> failwith "TODO: buildType - GlobalThis"
 
       TsType.TsKeywordType { Kind = kind; Loc = None }
     | TypeKind.Function f ->

--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -325,9 +325,17 @@ module Prelude =
           ("+", unaryArithmetic "+")
           ("!", unaryLogic "!") ]
 
+    let mutable ns = Namespace.empty
+
+    let t =
+      { Kind = TypeKind.Keyword Keyword.GlobalThis
+        Provenance = None }
+
+    ns <- ns.AddBinding "globalThis" (t, false)
+
     let mutable env =
       { Filename = "<empty>"
-        Namespace = Namespace.empty
+        Namespace = ns
         BinaryOps = binaryOps
         UnaryOps = unaryOps
         IsAsync = false

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -666,12 +666,14 @@ module Type =
     | Object
     | Unknown
     | Never
+    | GlobalThis
 
     override this.ToString() =
       match this with
       | Object -> "object"
       | Unknown -> "unknown"
       | Never -> "never"
+      | GlobalThis -> "globalThis"
 
   type Class<'T> =
     { Name: option<string>

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -299,7 +299,7 @@ let ImportThirdPartyModules () =
       Assert.Type(
         env,
         "SchedulerInteraction",
-        "{__count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number}"
+        "{__count: number, id: number, name: string, timestamp: number}"
       )
 
       Assert.Type(env, "AccentColor", "Property.AccentColor")

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -734,7 +734,7 @@ let ImportThirdPartyModules () =
   printfn "result = %A" result
   Assert.False(Result.isError result)
 
-[<Fact(Skip = "TODO")>]
+[<Fact>]
 let ImportReact () =
   let result =
     result {

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -713,7 +713,7 @@ let ImportThirdPartyModules () =
       Assert.Type(
         env,
         "SchedulerInteraction",
-        "{__count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number, __count: number, id: number, name: string, timestamp: number}"
+        "{__count: number, id: number, name: string, timestamp: number}"
       )
 
       Assert.Type(env, "AccentColor", "Property.AccentColor")
@@ -734,7 +734,7 @@ let ImportThirdPartyModules () =
   printfn "result = %A" result
   Assert.False(Result.isError result)
 
-[<Fact>]
+[<Fact(Skip = "TODO")>]
 let ImportReact () =
   let result =
     result {

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -277,9 +277,10 @@ module rec Env =
 
     member this.Merge(other: Namespace) =
       { this with
-          Values = FSharpPlus.Map.union this.Values other.Values
-          Namespaces = FSharpPlus.Map.union this.Namespaces other.Namespaces
-          Schemes = FSharpPlus.Map.union this.Schemes other.Schemes }
+          Values = FSharpPlus.Map.union other.Values this.Values
+          // TODO: call `merge` on each namespace?
+          Namespaces = FSharpPlus.Map.union other.Namespaces this.Namespaces
+          Schemes = FSharpPlus.Map.union other.Schemes this.Schemes }
 
   type Env =
     { Filename: string

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -2,6 +2,7 @@
 
 open Escalier.TypeChecker.ExprVisitor
 open FsToolkit.ErrorHandling
+open System
 open System.IO
 
 open Escalier.Data
@@ -3194,76 +3195,54 @@ module rec Infer =
       return newEnv, inferredNS
     }
 
-  let inferTreeRec
-    (ctx: Ctx)
-    (env: Env)
-    (root: Set<DeclIdent>)
-    (graph: DeclGraph<Syntax.Decl>)
-    (tree: CompTree)
-    : Result<Env, TypeError> =
-
-    result {
-      let mutable newEnv = env
-
-      match tree.TryFind root with
-      | Some deps ->
-        for dep in deps do
-          let! depEnv = inferTreeRec ctx newEnv dep graph tree
-          newEnv <- depEnv
-      | None -> ()
-
-      match List.ofSeq root with
-      | [] ->
-        return!
-          Error(
-            TypeError.SemanticError "inferTreeRec - rootSet should not be empty"
-          )
-      | [ name ] ->
-        let decls = graph.Nodes[name]
-
-        let! newEnv, placeholderNS =
-          Infer.inferDeclPlaceholders ctx newEnv decls graph
-
-        let! newEnv, inferredNS =
-          Infer.inferDeclDefinitions ctx newEnv placeholderNS decls graph
-
-        do!
-          Infer.unifyPlaceholdersAndInferredTypes
-            ctx
-            newEnv
-            placeholderNS
-            inferredNS
-
-        // TODO: update `inferDeclDefinitions` to take a `generalize` flag
-        // so that we can avoid generalizing here.
-        let bindings = generalizeBindings inferredNS.Values
-        let newEnv = newEnv.AddBindings bindings
-
-        return newEnv
-      | names ->
-        let decls =
-          names |> List.map (fun name -> graph.Nodes[name]) |> List.concat
-
-        let! newEnv, placeholderNS =
-          Infer.inferDeclPlaceholders ctx newEnv decls graph
-
-        let! newEnv, inferredNS =
-          Infer.inferDeclDefinitions ctx newEnv placeholderNS decls graph
-
-        do!
-          Infer.unifyPlaceholdersAndInferredTypes
-            ctx
-            newEnv
-            placeholderNS
-            inferredNS
-
-        // TODO: update `inferDeclDefinitions` to take a `generalize` flag
-        // so that we can avoid generalizing here.
-        let bindings = generalizeBindings inferredNS.Values
-        let newEnv = newEnv.AddBindings bindings
-
-        return newEnv
-    }
+  // let inferTreeRec
+  //   (ctx: Ctx)
+  //   (env: Env)
+  //   (root: Set<DeclIdent>)
+  //   (graph: DeclGraph<Syntax.Decl>)
+  //   (tree: CompTree)
+  //   : Result<Env, TypeError> =
+  //
+  //   result {
+  //     let mutable newEnv = env
+  //
+  //     match tree.TryFind root with
+  //     | Some deps ->
+  //       for dep in deps do
+  //         let! depEnv = inferTreeRec ctx newEnv dep graph tree
+  //         newEnv <- depEnv
+  //     | None -> ()
+  //
+  //     match List.ofSeq root with
+  //     | [] ->
+  //       return!
+  //         Error(
+  //           TypeError.SemanticError "inferTreeRec - rootSet should not be empty"
+  //         )
+  //     | names ->
+  //       let decls =
+  //         names |> List.map (fun name -> graph.Nodes[name]) |> List.concat
+  //
+  //       let! newEnv, placeholderNS =
+  //         Infer.inferDeclPlaceholders ctx newEnv decls graph
+  //
+  //       let! newEnv, inferredNS =
+  //         Infer.inferDeclDefinitions ctx newEnv placeholderNS decls graph
+  //
+  //       do!
+  //         Infer.unifyPlaceholdersAndInferredTypes
+  //           ctx
+  //           newEnv
+  //           placeholderNS
+  //           inferredNS
+  //
+  //       // TODO: update `inferDeclDefinitions` to take a `generalize` flag
+  //       // so that we can avoid generalizing here.
+  //       let bindings = generalizeBindings inferredNS.Values
+  //       let newEnv = newEnv.AddBindings bindings
+  //
+  //       return newEnv
+  //   }
 
   let inferTree
     (ctx: Ctx)
@@ -3275,6 +3254,63 @@ module rec Infer =
     result {
       let mutable newEnv = env
       let entryPoints = findEntryPoints tree
+
+      let mutable inferredDeps: Set<Set<DeclIdent>> = Set.empty
+
+      let rec inferTreeRec
+        (ctx: Ctx)
+        (env: Env)
+        (root: Set<DeclIdent>)
+        (graph: DeclGraph<Syntax.Decl>)
+        (tree: CompTree)
+        : Result<Env, TypeError> =
+
+        result {
+          if Set.contains root inferredDeps then
+            return env
+          else
+            let mutable newEnv = env
+
+            match tree.TryFind root with
+            | Some deps ->
+              for dep in deps do
+                let! depEnv = inferTreeRec ctx newEnv dep graph tree
+                newEnv <- depEnv
+            | None -> ()
+
+            match List.ofSeq root with
+            | [] ->
+              return!
+                Error(
+                  TypeError.SemanticError
+                    "inferTreeRec - rootSet should not be empty"
+                )
+            | names ->
+              let decls =
+                names |> List.map (fun name -> graph.Nodes[name]) |> List.concat
+
+              let! newEnv, placeholderNS =
+                Infer.inferDeclPlaceholders ctx newEnv decls graph
+
+              let! newEnv, inferredNS =
+                Infer.inferDeclDefinitions ctx newEnv placeholderNS decls graph
+
+              do!
+                Infer.unifyPlaceholdersAndInferredTypes
+                  ctx
+                  newEnv
+                  placeholderNS
+                  inferredNS
+
+              // TODO: update `inferDeclDefinitions` to take a `generalize` flag
+              // so that we can avoid generalizing here.
+              let bindings = generalizeBindings inferredNS.Values
+              let newEnv = newEnv.AddBindings bindings
+
+              inferredDeps <- inferredDeps.Add(root)
+
+              return newEnv
+        }
 
       for set in entryPoints do
         try
@@ -3315,13 +3351,16 @@ module rec Infer =
       let decls = getDeclsFromModule ast
       let! graph = buildGraph newEnv [] [] decls
 
-      // for KeyValue(key, value) in graph.Edges do
-      //   printfn $"{key} -> {value}"
+      let start = DateTime.Now
 
       let components = findStronglyConnectedComponents graph
       let tree = buildComponentTree graph components
-      // let tree = graphToTree graph.Edges
-      return! inferTree ctx newEnv graph tree
+      let elapsed = DateTime.Now - start
+      let! newEnv = inferTree ctx newEnv graph tree
+      let filename = Path.GetFileName env.Filename
+      // printfn $"{filename}: elapsed = {elapsed}"
+
+      return newEnv
     }
 
   let unifyPlaceholdersAndInferredTypes


### PR DESCRIPTION
We track which DeclIdent sets have already been inferred and return immediately if the set has already been processed.