### PR TITLE
instantiate type variables when assigned to a top-level binding

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -629,6 +629,7 @@ module Type =
   type TypeVar =
     { Id: int
       mutable Bound: option<Type>
+      mutable Default: option<Type>
       mutable Instance: option<Type> }
 
   // An n-ary type constructor which builds a new type from old

--- a/src/Escalier.TypeChecker.Tests/Functions.fs
+++ b/src/Escalier.TypeChecker.Tests/Functions.fs
@@ -765,7 +765,7 @@ let InferSimpleGenericWithDefault () =
     result {
       let src =
         """
-        declare fn foo<T: {} = {b: 10}>(bar?: T) -> T;
+        declare fn foo<T: {} = {b: 10}>(bar?: T) -> {value: T};
         let x = foo();
         let y = foo({a: 5});
         """
@@ -773,9 +773,9 @@ let InferSimpleGenericWithDefault () =
       let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "foo", "fn <T: {} = {b: 10}>(bar?: T) -> T")
-      Assert.Value(env, "x", "{b: 10}")
-      Assert.Value(env, "y", "{a: 5}")
+      Assert.Value(env, "foo", "fn <T: {} = {b: 10}>(bar?: T) -> {value: T}")
+      Assert.Value(env, "x", "{value: {b: 10}}")
+      Assert.Value(env, "y", "{value: {a: 5}}")
     }
 
   Assert.False(Result.isError result)
@@ -786,7 +786,7 @@ let InferSimpleGenericWithConstraint () =
     result {
       let src =
         """
-        declare fn foo<T: {}>(bar?: T) -> T;
+        declare fn foo<T: {}>(bar?: T) -> {value: T};
         let x = foo();
         let y = foo({a: 5});
         """
@@ -794,9 +794,9 @@ let InferSimpleGenericWithConstraint () =
       let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "foo", "fn <T: {}>(bar?: T) -> T")
-      Assert.Value(env, "x", "{}")
-      Assert.Value(env, "y", "{a: 5}")
+      Assert.Value(env, "foo", "fn <T: {}>(bar?: T) -> {value: T}")
+      Assert.Value(env, "x", "{value: {}}")
+      Assert.Value(env, "y", "{value: {a: 5}}")
     }
 
   Assert.False(Result.isError result)
@@ -807,7 +807,7 @@ let InferSimpleGenericWithoutDefaultOrConstraint () =
     result {
       let src =
         """
-        declare fn foo<T>(bar?: T) -> T;
+        declare fn foo<T>(bar?: T) -> {value: T};
         let x = foo();
         let y = foo({a: 5});
         """
@@ -815,9 +815,9 @@ let InferSimpleGenericWithoutDefaultOrConstraint () =
       let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "foo", "fn <T>(bar?: T) -> T")
-      Assert.Value(env, "x", "unknown")
-      Assert.Value(env, "y", "{a: 5}")
+      Assert.Value(env, "foo", "fn <T>(bar?: T) -> {value: T}")
+      Assert.Value(env, "x", "{value: unknown}")
+      Assert.Value(env, "y", "{value: {a: 5}}")
     }
 
   Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/Functions.fs
+++ b/src/Escalier.TypeChecker.Tests/Functions.fs
@@ -759,7 +759,7 @@ let InferGenericWithConstraintRefrencingOtherTypeParamAndOtherTypeRefsUsingLetFn
 
   Assert.False(Result.isError result)
 
-[<Fact(Skip = "TODO: Add .Default to TypeVar and use the .Default in unifyFuncCall")>]
+[<Fact>]
 let InferSimpleGenericWithDefault () =
   let result =
     result {
@@ -774,11 +774,52 @@ let InferSimpleGenericWithDefault () =
 
       Assert.Empty(ctx.Diagnostics)
       Assert.Value(env, "foo", "fn <T: {} = {b: 10}>(bar?: T) -> T")
+      Assert.Value(env, "x", "{b: 10}")
+      Assert.Value(env, "y", "{a: 5}")
+    }
+
+  Assert.False(Result.isError result)
+
+[<Fact>]
+let InferSimpleGenericWithConstraint () =
+  let result =
+    result {
+      let src =
+        """
+        declare fn foo<T: {}>(bar?: T) -> T;
+        let x = foo();
+        let y = foo({a: 5});
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Diagnostics)
+      Assert.Value(env, "foo", "fn <T: {}>(bar?: T) -> T")
       Assert.Value(env, "x", "{}")
       Assert.Value(env, "y", "{a: 5}")
     }
 
-  printfn "result = %A" result
+  Assert.False(Result.isError result)
+
+[<Fact>]
+let InferSimpleGenericWithoutDefaultOrConstraint () =
+  let result =
+    result {
+      let src =
+        """
+        declare fn foo<T>(bar?: T) -> T;
+        let x = foo();
+        let y = foo({a: 5});
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Diagnostics)
+      Assert.Value(env, "foo", "fn <T>(bar?: T) -> T")
+      Assert.Value(env, "x", "unknown")
+      Assert.Value(env, "y", "{a: 5}")
+    }
+
   Assert.False(Result.isError result)
 
 [<Fact(Skip = "TODO: check superclass when determining if class instances are assignable")>]

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -52,10 +52,11 @@ module rec Env =
     member val NextTypeVarId = nextTypeVarId with get, set
     member val NextUniqueId = nextUniqueId with get, set
 
-    member this.FreshTypeVar(bound: option<Type>) =
+    member this.FreshTypeVar (bound: option<Type>) (def: option<Type>) =
       let newVar =
         { Id = nextTypeVarId
           Bound = bound
+          Default = def
           Instance = None }
 
       nextTypeVarId <- nextTypeVarId + 1

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -283,7 +283,7 @@ let fresh (ctx: Ctx) (t: Type) : Type =
   let folder: Type -> option<Type> =
     fun t ->
       match t.Kind with
-      | TypeKind.TypeVar _ -> Some(ctx.FreshTypeVar None)
+      | TypeKind.TypeVar _ -> Some(ctx.FreshTypeVar None None)
       | _ -> None
 
   Folder.foldType folder t

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -2726,7 +2726,7 @@ module rec Infer =
 
       return
         { TypeParams = typeParams
-          Type = generalizeFunctionsInType t
+          Type = generalizeType t
           IsTypeParam = false }
     }
 

--- a/src/Escalier.TypeChecker/InferGraph.fs
+++ b/src/Escalier.TypeChecker/InferGraph.fs
@@ -839,19 +839,7 @@ let generalizeBindings
   let mutable newBindings = Map.empty
 
   for KeyValue(name, (t, isMut)) in bindings do
-    let t =
-      match (prune t).Kind with
-      // TODO: generalize all type variables outside of functions in the type
-      | TypeKind.TypeVar { Instance = None; Default = Some d } -> d
-      | TypeKind.TypeVar { Instance = None; Bound = Some b } -> b
-      | TypeKind.TypeVar { Instance = None
-                           Bound = None
-                           Default = None } ->
-        { Kind = TypeKind.Keyword Keyword.Unknown
-          Provenance = None }
-      | _ -> Helpers.generalizeFunctionsInType t
-
-    let t = Helpers.generalizeFunctionsInType t
+    let t = Helpers.generalizeType t
     newBindings <- newBindings.Add(name, (t, isMut))
 
   newBindings

--- a/src/Escalier.TypeChecker/Poly.fs
+++ b/src/Escalier.TypeChecker/Poly.fs
@@ -225,14 +225,9 @@ module Poly =
               let typeParam = typeParamMap[name]
 
               let c = typeParam.Constraint |> Option.map (foldType folder)
-              // TODO: figure out how to use the default type param
-              // I think we want to use it when no type arg is explicitly
-              // provided and in this case we should use the default type
-              // instead of creating a fresh type parameter.
-              // TODO: check that default type is a subtype of the constraint
               let d = typeParam.Default |> Option.map (foldType folder)
 
-              mapping <- mapping.Add(name, ctx.FreshTypeVar c)
+              mapping <- mapping.Add(name, ctx.FreshTypeVar c d)
       | None -> ()
 
       return
@@ -277,7 +272,8 @@ module Poly =
             mapping <- mapping.Add(tp.Name, ta)
         | None ->
           for tp in typeParams do
-            mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar tp.Constraint)
+            mapping <-
+              mapping.Add(tp.Name, ctx.FreshTypeVar tp.Constraint tp.Default)
       | None -> ()
 
       return foldType folder t

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -238,7 +238,7 @@ module rec Unify =
                 mapping <- mapping.Add(tp.Name, ta)
             | None ->
               for tp in typeParams do
-                mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None)
+                mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None None)
           | None -> ()
 
           let! t = expandScheme ctx env ips scheme mapping typeArgs
@@ -261,7 +261,7 @@ module rec Unify =
                 mapping <- mapping.Add(tp.Name, ta)
             | None ->
               for tp in typeParams do
-                mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None)
+                mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None None)
           | None -> ()
 
           let! t = expandScheme ctx env ips scheme mapping typeArgs
@@ -708,7 +708,8 @@ module rec Unify =
                   do! unify ctx env ips bound2 bound1
                 | None -> ()
 
-                v2.Bound <- Some(bound1)
+                v2.Bound <- v1.Bound
+                v2.Default <- v1.Default
                 v1.Instance <- Some(t2)
               | TypeKind.Keyword Keyword.Never ->
                 // TODO: figure out when the bound is never so I can write
@@ -894,7 +895,7 @@ module rec Unify =
           let mutable newMapping = mapping
 
           for name in infers do
-            let t = ctx.FreshTypeVar None
+            let t = ctx.FreshTypeVar None None
             newMapping <- Map.add name t newMapping
 
           let extends = replaceInfers extends newMapping


### PR DESCRIPTION
When `generalizeType` encounters a type variable outside of a function type it will generalize that type variable in the following way:
- if it has a default type associated with it, the default type will be used
- if it has a constraint/bound type associated with it, the constraint/bound type will be used
- if it has neither, `unknown` will be the type that the type var is generalized to