### PR TITLE
Fix qualified type refs

### DIFF
--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -761,7 +761,12 @@ let ImportReact () =
         type ElementType = React.React.ElementType;
         type ReactElement = React.React.ReactElement;
         let createElement = React.React.createElement;
-        // let div = React.React.createElement("div", {});
+        let htmlAttrs: React.React.HTMLAttributes<HTMLElement> = {};
+        let classAttrs: React.React.ClassAttributes<HTMLElement> = {};
+        let attrs: React.React.HTMLAttributes<HTMLElement> & React.React.ClassAttributes<HTMLElement> = {};
+        
+        declare let myCreateElement: fn <P: React.React.HTMLAttributes<T>, T: HTMLElement>(mut type: keyof React.React.ReactHTML, mut props: React.React.ClassAttributes<T> & P | null, ...mut children: React.React.ReactNode[]) -> React.React.DetailedReactHTMLElement<P, T>;
+        let div = myCreateElement("div", {});
         """
 
       let! ast =
@@ -773,17 +778,23 @@ let ImportReact () =
         InferGraph.inferModule ctx env ast
         |> Result.mapError CompileError.TypeError
 
-      match env.TryFindValue "createElement" with
-      | Some(t, _) ->
-        let! t =
-          Unify.expandType ctx env None Map.empty t
-          |> Result.mapError CompileError.TypeError
-
-        printfn $"t = {t}"
-      | None -> ()
+      let t, _ = env.FindValue "createElement"
+      printfn $"createElement = {t}"
 
       Assert.Type(env, "ReactElement", "React.React.ReactElement")
-    // Assert.Value(env, "div", "React.React.ElementType")
+      Assert.Value(env, "htmlAttrs", "React.React.HTMLAttributes<HTMLElement>")
+
+      Assert.Value(
+        env,
+        "classAttrs",
+        "React.React.ClassAttributes<HTMLElement>"
+      )
+
+    // Assert.Value(
+    //   env,
+    //   "div",
+    //   "React.DetailedReactHTMLElement<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>"
+    // )
     }
 
   printfn "result = %A" result

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -599,6 +599,30 @@ let ParseRangeIteratorType () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseSimpleRangeType () =
+  let src =
+    """
+      type Range = Min..Max;
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseRangeTypeAndQualifiedTypeRefInObject () =
+  let src =
+    """
+      type Obj = {range: Min..Max, qual: Foo.Bar};
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
 let ParseTemplateLiteralType () =
   let src = """type TemplateLiteral = `foo${number}`;"""
 

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeTypeAndQualifiedTypeRefInObject.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeTypeAndQualifiedTypeRefInObject.verified.txt
@@ -1,0 +1,62 @@
+﻿input: 
+      type Obj = {range: Min..Max, qual: Foo.Bar};
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                TypeDecl
+                  { Name = "Obj"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "range"
+                                  TypeAnn =
+                                   { Kind =
+                                      Range
+                                        { Min =
+                                           { Kind =
+                                              TypeRef { Ident = Ident "Min"
+                                                        TypeArgs = None }
+                                             Span = { Start = (Ln: 2, Col: 26)
+                                                      Stop = (Ln: 2, Col: 29) }
+                                             InferredType = None }
+                                          Max =
+                                           { Kind =
+                                              TypeRef { Ident = Ident "Max"
+                                                        TypeArgs = None }
+                                             Span = { Start = (Ln: 2, Col: 31)
+                                                      Stop = (Ln: 2, Col: 34) }
+                                             InferredType = None } }
+                                     Span = { Start = (Ln: 2, Col: 26)
+                                              Stop = (Ln: 2, Col: 34) }
+                                     InferredType = None }
+                                  Optional = false
+                                  Readonly = false
+                                  Static = false };
+                              Property
+                                { Name = String "qual"
+                                  TypeAnn =
+                                   { Kind =
+                                      TypeRef
+                                        { Ident = Member (Ident "Foo", "Bar")
+                                          TypeArgs = None }
+                                     Span = { Start = (Ln: 2, Col: 42)
+                                              Stop = (Ln: 2, Col: 49) }
+                                     InferredType = None }
+                                  Optional = false
+                                  Readonly = false
+                                  Static = false }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 18)
+                                Stop = (Ln: 2, Col: 50) }
+                       InferredType = None }
+                    TypeParams = None }
+               Span = { Start = (Ln: 2, Col: 7)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 7)
+                   Stop = (Ln: 3, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseSimpleRangeType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseSimpleRangeType.verified.txt
@@ -1,0 +1,31 @@
+﻿input: 
+      type Range = Min..Max;
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                TypeDecl
+                  { Name = "Range"
+                    TypeAnn =
+                     { Kind =
+                        Range { Min = { Kind = TypeRef { Ident = Ident "Min"
+                                                         TypeArgs = None }
+                                        Span = { Start = (Ln: 2, Col: 20)
+                                                 Stop = (Ln: 2, Col: 23) }
+                                        InferredType = None }
+                                Max = { Kind = TypeRef { Ident = Ident "Max"
+                                                         TypeArgs = None }
+                                        Span = { Start = (Ln: 2, Col: 25)
+                                                 Stop = (Ln: 2, Col: 28) }
+                                        InferredType = None } }
+                       Span = { Start = (Ln: 2, Col: 20)
+                                Stop = (Ln: 2, Col: 28) }
+                       InferredType = None }
+                    TypeParams = None }
+               Span = { Start = (Ln: 2, Col: 7)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 7)
+                   Stop = (Ln: 3, Col: 5) } }] }

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -542,6 +542,7 @@ module rec Infer =
         | ExprKind.Call call ->
           let! callee = inferExpr ctx env call.Callee
 
+          // TODO: handle typeArgs at the callsite, e.g. `foo<number>(1)`
           let! result, throws = unifyCall ctx env None call.Args None callee
 
           call.Throws <- Some(throws)
@@ -2942,9 +2943,12 @@ module rec Infer =
         match bind ctx env ips callee callType with
         | Ok _ -> return (prune retType, prune throwsType)
         | Error e -> return! Error e
-      | kind -> return! Error(TypeError.NotImplemented $"kind = {kind}")
+      | kind ->
+        printfn $"callee = {callee}"
+        return! Error(TypeError.NotImplemented $"kind = {kind}")
     }
 
+  // Returns a Result with 2-tuple containing the return and throws types.
   let unifyFuncCall
     (ctx: Ctx)
     (env: Env)


### PR DESCRIPTION
This PR fixes two issues:
- the parser was ignore type args to qualified type refs
- when expanding qualified type refs, we weren't checking if the type ref's `Scheme` field to see if it had already been inferred