### PR TITLE
Improve type inference involving intersection types

### DIFF
--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -1262,3 +1262,24 @@ let InferInterfaceInModule () =
 
   printfn "result = %A" result
   Assert.False(Result.isError result)
+
+[<Fact>]
+let InferTypeParamInIntersection () =
+  let result =
+    result {
+      let src =
+        """
+        declare fn foo<T: {}>(props: T & {x: number}) -> T;
+        let bar = foo({x: 5, y: "hello", z: true});
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Diagnostics)
+
+      Assert.Value(env, "foo", "fn <T: {}>(props: T & {x: number}) -> T")
+      Assert.Value(env, "bar", "{y: \"hello\", z: true}")
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -1283,3 +1283,27 @@ let InferTypeParamInIntersection () =
 
   printfn "result = %A" result
   Assert.False(Result.isError result)
+
+[<Fact(Skip = "TODO")>]
+let UnifyIntersectionTypesWithIntersectionTypes () =
+  let result =
+    result {
+      let src =
+        """
+        fn foo<T: {}>(props: T & {x: number}) -> T {
+          const {x, ...rest} = props;
+          return rest;
+        };
+        let bar = foo({x: 5, y: "hello", z: true});
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Diagnostics)
+
+      Assert.Value(env, "foo", "fn <T: {}>(props: T & {x: number}) -> T")
+      Assert.Value(env, "bar", "{y: \"hello\", z: true}")
+    }
+
+  printfn "result = %A" result
+  Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -224,47 +224,48 @@ module rec Unify =
       | TypeKind.TypeRef { TypeArgs = typeArgs; Scheme = scheme }, _ ->
         match scheme with
         | Some scheme ->
-          // TODO: dedupe the same code in generalizeFunc
-          let mutable mapping: Map<string, Type> = Map.empty
-
-          match scheme.TypeParams with
-          | Some(typeParams) ->
-            match typeArgs with
-            | Some(typeArgs) ->
-              if typeArgs.Length <> typeParams.Length then
-                return! Error(TypeError.WrongNumberOfTypeArgs)
-
-              for tp, ta in List.zip typeParams typeArgs do
-                mapping <- mapping.Add(tp.Name, ta)
-            | None ->
-              for tp in typeParams do
-                mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None None)
-          | None -> ()
-
-          let! t = expandScheme ctx env ips scheme mapping typeArgs
+          // // TODO: dedupe the same code in generalizeFunc
+          // let mutable mapping: Map<string, Type> = Map.empty
+          //
+          // match scheme.TypeParams with
+          // | Some(typeParams) ->
+          //   match typeArgs with
+          //   | Some(typeArgs) ->
+          //     if typeArgs.Length <> typeParams.Length then
+          //       return! Error(TypeError.WrongNumberOfTypeArgs)
+          //
+          //     for tp, ta in List.zip typeParams typeArgs do
+          //       mapping <- mapping.Add(tp.Name, ta)
+          //   | None ->
+          //     for tp in typeParams do
+          //       mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None None)
+          // | None -> ()
+          // let! t = expandScheme ctx env ips scheme mapping typeArgs
+          let! t = expandScheme ctx env ips scheme Map.empty typeArgs
           do! unify ctx env ips t t2
         | _ -> return! unifyFallThrough ctx env ips t1 t2
       | _, TypeKind.TypeRef { TypeArgs = typeArgs; Scheme = scheme } ->
         match scheme with
         | Some scheme ->
-          // TODO: dedupe the same code in generalizeFunc
-          let mutable mapping: Map<string, Type> = Map.empty
-
-          match scheme.TypeParams with
-          | Some(typeParams) ->
-            match typeArgs with
-            | Some(typeArgs) ->
-              if typeArgs.Length <> typeParams.Length then
-                return! Error(TypeError.WrongNumberOfTypeArgs)
-
-              for tp, ta in List.zip typeParams typeArgs do
-                mapping <- mapping.Add(tp.Name, ta)
-            | None ->
-              for tp in typeParams do
-                mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None None)
-          | None -> ()
-
-          let! t = expandScheme ctx env ips scheme mapping typeArgs
+          // // TODO: dedupe the same code in generalizeFunc
+          // let mutable mapping: Map<string, Type> = Map.empty
+          //
+          // match scheme.TypeParams with
+          // | Some(typeParams) ->
+          //   match typeArgs with
+          //   | Some(typeArgs) ->
+          //     if typeArgs.Length <> typeParams.Length then
+          //       return! Error(TypeError.WrongNumberOfTypeArgs)
+          //
+          //     for tp, ta in List.zip typeParams typeArgs do
+          //       mapping <- mapping.Add(tp.Name, ta)
+          //   | None ->
+          //     for tp in typeParams do
+          //       mapping <- mapping.Add(tp.Name, ctx.FreshTypeVar None None)
+          // | None -> ()
+          //
+          // let! t = expandScheme ctx env ips scheme mapping typeArgs
+          let! t = expandScheme ctx env ips scheme Map.empty typeArgs
           do! unify ctx env ips t1 t
         | _ -> return! unifyFallThrough ctx env ips t1 t2
       | TypeKind.Range range1, TypeKind.Range range2 ->
@@ -349,11 +350,14 @@ module rec Unify =
         let mutable combinedElems = []
         let mutable restTypes = []
 
+        // TODO: dedupe with TypeKind.Intersection, TypeKind.Object case
         for t in types do
           match t.Kind with
           | TypeKind.Object { Elems = elems } ->
             combinedElems <- combinedElems @ elems
           | TypeKind.Rest t -> restTypes <- t :: restTypes
+          | TypeKind.TypeVar { Bound = Some bound } ->
+            restTypes <- t :: restTypes
           | TypeKind.TypeRef _ ->
             let! t = expandType ctx env ips Map.empty t
 
@@ -365,9 +369,6 @@ module rec Unify =
               printfn $"t is not an object types - {t}"
               return! Error(TypeError.TypeMismatch(t1, t2))
           | _ ->
-            // TODO: handle the case where `t` is a type variable
-            // NOTE: we can only handle situations where one of the types is
-            // a type variable otherwise it's undecidable.
             printfn $"t is not an object types - {t}"
             return! Error(TypeError.TypeMismatch(t1, t2))
 
@@ -421,11 +422,22 @@ module rec Unify =
         let mutable combinedElems = []
         let mutable restTypes = []
 
+        // TODO: dedupe with TypeKind.Object, TypeKind.Intersection case
         for t in types do
           match t.Kind with
           | TypeKind.Object { Elems = elems } ->
             combinedElems <- combinedElems @ elems
           | TypeKind.Rest t -> restTypes <- t :: restTypes
+          | TypeKind.TypeVar { Bound = Some bound } ->
+            restTypes <- t :: restTypes
+          | TypeKind.TypeRef { Name = name } ->
+            let! t = expandType ctx env ips Map.empty t
+
+            match t.Kind with
+            | TypeKind.Object { Elems = elems } ->
+              combinedElems <- combinedElems @ elems
+            | TypeKind.Rest t -> restTypes <- t :: restTypes
+            | _ -> failwith $"TODO: handle type {t} in intersection"
           | _ -> return! Error(TypeError.TypeMismatch(t1, t2))
 
         let objType =
@@ -473,6 +485,9 @@ module rec Unify =
 
           do! unify ctx env ips restType newRestType
         | _ -> return! Error(TypeError.TypeMismatch(t1, t2))
+
+      | TypeKind.Intersection types1, TypeKind.Intersection types2 ->
+        failwith "TODO: handle unify(intersection, intersection)"
 
       | TypeKind.Union(types), _ ->
         let! _ = types |> List.traverseResultM (fun t -> unify ctx env ips t t2)


### PR DESCRIPTION
Now we can do type inference on intersection types that include type references and type variables.