### PR TITLE
Use qualified graph for inferring .d.ts files

### DIFF
--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -363,7 +363,7 @@ module Prelude =
       let newEnv = { env with Filename = fullPath }
 
       let! outEnv =
-        Infer.inferModule ctx newEnv ast
+        InferGraph.inferModule ctx newEnv ast
         |> Result.mapError CompileError.TypeError
 
       return outEnv, ast
@@ -483,18 +483,16 @@ module Prelude =
         let! ctx = getCtx baseDir (fun _ -> newEnv)
 
         let libs =
-          [ "lib.es5.d.ts"
-            "lib.es2015.core.d.ts"
-            "lib.es2015.symbol.d.ts"
-            "lib.es2015.symbol.wellknown.d.ts"
-            "lib.es2015.iterable.d.ts"
-            "lib.es2015.generator.d.ts"
-            // TODO: modify Promise types to include type param for rejections
-            // "lib.es2015.promise.d.ts"
-            "lib.es2015.proxy.d.ts"
-            // "lib.es2015.reflect.d.ts"
-            // "lib.dom.d.ts" // requires `globalThis` to be defined
-            ]
+          [ "lib.es5.d.ts"; "lib.es2015.core.d.ts"; "lib.es2015.symbol.d.ts" ]
+        // "lib.es2015.symbol.wellknown.d.ts"
+        // "lib.es2015.iterable.d.ts"
+        // "lib.es2015.generator.d.ts"
+        // // TODO: modify Promise types to include type param for rejections
+        // // "lib.es2015.promise.d.ts"
+        // "lib.es2015.proxy.d.ts"
+        // // "lib.es2015.reflect.d.ts"
+        // // "lib.dom.d.ts" // requires `globalThis` to be defined
+        // ]
 
         let packageRoot = findNearestAncestorWithNodeModules baseDir
         let nodeModulesDir = Path.Combine(packageRoot, "node_modules")

--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -483,16 +483,18 @@ module Prelude =
         let! ctx = getCtx baseDir (fun _ -> newEnv)
 
         let libs =
-          [ "lib.es5.d.ts"; "lib.es2015.core.d.ts"; "lib.es2015.symbol.d.ts" ]
-        // "lib.es2015.symbol.wellknown.d.ts"
-        // "lib.es2015.iterable.d.ts"
-        // "lib.es2015.generator.d.ts"
-        // // TODO: modify Promise types to include type param for rejections
-        // // "lib.es2015.promise.d.ts"
-        // "lib.es2015.proxy.d.ts"
-        // // "lib.es2015.reflect.d.ts"
-        // // "lib.dom.d.ts" // requires `globalThis` to be defined
-        // ]
+          [ "lib.es5.d.ts"
+            "lib.es2015.core.d.ts"
+            "lib.es2015.symbol.d.ts"
+            "lib.es2015.symbol.wellknown.d.ts"
+            "lib.es2015.iterable.d.ts"
+            "lib.es2015.generator.d.ts"
+            // TODO: modify Promise types to include type param for rejections
+            // "lib.es2015.promise.d.ts"
+            "lib.es2015.proxy.d.ts"
+            // "lib.es2015.reflect.d.ts"
+            // "lib.dom.d.ts"
+            ]
 
         let packageRoot = findNearestAncestorWithNodeModules baseDir
         let nodeModulesDir = Path.Combine(packageRoot, "node_modules")

--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -150,6 +150,7 @@ let InferForIn () =
       ()
     }
 
+  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker.Tests/BuildGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/BuildGraphTests.fs
@@ -10,8 +10,8 @@ open Escalier.TypeChecker.BuildGraph
 let PlaceholderTest () =
   let ns = Namespace.empty
   let ident = QDeclIdent.MakeValue [ "x" ]
-
-  let actual = postProcessDeps ns [] ident []
+  let localsTree = localsToDeclTree []
+  let actual = postProcessDeps ns [] localsTree ident []
 
   let expected = []
   Assert.Equal<QDeclIdent list>(expected, actual)
@@ -20,10 +20,11 @@ let PlaceholderTest () =
 let SimpleDeps () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo" ]; QDeclIdent.MakeValue [ "bar" ] ]
 
-  let actual = postProcessDeps ns locals ident deps
+  let actual = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo" ] ]
   Assert.Equal<QDeclIdent list>(expected, actual)
@@ -32,10 +33,11 @@ let SimpleDeps () =
 let DepsWithMemberAccess () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
 
-  let actual = postProcessDeps ns locals ident deps
+  let actual = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo" ] ]
   Assert.Equal<QDeclIdent list>(expected, actual)
@@ -44,10 +46,11 @@ let DepsWithMemberAccess () =
 let QualifiedDeps () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
 
-  let actual = postProcessDeps ns locals ident deps
+  let actual = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
   Assert.Equal<QDeclIdent list>(expected, actual)
@@ -56,10 +59,11 @@ let QualifiedDeps () =
 let QualifiedDepsWithMemberAccess () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
 
-  let actual = postProcessDeps ns locals ident deps
+  let actual = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
   Assert.Equal<QDeclIdent list>(expected, actual)
@@ -68,10 +72,11 @@ let QualifiedDepsWithMemberAccess () =
 let SimpleDepsNeedingNamespaces () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "foo"; "x" ]
   let deps = [ QDeclIdent.MakeValue [ "bar" ]; QDeclIdent.MakeValue [ "baz" ] ]
 
-  let result = postProcessDeps ns locals ident deps
+  let result = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
 
@@ -81,13 +86,14 @@ let SimpleDepsNeedingNamespaces () =
 let FullnamespacedDepsInsideNamespace () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "foo"; "x" ]
 
   let deps =
     [ QDeclIdent.MakeValue [ "foo"; "bar" ]
       QDeclIdent.MakeValue [ "foo"; "baz" ] ]
 
-  let result = postProcessDeps ns locals ident deps
+  let result = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
 
@@ -97,10 +103,11 @@ let FullnamespacedDepsInsideNamespace () =
 let PartialShadowing () =
   let ns = Namespace.empty
   let locals = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
+  let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "foo"; "bar"; "x" ]
   let deps = [ QDeclIdent.MakeValue [ "bar"; "baz" ] ]
 
-  let result = postProcessDeps ns locals ident deps
+  let result = postProcessDeps ns locals localsTree ident deps
 
   let expected = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
 

--- a/src/Escalier.TypeChecker.Tests/GraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/GraphTests.fs
@@ -752,7 +752,8 @@ let MergeInterfaceBetweenFiles () =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
       let! env =
-        Infer.inferModule ctx env ast |> Result.mapError CompileError.TypeError
+        InferGraph.inferModule ctx env ast
+        |> Result.mapError CompileError.TypeError
 
       Assert.Type(env, "Keys", "{foo: \"foo\", bar: \"bar\"}")
 

--- a/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
@@ -173,6 +173,62 @@ let NamespaceBasicTypes () =
   Assert.True(Result.isOk res)
 
 [<Fact>]
+let NamespaceWithInterface () =
+  let res =
+    result {
+      let src =
+        """
+        namespace Foo {
+          interface Bar {
+            msg: string
+          }
+        }
+        interface Baz {
+          bar: Foo.Bar
+        }
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Type(env, "Baz", "{bar: Foo.Bar}")
+
+      let! t =
+        Unify.expandScheme ctx env None (env.FindScheme "Baz") Map.empty None
+        |> Result.mapError CompileError.TypeError
+
+      Assert.Equal(t.ToString(), "{bar: Foo.Bar}")
+    }
+
+  printfn "res = %A" res
+  Assert.True(Result.isOk res)
+
+[<Fact>]
+let InterfacesInTheSameNamespace () =
+  let res =
+    result {
+      let src =
+        """
+        namespace Foo {
+          interface Bar {
+            msg: string
+          }
+          
+          interface Baz {
+            bar: Bar
+          }
+        }
+        """
+
+      let! ctx, env = inferModule src
+
+      ()
+    }
+
+  printfn "res = %A" res
+  Assert.True(Result.isOk res)
+
+
+[<Fact>]
 let BasicGraphInferCompositeValues () =
   let res =
     result {

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -309,6 +309,7 @@ let InferObjProps () =
       Assert.Value(env, "c", "\"hello\"")
     }
 
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker/BuildGraph.fs
+++ b/src/Escalier.TypeChecker/BuildGraph.fs
@@ -257,9 +257,6 @@ let findDepsForTypeIdent
               if not (List.contains ident typeParams) then
                 typeRefIdents <- QDeclIdent.Type ident :: typeRefIdents
 
-              if ident = QualifiedIdent.FromString "ArrayBuffer" then
-                printfn $"typeRefIdents = {typeRefIdents}"
-
               []
             | TypeAnnKind.Typeof ident ->
               let ident = QualifiedIdent.FromCommonQualifiedIdent ident
@@ -612,7 +609,7 @@ let getPropNameDeps
         else
           match env.TryFindValue name with
           | Some(t, _) ->
-            match t.Kind with
+            match (prune t).Kind with
             | TypeKind.TypeRef { Name = ident } ->
               let ident = QualifiedIdent.FromCommonQualifiedIdent ident
 
@@ -854,9 +851,6 @@ let getEdges
               (fun (tp: TypeParam) -> QualifiedIdent.FromString tp.Name)
               typeParams
 
-        if name = "ArrayBufferConstructor" then
-          printfn "GET READY"
-
         let deps =
           elems
           |> List.collect (fun elem ->
@@ -955,9 +949,6 @@ let getEdges
                   interfaceTypeParamNames
                   ident
                   (SyntaxNode.TypeAnn typeAnn))
-
-        if name = "ArrayBufferConstructor" then
-          printfn $"ArrayBufferConstructor deps = {deps}"
 
         match edges.TryFind(ident) with
         | Some existingDeps -> edges <- edges.Add(ident, existingDeps @ deps)

--- a/src/Escalier.TypeChecker/BuildGraph.fs
+++ b/src/Escalier.TypeChecker/BuildGraph.fs
@@ -110,6 +110,7 @@ let getLocalForDep (tree: QDeclTree) (local: QDeclIdent) : option<QDeclIdent> =
 let postProcessDeps
   (ns: Namespace)
   (locals: list<QDeclIdent>)
+  (localsTree: QDeclTree)
   (ident: QDeclIdent)
   (deps: list<QDeclIdent>)
   : list<QDeclIdent> =
@@ -146,7 +147,7 @@ let postProcessDeps
         else
           true)
 
-  let tree = localsToDeclTree locals
+  // let tree = localsToDeclTree locals
 
   if ident.GetParts().Length > 1 then
     deps
@@ -166,15 +167,16 @@ let postProcessDeps
             | Type qid -> Type { Parts = ns @ qid.Parts }
             | Value qid -> Value { Parts = ns @ qid.Parts }
 
-          result <- getLocalForDep tree candidateDep
+          result <- getLocalForDep localsTree candidateDep
 
       result)
   else
-    List.choose (getLocalForDep tree) deps
+    List.choose (getLocalForDep localsTree) deps
 
 let findDepsForValueIdent
   (ns: Namespace)
   (locals: list<QDeclIdent>)
+  (localsTree: QDeclTree)
   (ident: QDeclIdent)
   (expr: Expr)
   : list<QDeclIdent> =
@@ -212,7 +214,7 @@ let findDepsForValueIdent
 
   walkExpr visitor () expr
 
-  postProcessDeps ns locals ident (List.rev ids)
+  postProcessDeps ns locals localsTree ident (List.rev ids)
 
 let findInferTypeAnns (typeAnn: TypeAnn) : list<QDeclIdent> =
   let mutable idents: list<QDeclIdent> = []
@@ -236,6 +238,7 @@ let findInferTypeAnns (typeAnn: TypeAnn) : list<QDeclIdent> =
 let findDepsForTypeIdent
   (env: Env)
   (possibleDeps: list<QDeclIdent>)
+  (localsTree: QDeclTree)
   (typeParams: list<QualifiedIdent>)
   (ident: QDeclIdent)
   (syntaxNode: SyntaxNode)
@@ -309,7 +312,12 @@ let findDepsForTypeIdent
   | SyntaxNode.TypeAnn typeAnn -> walkTypeAnn visitor typeParams typeAnn
   | SyntaxNode.Expr expr -> walkExpr visitor typeParams expr
 
-  postProcessDeps env.Namespace possibleDeps ident (List.rev typeRefIdents)
+  postProcessDeps
+    env.Namespace
+    possibleDeps
+    localsTree
+    ident
+    (List.rev typeRefIdents)
 
 
 let findLocals (decls: list<Decl>) : list<QDeclIdent> =
@@ -454,6 +462,7 @@ let getDepsForFn
   (env: Env)
   (ident: QDeclIdent)
   (possibleDeps: list<QDeclIdent>)
+  (localsTree: QDeclTree)
   (excludedTypeNames: list<QualifiedIdent>)
   (fnSig: FuncSig)
   (body: option<BlockOrExpr>)
@@ -478,6 +487,7 @@ let getDepsForFn
           @ findDepsForTypeIdent
               env
               possibleDeps
+              localsTree
               (excludedTypeNames @ typeParamNames)
               ident
               (SyntaxNode.TypeAnn c)
@@ -490,6 +500,7 @@ let getDepsForFn
           @ findDepsForTypeIdent
               env
               possibleDeps
+              localsTree
               (excludedTypeNames @ typeParamNames)
               ident
               (SyntaxNode.TypeAnn d)
@@ -505,6 +516,7 @@ let getDepsForFn
         @ findDepsForTypeIdent
             env
             possibleDeps
+            localsTree
             (excludedTypeNames @ typeParamNames)
             ident
             (SyntaxNode.TypeAnn typeAnn)
@@ -526,6 +538,7 @@ let getDepsForFn
       @ findDepsForTypeIdent
           env
           possibleDeps
+          localsTree
           (excludedTypeNames @ typeParamNames)
           ident
           (SyntaxNode.TypeAnn returnType)
@@ -548,6 +561,7 @@ let getDepsForFn
 let getDepsForInterfaceFn
   (env: Env)
   (possibleDeps: list<QDeclIdent>)
+  (localsTree: QDeclTree)
   (interfaceTypeParamNames: list<QualifiedIdent>)
   (ident: QDeclIdent)
   (fnSig: FuncSig)
@@ -571,6 +585,7 @@ let getDepsForInterfaceFn
         @ findDepsForTypeIdent
             env
             possibleDeps
+            localsTree
             (interfaceTypeParamNames @ typeParamNames)
             ident
             (SyntaxNode.TypeAnn typeAnn)
@@ -583,6 +598,7 @@ let getDepsForInterfaceFn
       @ findDepsForTypeIdent
           env
           possibleDeps
+          localsTree
           (interfaceTypeParamNames @ typeParamNames)
           ident
           (SyntaxNode.TypeAnn returnType)
@@ -677,6 +693,7 @@ let getNodes (decls: list<Decl>) : Map<QDeclIdent, list<Decl>> =
 let getEdges
   (env: Env)
   (locals: list<QDeclIdent>)
+  (localsTree: QDeclTree)
   (nodes: Map<QDeclIdent, list<Decl>>)
   : Map<QDeclIdent, list<QDeclIdent>> =
   let mutable edges: Map<QDeclIdent, list<QDeclIdent>> = Map.empty
@@ -696,13 +713,14 @@ let getEdges
           match init with
           | Some init ->
             let mutable deps =
-              findDepsForValueIdent env.Namespace locals ident init
+              findDepsForValueIdent env.Namespace locals localsTree ident init
 
             // TODO: reimplement findTypeRefIdents to only look at localTypeNames
             let typeDepsInExpr =
               findDepsForTypeIdent
                 env
                 possibleDeps
+                localsTree
                 []
                 ident
                 (SyntaxNode.Expr init)
@@ -713,6 +731,7 @@ let getEdges
                 findDepsForTypeIdent
                   env
                   possibleDeps
+                  localsTree
                   []
                   ident
                   (SyntaxNode.TypeAnn typeAnn)
@@ -748,6 +767,7 @@ let getEdges
                 findDepsForTypeIdent
                   env
                   possibleDeps
+                  localsTree
                   []
                   ident
                   (SyntaxNode.TypeAnn typeAnn)
@@ -776,7 +796,7 @@ let getEdges
       | FnDecl { Name = name
                  Sig = fnSig
                  Body = body } ->
-        let deps = getDepsForFn env ident locals [] fnSig body
+        let deps = getDepsForFn env ident locals localsTree [] fnSig body
         edges <- edges.Add(ident, deps)
       | ClassDecl { Name = name } ->
         let deps =
@@ -813,6 +833,7 @@ let getEdges
                 @ findDepsForTypeIdent
                     env
                     possibleDeps
+                    localsTree
                     typeParamNames
                     ident
                     (SyntaxNode.TypeAnn c)
@@ -825,6 +846,7 @@ let getEdges
                 @ findDepsForTypeIdent
                     env
                     possibleDeps
+                    localsTree
                     typeParamNames
                     ident
                     (SyntaxNode.TypeAnn d)
@@ -835,6 +857,7 @@ let getEdges
           @ findDepsForTypeIdent
               env
               possibleDeps
+              localsTree
               typeParamNames
               ident
               (SyntaxNode.TypeAnn typeAnn)
@@ -859,6 +882,7 @@ let getEdges
               getDepsForInterfaceFn
                 env
                 locals
+                localsTree
                 interfaceTypeParamNames
                 ident
                 fnSig
@@ -866,6 +890,7 @@ let getEdges
               getDepsForInterfaceFn
                 env
                 locals
+                localsTree
                 interfaceTypeParamNames
                 ident
                 fnSig
@@ -876,6 +901,7 @@ let getEdges
                 getDepsForInterfaceFn
                   env
                   locals
+                  localsTree
                   interfaceTypeParamNames
                   ident
                   fnSig
@@ -890,6 +916,7 @@ let getEdges
                   findDepsForTypeIdent
                     env
                     possibleDeps
+                    localsTree
                     interfaceTypeParamNames
                     ident
                     (SyntaxNode.TypeAnn returnType)
@@ -906,6 +933,7 @@ let getEdges
                   findDepsForTypeIdent
                     env
                     possibleDeps
+                    localsTree
                     interfaceTypeParamNames
                     ident
                     (SyntaxNode.TypeAnn typeAnn)
@@ -919,6 +947,7 @@ let getEdges
                 findDepsForTypeIdent
                   env
                   possibleDeps
+                  localsTree
                   interfaceTypeParamNames
                   ident
                   (SyntaxNode.TypeAnn typeAnn)
@@ -940,12 +969,14 @@ let getEdges
               findDepsForTypeIdent
                 env
                 possibleDeps
+                localsTree
                 interfaceTypeParamNames
                 ident
                 (SyntaxNode.TypeAnn typeParam.Constraint)
               @ findDepsForTypeIdent
                   env
                   possibleDeps
+                  localsTree
                   interfaceTypeParamNames
                   ident
                   (SyntaxNode.TypeAnn typeAnn))
@@ -999,7 +1030,9 @@ let buildGraph (env: Env) (m: Module) : QGraph<Decl> =
       | _ -> None)
 
   let nodes = getNodes decls
-  let edges = getEdges env locals nodes
+  // We compute localsTree once here because it's expensive to compute
+  let localsTree = localsToDeclTree locals
+  let edges = getEdges env locals localsTree nodes
 
   // printfn "--- EDGES ---"
   //

--- a/src/Escalier.TypeChecker/InferGraph.fs
+++ b/src/Escalier.TypeChecker/InferGraph.fs
@@ -824,18 +824,10 @@ let inferModule (ctx: Ctx) (env: Env) (ast: Module) : Result<Env, TypeError> =
       let! importEnv = Infer.inferImport ctx newEnv import
       newEnv <- importEnv
 
-    // printfn $"building graph for {env.Filename}"
-    // let start = System.DateTime.Now
     let decls = getDeclsFromModule ast
     let graph = buildGraph env ast
-    // let elapsed = System.DateTime.Now - start
-    // printfn $"buildGraph took {elapsed.TotalMilliseconds}ms"
-
-    // let start = System.DateTime.Now
     let components = findStronglyConnectedComponents graph
     let tree = buildComponentTree graph components
-    // let elapsed = System.DateTime.Now - start
-    // printfn $"buildComponentTree took {elapsed.TotalMilliseconds}ms"
 
     let! newEnv = inferTree ctx newEnv graph tree
 

--- a/src/Escalier.TypeChecker/InferGraph.fs
+++ b/src/Escalier.TypeChecker/InferGraph.fs
@@ -165,17 +165,22 @@ let inferDeclPlaceholders
 
           qns <- qns.AddScheme key placeholder
         | InterfaceDecl({ Name = name; TypeParams = typeParams } as decl) ->
+          let key =
+            match ident with
+            | Type { Parts = parts } ->
+              { Parts = List.take (parts.Length - 1) parts @ [ name ] }
+            | Value { Parts = parts } ->
+              { Parts = List.take (parts.Length - 1) parts @ [ name ] }
+
           // Instead of looking things up in the environment, we need some way to
           // find the existing type on other declarations.
           let! placeholder =
-            match env.TryFindScheme name with
+            // TODO: looking up the key in the environment first
+            match qns.Schemes.TryFind(key) with
             | Some scheme -> Result.Ok scheme
-            | None ->
-              match qns.Schemes.TryFind(QualifiedIdent.FromString name) with
-              | Some scheme -> Result.Ok scheme
-              | None -> Infer.inferTypeDeclPlaceholderScheme ctx env typeParams
+            | None -> Infer.inferTypeDeclPlaceholderScheme ctx env typeParams
 
-          qns <- qns.AddScheme (QualifiedIdent.FromString name) placeholder
+          qns <- qns.AddScheme key placeholder
         // newEnv <- newEnv.AddScheme name placeholder
         | NamespaceDecl nsDecl ->
           return!
@@ -374,17 +379,24 @@ let inferDeclDefinitions
         | InterfaceDecl { Name = name
                           TypeParams = typeParams
                           Elems = elems } ->
-          let placeholder = qns.Schemes[(QualifiedIdent.FromString name)]
+          let key =
+            match ident with
+            | Type { Parts = parts } ->
+              { Parts = List.take (parts.Length - 1) parts @ [ name ] }
+            | Value { Parts = parts } ->
+              { Parts = List.take (parts.Length - 1) parts @ [ name ] }
+
+          let placeholder = qns.Schemes[key]
 
           // TODO: when computing the decl graph, include self-recursive types in
           // the deps set so that we don't have to special case this here.
           // Handles self-recursive types
-          let newEnv = env.AddScheme name placeholder
+          let newEnv = newEnv.AddScheme name placeholder
 
           let getType (env: Env) : Result<Type, TypeError> =
             result {
               let! elems =
-                List.traverseResultM (Infer.inferObjElem ctx newEnv) elems
+                List.traverseResultM (Infer.inferObjElem ctx env) elems
 
               let kind =
                 TypeKind.Object
@@ -420,13 +432,13 @@ let inferDeclDefinitions
             // We modify the existing scheme in place so that existing values
             // with this type are updated.
             placeholder.Type <- t
-            qns.Schemes[(QualifiedIdent.FromString name)].Type <- t
+            qns.Schemes[key].Type <- t
           | _ ->
             // Replace the placeholder's type with the actual type.
             // NOTE: This is a bit hacky and we may want to change this later to use
             // `foldType` to replace any uses of the placeholder with the actual type.
             placeholder.Type <- newScheme.Type
-            qns.Schemes[(QualifiedIdent.FromString name)].Type <- newScheme.Type
+            qns.Schemes[key].Type <- newScheme.Type
         | NamespaceDecl { Name = name; Body = decls } ->
           return!
             Error(


### PR DESCRIPTION
- Get the first few .d.ts files working
- Get all previously working .d.ts (except lib.dom.d.ts) working again)

NOTE: There's still an issue with inferring lib.dom.d.ts.  I'm going to address that in a separate PR.