### PR TITLE
fix function overloads

### DIFF
--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -85,6 +85,13 @@ module rec Env =
     member this.PopReport() =
       match parentReports with
       | parent :: ancestors ->
+        currentReport <- parent
+        parentReports <- ancestors
+      | [] -> ()
+
+    member this.MergeUpReport() =
+      match parentReports with
+      | parent :: ancestors ->
         currentReport.Diagnostics <-
           parent.Diagnostics @ currentReport.Diagnostics
 


### PR DESCRIPTION
We now check if `ctx.Report.Diagnostics` is empty after attempting to unify each overload with the provided call args.