### PR TITLE
Fix how we instantiate generic functions

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -906,7 +906,7 @@ module Type =
 
   [<CustomEquality; NoComparison>]
   type Type =
-    { mutable Kind: TypeKind // Used to rename AnonymousClass to the class name
+    { mutable Kind: TypeKind // Modified to rename AnonymousClass to the class name
       mutable Provenance: option<Provenance> }
 
     override this.Equals other =
@@ -921,10 +921,8 @@ module Type =
   type Binding = Type * bool
 
   type Scheme =
-    // TODO: allow type params to have constraints and defaults
     { TypeParams: option<list<TypeParam>>
-      mutable Type: Type // Only used when inferring type declarations
-      IsTypeParam: bool }
+      mutable Type: Type } // Modified used when inferring type declarations
 
     override this.ToString() =
       match this.TypeParams with

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -953,7 +953,7 @@ let InferIfLetWithShadowing () =
 
       Assert.Empty(ctx.Diagnostics)
       // TODO: fix this shadowing issue
-      Assert.Value(env, "y", "t5:number + 1 | 0")
+      Assert.Value(env, "y", "t3:number + 1 | 0")
     }
 
   Assert.False(Result.isError result)

--- a/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
+++ b/src/Escalier.TypeChecker.Tests/UtilityTypes.fs
@@ -230,7 +230,7 @@ let InfersPickUnionOfKeyInModule () =
     result {
       let src =
         """
-        type Pick<T, K: keyof T> = {
+        type Pick<K: keyof T, T> = {
           [P]: T[P] for P in K
         };
 
@@ -277,6 +277,7 @@ let InfersPickSingleKey () =
       Assert.Equal("{a: number, c: boolean}", result.ToString())
     }
 
+  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]


### PR DESCRIPTION
This PR makes the following changes:
- type params without type args in generic function calls are instantiated as type (unification) variables now
- generation of dependency tree generation between type params has been extracted into a helper function
- instantiation of generic schemes has been update to use the new helper function