### PR TITLE
Update inferBlock to use inferTree et al.

### DIFF
--- a/src/Escalier.TypeChecker.Tests/Modules.fs
+++ b/src/Escalier.TypeChecker.Tests/Modules.fs
@@ -145,3 +145,24 @@ let InferModuleWithTopLevelAssignments () =
     }
 
   Assert.False(Result.isError res)
+
+[<Fact>]
+let InferModuleWithTopLevelForLoop () =
+  let res =
+    result {
+      let src =
+        """
+        let mut sum: number = 0;
+        for x in [1, 2, 3] {
+          let square = x * x;
+          sum = sum + square;
+        }
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Diagnostics)
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
@@ -1,5 +1,6 @@
 module Escalier.TypeChecker.Tests.QualifiedGraphTests
 
+open Escalier.Data
 open Escalier.Data.Type
 open FsToolkit.ErrorHandling
 open Xunit
@@ -508,7 +509,15 @@ let MergeInterfaceBetweenFiles () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let graph = buildGraph env ast
+      let decls =
+        List.choose
+          (fun (item: Syntax.ModuleItem) ->
+            match item with
+            | Syntax.ModuleItem.Stmt { Kind = Syntax.Decl decl } -> Some decl
+            | _ -> None)
+          ast.Items
+
+      let graph = buildGraph env decls
 
       let! env =
         Infer.inferGraph ctx env graph |> Result.mapError CompileError.TypeError
@@ -546,7 +555,15 @@ let MergeInterfaceBetweenFilesWithComputedKeys () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let graph = buildGraph env ast
+      let decls =
+        List.choose
+          (fun (item: Syntax.ModuleItem) ->
+            match item with
+            | Syntax.ModuleItem.Stmt { Kind = Syntax.Decl decl } -> Some decl
+            | _ -> None)
+          ast.Items
+
+      let graph = buildGraph env decls
 
       let! env =
         Infer.inferGraph ctx env graph |> Result.mapError CompileError.TypeError

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -496,13 +496,13 @@ let ReturnRecursivePrivateGenericObjectType () =
       let src =
         """
         let makeTree = fn () {
-          type Node<T> = {
+          type MyNode<T> = {
             value: T,
-            left?: Node<T>,
-            right?: Node<T>
+            left?: MyNode<T>,
+            right?: MyNode<T>
           };
 
-          let node: Node<number> = {
+          let node: MyNode<number> = {
             value: 5,
             left: {
               value: 10
@@ -518,10 +518,10 @@ let ReturnRecursivePrivateGenericObjectType () =
         let x = node.left?.value;
         """
 
-      let! ctx, env = inferScript src
+      let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Diagnostics)
-      Assert.Value(env, "node", "Node<number>")
+      Assert.Value(env, "node", "MyNode<number>")
       Assert.Value(env, "x", "number | undefined")
     }
 
@@ -1046,6 +1046,7 @@ let InferLetElseEarlyReturn () =
       Assert.Value(env, "foo", "fn (x: number | undefined) -> number")
     }
 
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker/BuildGraph.fs
+++ b/src/Escalier.TypeChecker/BuildGraph.fs
@@ -1249,11 +1249,10 @@ let getEdges
 
   edges
 
-let buildGraph (env: Env) (m: Module) : QGraph<Decl> =
+let buildGraph (env: Env) (decls: list<Decl>) : QGraph<Decl> =
 
   let mutable graph: QGraph<Decl> = { Nodes = Map.empty; Edges = Map.empty }
 
-  let decls = getDeclsFromModule m
   let locals = findLocals decls
 
   // printfn "--- LOCALS ---"
@@ -1267,13 +1266,6 @@ let buildGraph (env: Env) (m: Module) : QGraph<Decl> =
     |> List.choose (fun qid ->
       match qid with
       | Type name -> Some name
-      | _ -> None)
-
-  let decls =
-    m.Items
-    |> List.choose (fun (item: ModuleItem) ->
-      match item with
-      | ModuleItem.Stmt { Kind = StmtKind.Decl decl } -> Some decl
       | _ -> None)
 
   let nodes = getNodes decls

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -788,7 +788,10 @@ module rec Unify =
           newEnv <- newEnv.AddScheme name { Type = t; TypeParams = None }
 
         return! expandType ctx newEnv ips mapping scheme.Type
-      | _ ->
+      | typeParams, typeArgs ->
+        printfn $"typeParams = {typeParams}"
+        printfn $"typeArgs = {typeArgs}"
+
         return!
           Error(
             TypeError.NotImplemented "TODO: expandScheme with type params/args"


### PR DESCRIPTION
This PR updates `inferBlock` (which infers function bodies, if/else blocks, etc.) to use the same internals as `inferModule` and after a few minor tweaks (around when to generalize or not) all the tests are passing.  There are still some test cases that using `inferScript` that will need to be migrated over to `inferModule`, hopefully I don't run into too many issues with that.  I'll tackle that in a followup PR.