### PR TITLE
Use Set<QDeclIdent> instead of list<QDeclIDent> in Edges

### DIFF
--- a/src/Escalier.TypeChecker.Tests/BuildGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/BuildGraphTests.fs
@@ -10,82 +10,82 @@ open Escalier.TypeChecker.BuildGraph
 let PlaceholderTest () =
   let ns = Namespace.empty
   let ident = QDeclIdent.MakeValue [ "x" ]
-  let localsTree = localsToDeclTree []
-  let actual = postProcessDeps ns [] localsTree ident []
+  let localsTree = localsToDeclTree Set.empty
+  let actual = postProcessDeps ns Set.empty localsTree ident []
 
-  let expected = []
-  Assert.Equal<QDeclIdent list>(expected, actual)
+  let expected = Set.empty
+  Assert.Equal<QDeclIdent Set>(expected, actual)
 
 [<Fact>]
 let SimpleDeps () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo" ]; QDeclIdent.MakeValue [ "bar" ] ]
 
   let actual = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo" ] ]
-  Assert.Equal<QDeclIdent list>(expected, actual)
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo" ])
+  Assert.Equal<QDeclIdent Set>(expected, actual)
 
 [<Fact>]
 let DepsWithMemberAccess () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
 
   let actual = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo" ] ]
-  Assert.Equal<QDeclIdent list>(expected, actual)
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo" ])
+  Assert.Equal<QDeclIdent Set>(expected, actual)
 
 [<Fact>]
 let QualifiedDeps () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
 
   let actual = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
-  Assert.Equal<QDeclIdent list>(expected, actual)
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ])
+  Assert.Equal<QDeclIdent Set>(expected, actual)
 
 [<Fact>]
 let QualifiedDepsWithMemberAccess () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "x" ]
   let deps = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
 
   let actual = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
-  Assert.Equal<QDeclIdent list>(expected, actual)
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar" ])
+  Assert.Equal<QDeclIdent Set>(expected, actual)
 
 [<Fact>]
 let SimpleDepsNeedingNamespaces () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "foo"; "x" ]
   let deps = [ QDeclIdent.MakeValue [ "bar" ]; QDeclIdent.MakeValue [ "baz" ] ]
 
   let result = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar" ])
 
-  Assert.Equal<QDeclIdent list>(expected, result)
+  Assert.Equal<QDeclIdent Set>(expected, result)
 
 [<Fact>]
 let FullnamespacedDepsInsideNamespace () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "foo"; "x" ]
 
@@ -95,20 +95,20 @@ let FullnamespacedDepsInsideNamespace () =
 
   let result = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo"; "bar" ] ]
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar" ])
 
-  Assert.Equal<QDeclIdent list>(expected, result)
+  Assert.Equal<QDeclIdent Set>(expected, result)
 
 [<Fact>]
 let PartialShadowing () =
   let ns = Namespace.empty
-  let locals = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
+  let locals = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ])
   let localsTree = localsToDeclTree locals
   let ident = QDeclIdent.MakeValue [ "foo"; "bar"; "x" ]
   let deps = [ QDeclIdent.MakeValue [ "bar"; "baz" ] ]
 
   let result = postProcessDeps ns locals localsTree ident deps
 
-  let expected = [ QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ] ]
+  let expected = Set.singleton (QDeclIdent.MakeValue [ "foo"; "bar"; "baz" ])
 
-  Assert.Equal<QDeclIdent list>(expected, result)
+  Assert.Equal<QDeclIdent Set>(expected, result)

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -76,7 +76,7 @@ let generalizeBindings (bindings: Map<string, Binding>) : Map<string, Binding> =
 
   newBindings
 
-let findBindingNames (p: Syntax.Pattern) : list<string> =
+let findBindingNames (p: Syntax.Pattern) : Set<string> =
   let mutable names: list<string> = []
 
   let visitor =
@@ -105,7 +105,7 @@ let findBindingNames (p: Syntax.Pattern) : list<string> =
 
   walkPattern visitor () p
 
-  List.rev names
+  Set.ofList names
 
 let findReturns (body: BlockOrExpr) : list<Expr> =
   let mutable returns: list<Expr> = []
@@ -243,15 +243,15 @@ let findThrowsInBlock (block: Block) : list<Type> =
 
   throws
 
-let findModuleBindingNames (m: Script) : list<string> =
-  let mutable names: list<string> = []
+let findModuleBindingNames (m: Script) : Set<string> =
+  let mutable names: Set<string> = Set.empty
 
   for item in m.Items do
     match item with
     | Stmt stmt ->
       match stmt.Kind with
       | StmtKind.Decl({ Kind = DeclKind.VarDecl { Pattern = pattern } }) ->
-        names <- List.concat [ names; findBindingNames pattern ]
+        names <- Set.union names (findBindingNames pattern)
       | _ -> ()
     | _ -> ()
 

--- a/src/Escalier.TypeChecker/InferGraph.fs
+++ b/src/Escalier.TypeChecker/InferGraph.fs
@@ -705,7 +705,7 @@ let findStronglyConnectedComponents<'T>
 
     let deps =
       match graph.Edges.TryFind v with
-      | None -> []
+      | None -> Set.empty
       | Some deps -> deps
 
     // 3. For each edge from v to a neighboring vertex w:
@@ -776,7 +776,7 @@ let buildComponentTree<'T>
       let nodeDeps =
         match graph.Edges.TryFind node with
         | None -> Set.empty
-        | Some deps -> Set.ofList deps
+        | Some deps -> deps
 
       compDepNodes <- Set.union (Set.difference nodeDeps comp) compDepNodes
 

--- a/src/Escalier.TypeChecker/QualifiedGraph.fs
+++ b/src/Escalier.TypeChecker/QualifiedGraph.fs
@@ -54,7 +54,7 @@ type QDeclIdent =
 type QGraph<'T> =
   // A type can depend on multiple interface declarations
   { Nodes: Map<QDeclIdent, list<'T>>
-    Edges: Map<QDeclIdent, list<QDeclIdent>> }
+    Edges: Map<QDeclIdent, Set<QDeclIdent>> }
 
 // member this.Add(name: QDeclIdent, decl: 'T, deps: list<QDeclIdent>) =
 //   printfn $"adding {name}"


### PR DESCRIPTION
There's some other `list<QDeclIdent>`s in BuildGraph.fs that could be replaces well, but this is a good start.