### PR TITLE
Check whether a value is an l-value or not when calling getPropType()

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -527,13 +527,11 @@ module Syntax =
 
   type GetterType =
     { Name: PropName
-      Self: FuncParam
-      ReturnType: option<TypeAnn>
+      ReturnType: TypeAnn
       Throws: option<TypeAnn> }
 
   type SetterType =
     { Name: PropName
-      Self: FuncParam
       Param: FuncParam
       Throws: option<TypeAnn> }
 

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -134,7 +134,7 @@ let ParseAndInferInterface () =
       Assert.Type(
         env,
         "Foo",
-        "{bar fn (self: Self) -> number, baz fn (self: Self, mut x: string) -> boolean, get qux fn () -> string, set qux fn () -> undefined}"
+        "{bar fn (self: Self) -> number, baz fn (self: Self, mut x: string) -> boolean, get qux fn () -> string, set qux fn (mut x: string) -> undefined}"
       )
     }
 

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -263,8 +263,7 @@ module rec Migrate =
 
       ObjTypeAnnElem.Getter
         { Name = name
-          Self = makeSelfFuncParam ()
-          ReturnType = Some retType
+          ReturnType = retType
           Throws = None }
     | TsSetterSignature { Key = key
                           Param = fnParam
@@ -286,7 +285,6 @@ module rec Migrate =
 
       ObjTypeAnnElem.Setter
         { Name = name
-          Self = makeSelfFuncParam ()
           Param = fnParam
           Throws = None }
 

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -545,6 +545,22 @@ let ParsePropKeysInObjectType () =
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
 
 [<Fact>]
+let ParseGetterSetterInObjectType () =
+  let src =
+    """
+    type Obj = {
+      get foo() -> string,
+      set foo(value: string),
+    };
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+
+[<Fact>]
 let ParseForLoop () =
   let src =
     """

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGetterSetterInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGetterSetterInObjectType.verified.txt
@@ -1,0 +1,52 @@
+﻿input: 
+    type Obj = {
+      get foo() -> string,
+      set foo(value: string),
+    };
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                TypeDecl
+                  { Name = "Obj"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Getter
+                                { Name = String "foo"
+                                  ReturnType =
+                                   { Kind = Keyword String
+                                     Span = { Start = (Ln: 3, Col: 20)
+                                              Stop = (Ln: 3, Col: 26) }
+                                     InferredType = None }
+                                  Throws = None };
+                              Setter
+                                { Name = String "foo"
+                                  Param =
+                                   { Pattern =
+                                      { Kind = Ident { Name = "value"
+                                                       IsMut = false
+                                                       Assertion = None }
+                                        Span = { Start = (Ln: 4, Col: 15)
+                                                 Stop = (Ln: 4, Col: 20) }
+                                        InferredType = None }
+                                     TypeAnn =
+                                      Some { Kind = Keyword String
+                                             Span = { Start = (Ln: 4, Col: 22)
+                                                      Stop = (Ln: 4, Col: 28) }
+                                             InferredType = None }
+                                     Optional = false }
+                                  Throws = None }]
+                            Immutable = false }
+                       Span = { Start = (Ln: 2, Col: 16)
+                                Stop = (Ln: 5, Col: 6) }
+                       InferredType = None }
+                    TypeParams = None }
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 6, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 6, Col: 5) } }] }

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -369,6 +369,34 @@ let DontIncludeSettersInRvalues () =
   )
 
 [<Fact>]
+let DontIncludeSettersInRvaluesDestructuring () =
+  let result =
+    result {
+      let src =
+        """
+        type Obj = {
+          get foo() -> string,
+          set bar(value: number),
+        };
+        declare let obj: Obj;
+        let {foo, bar} = obj;
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+    }
+
+  Assert.Equal(
+    result,
+    Result.Error(
+      Compiler.CompileError.TypeError(
+        TypeError.PropertyMissing(Escalier.Data.Type.PropName.String "bar")
+      )
+    )
+  )
+
+[<Fact>]
 let DontIncludeGettersInLvalues () =
   let result =
     result {

--- a/src/Escalier.TypeChecker/BuildGraph.fs
+++ b/src/Escalier.TypeChecker/BuildGraph.fs
@@ -1131,16 +1131,13 @@ let getEdges
               let propNameDeps = getPropNameDeps env locals name
 
               let fnDeps =
-                match returnType with
-                | Some returnType ->
-                  findDepsForTypeIdent
-                    env
-                    possibleDeps
-                    localsTree
-                    typeParamNames
-                    ident
-                    (SyntaxNode.TypeAnn returnType)
-                | None -> Set.empty
+                findDepsForTypeIdent
+                  env
+                  possibleDeps
+                  localsTree
+                  typeParamNames
+                  ident
+                  (SyntaxNode.TypeAnn returnType)
 
               Set.union propNameDeps fnDeps
             | ObjTypeAnnElem.Setter { Param = { TypeAnn = typeAnn }

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -790,7 +790,8 @@ module rec Infer =
           let! objType = inferExpr ctx env obj
           let propKey = PropName.String(prop)
 
-          let! t = getPropType ctx env objType propKey optChain false
+          let! t =
+            getPropType ctx env objType propKey optChain ValueCategory.RValue
 
           let mutable t = t
 
@@ -951,7 +952,7 @@ module rec Infer =
                 printfn "index = %A" index
                 failwith $"TODO: index can't be a {index}"
 
-            return! getPropType ctx env target key optChain false
+            return! getPropType ctx env target key optChain ValueCategory.RValue
         | ExprKind.Range { Min = min; Max = max } ->
           // TODO: add a constraint that `min` and `max` must be numbers
           // We can do this by creating type variables for them with the
@@ -1286,18 +1287,14 @@ module rec Infer =
     (t: Type)
     (key: PropName)
     (optChain: bool)
-    (isLValue: bool)
+    (valueCategory: ValueCategory)
     : Result<Type, TypeError> =
     result {
-
-      if key = PropName.String "foo" then
-        printfn $"isLValue = {isLValue}"
-
       let t = prune t
 
       match t.Kind with
       | TypeKind.Object { Elems = elems } ->
-        match inferMemberAccess ctx key isLValue elems with
+        match inferMemberAccess ctx key valueCategory elems with
         | Some t -> return t
         | None ->
           return! Error(TypeError.SemanticError $"Property {key} not found")
@@ -1337,11 +1334,11 @@ module rec Infer =
         match scheme with
         | Some scheme ->
           let! objType = expandScheme ctx env None scheme Map.empty typeArgs
-          return! getPropType ctx env objType key optChain isLValue
+          return! getPropType ctx env objType key optChain valueCategory
         | None ->
           let! scheme = env.GetScheme typeRefName
           let! objType = expandScheme ctx env None scheme Map.empty typeArgs
-          return! getPropType ctx env objType key optChain isLValue
+          return! getPropType ctx env objType key optChain valueCategory
       | TypeKind.Union types ->
         let undefinedTypes, definedTypes =
           List.partition
@@ -1357,7 +1354,7 @@ module rec Infer =
         else
           match definedTypes with
           | [ t ] ->
-            let! t = getPropType ctx env t key optChain isLValue
+            let! t = getPropType ctx env t key optChain valueCategory
 
             let undefined =
               { Kind = TypeKind.Literal(Literal.Undefined)
@@ -1422,7 +1419,7 @@ module rec Infer =
           // Instead of expanding the whole scheme which could be quite expensive
           // we get the property from the type and then only instantiate it.
           let t = arrayScheme.Type
-          let! prop = getPropType ctx env t key optChain isLValue
+          let! prop = getPropType ctx env t key optChain valueCategory
 
           let! prop =
             instantiateType ctx prop arrayScheme.TypeParams (Some [ elem ])
@@ -1441,7 +1438,7 @@ module rec Infer =
     // TODO: do the search first and then return the appropriate ObjTypeElem
     (ctx: Ctx)
     (key: PropName)
-    (isLValue: bool)
+    (valueCategory: ValueCategory)
     (elems: list<ObjTypeElem>)
     : option<Type> =
 
@@ -1453,9 +1450,12 @@ module rec Infer =
         (fun (elem: ObjTypeElem) ->
           match elem with
           | Property { Name = name } -> name = key
-          | Method(name, _) -> name = key && not isLValue // can't assign to methods
-          | Getter(name, _) -> name = key && not isLValue // can't assign to getters
-          | Setter(name, _) -> name = key && isLValue // can't read from setters
+          | Method(name, _) ->
+            name = key && valueCategory = ValueCategory.RValue
+          | Getter(name, _) ->
+            name = key && valueCategory = ValueCategory.RValue
+          | Setter(name, _) ->
+            name = key && valueCategory = ValueCategory.LValue
           | Mapped _ ->
             failwith
               "TODO: inferMemberAccess - mapped (check if key is subtype of Mapped.TypeParam)"
@@ -2670,7 +2670,15 @@ module rec Infer =
           return { Kind = kind; Provenance = None }
       | QualifiedIdent.Member(left, right) ->
         let! left = getQualifiedIdentType ctx env left
-        return! getPropType ctx env left (PropName.String right) false false
+
+        return!
+          getPropType
+            ctx
+            env
+            left
+            (PropName.String right)
+            false
+            ValueCategory.RValue
     }
 
   let rec getLvalue
@@ -2695,7 +2703,7 @@ module rec Infer =
             printfn "index = %A" index
             failwith $"TODO: index can't be a {index}"
 
-        let! t = getPropType ctx env target key false true
+        let! t = getPropType ctx env target key false ValueCategory.LValue
         return t, isMut
       | ExprKind.Member(target, name, _optChain) ->
         // TODO: check if `target` is a namespace
@@ -2704,7 +2712,16 @@ module rec Infer =
 
         // TODO: disallow optChain in lvalues
         let! target, isMut = getLvalue ctx env target
-        let! t = getPropType ctx env target (PropName.String name) false true
+
+        let! t =
+          getPropType
+            ctx
+            env
+            target
+            (PropName.String name)
+            false
+            ValueCategory.LValue
+
         return t, isMut
       | _ ->
         return! Error(TypeError.SemanticError $"{expr} is not a valid lvalue")
@@ -3862,7 +3879,7 @@ module rec Infer =
               symbol
               (PropName.String "iterator")
               false
-              false // isLValue
+              ValueCategory.RValue
 
           // TODO: only lookup Symbol.iterator on Array for arrays and tuples
           let arrayScheme =
@@ -3876,7 +3893,13 @@ module rec Infer =
             | _ -> failwith "Symbol.iterator is not a unique symbol"
 
           let! _ =
-            getPropType ctx blockEnv arrayScheme.Type propName false false
+            getPropType
+              ctx
+              blockEnv
+              arrayScheme.Type
+              propName
+              false
+              ValueCategory.RValue
 
           // TODO: add a variant of `ExpandType` that allows us to specify a
           // predicate that can stop the expansion early.
@@ -3901,7 +3924,7 @@ module rec Infer =
                     rightType
                     (PropName.String "next")
                     false
-                    false
+                    ValueCategory.RValue
 
                 match next.Kind with
                 | TypeKind.Function f ->
@@ -3912,7 +3935,7 @@ module rec Infer =
                       f.Return
                       (PropName.String "value")
                       false
-                      false
+                      ValueCategory.RValue
                 | _ ->
                   return!
                     Error(

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -790,7 +790,7 @@ module rec Infer =
           let! objType = inferExpr ctx env obj
           let propKey = PropName.String(prop)
 
-          let! t = getPropType ctx env objType propKey optChain
+          let! t = getPropType ctx env objType propKey optChain false
 
           let mutable t = t
 
@@ -951,7 +951,7 @@ module rec Infer =
                 printfn "index = %A" index
                 failwith $"TODO: index can't be a {index}"
 
-            return! getPropType ctx env target key optChain
+            return! getPropType ctx env target key optChain false
         | ExprKind.Range { Min = min; Max = max } ->
           // TODO: add a constraint that `min` and `max` must be numbers
           // We can do this by creating type variables for them with the
@@ -1286,14 +1286,18 @@ module rec Infer =
     (t: Type)
     (key: PropName)
     (optChain: bool)
+    (isLValue: bool)
     : Result<Type, TypeError> =
     result {
+
+      if key = PropName.String "foo" then
+        printfn $"isLValue = {isLValue}"
 
       let t = prune t
 
       match t.Kind with
       | TypeKind.Object { Elems = elems } ->
-        match inferMemberAccess key elems with
+        match inferMemberAccess ctx key isLValue elems with
         | Some t -> return t
         | None ->
           return! Error(TypeError.SemanticError $"Property {key} not found")
@@ -1333,11 +1337,11 @@ module rec Infer =
         match scheme with
         | Some scheme ->
           let! objType = expandScheme ctx env None scheme Map.empty typeArgs
-          return! getPropType ctx env objType key optChain
+          return! getPropType ctx env objType key optChain isLValue
         | None ->
           let! scheme = env.GetScheme typeRefName
           let! objType = expandScheme ctx env None scheme Map.empty typeArgs
-          return! getPropType ctx env objType key optChain
+          return! getPropType ctx env objType key optChain isLValue
       | TypeKind.Union types ->
         let undefinedTypes, definedTypes =
           List.partition
@@ -1353,7 +1357,7 @@ module rec Infer =
         else
           match definedTypes with
           | [ t ] ->
-            let! t = getPropType ctx env t key optChain
+            let! t = getPropType ctx env t key optChain isLValue
 
             let undefined =
               { Kind = TypeKind.Literal(Literal.Undefined)
@@ -1418,7 +1422,7 @@ module rec Infer =
           // Instead of expanding the whole scheme which could be quite expensive
           // we get the property from the type and then only instantiate it.
           let t = arrayScheme.Type
-          let! prop = getPropType ctx env t key optChain
+          let! prop = getPropType ctx env t key optChain isLValue
 
           let! prop =
             instantiateType ctx prop arrayScheme.TypeParams (Some [ elem ])
@@ -1435,18 +1439,23 @@ module rec Infer =
   // - setting: non-readonly property, setter, non-readonly mapped
   let inferMemberAccess
     // TODO: do the search first and then return the appropriate ObjTypeElem
+    (ctx: Ctx)
     (key: PropName)
+    (isLValue: bool)
     (elems: list<ObjTypeElem>)
     : option<Type> =
 
+    // TODO: instead of using tryFind, use a for-loop with an early return
+    // we can use this to provide better error messages when trying to assign
+    // something that has a getter by no setter and similar situations.
     let elem =
       List.tryFind
         (fun (elem: ObjTypeElem) ->
           match elem with
           | Property { Name = name } -> name = key
-          | Method(name, _) -> name = key
-          | Getter(name, _) -> name = key
-          | Setter(name, _) -> name = key
+          | Method(name, _) -> name = key && not isLValue // can't assign to methods
+          | Getter(name, _) -> name = key && not isLValue // can't assign to getters
+          | Setter(name, _) -> name = key && isLValue // can't read from setters
           | Mapped _ ->
             failwith
               "TODO: inferMemberAccess - mapped (check if key is subtype of Mapped.TypeParam)"
@@ -1473,14 +1482,8 @@ module rec Infer =
             Provenance = None }
 
         Some t
-      | Getter(_name, fn) ->
-        // TODO: check if it's an lvalue
-        // TODO: handle throws
-        Some fn.Return
-      | Setter(_name, fn) ->
-        // TODO: check if it's an rvalue
-        // TODO: handle throws
-        Some fn.ParamList[0].Type
+      | Getter(_, fn) -> Some fn.Return // TODO: handle throws
+      | Setter(_, fn) -> Some fn.ParamList[0].Type // TODO: handle throws
       | Mapped _mapped -> failwith "TODO: inferMemberAccess - mapped"
       | Callable _ -> failwith "Callable signatures don't have a name"
       | Constructor _ -> failwith "Constructor signatures don't have a name"
@@ -1607,7 +1610,7 @@ module rec Infer =
           { TypeParams = None
             Self = None
             ParamList = []
-            ReturnType = retType
+            ReturnType = Some retType
             Throws = throws
             IsAsync = false }
 
@@ -1615,7 +1618,7 @@ module rec Infer =
         let! name = inferPropName ctx env name
         return Getter(name, f)
       | ObjTypeAnnElem.Setter { Name = name
-                                Param = fnParam
+                                Param = param
                                 Throws = throws } ->
 
         let undefined =
@@ -1626,7 +1629,7 @@ module rec Infer =
         let f: FuncSig =
           { TypeParams = None
             Self = None
-            ParamList = []
+            ParamList = [ param ]
             ReturnType = Some undefined
             Throws = throws
             IsAsync = false }
@@ -2667,7 +2670,7 @@ module rec Infer =
           return { Kind = kind; Provenance = None }
       | QualifiedIdent.Member(left, right) ->
         let! left = getQualifiedIdentType ctx env left
-        return! getPropType ctx env left (PropName.String right) false
+        return! getPropType ctx env left (PropName.String right) false false
     }
 
   let rec getLvalue
@@ -2692,7 +2695,7 @@ module rec Infer =
             printfn "index = %A" index
             failwith $"TODO: index can't be a {index}"
 
-        let! t = getPropType ctx env target key false
+        let! t = getPropType ctx env target key false true
         return t, isMut
       | ExprKind.Member(target, name, _optChain) ->
         // TODO: check if `target` is a namespace
@@ -2701,7 +2704,7 @@ module rec Infer =
 
         // TODO: disallow optChain in lvalues
         let! target, isMut = getLvalue ctx env target
-        let! t = getPropType ctx env target (PropName.String name) false
+        let! t = getPropType ctx env target (PropName.String name) false true
         return t, isMut
       | _ ->
         return! Error(TypeError.SemanticError $"{expr} is not a valid lvalue")
@@ -3853,7 +3856,13 @@ module rec Infer =
             | None -> failwith "Symbol not in scope"
 
           let! symbolIterator =
-            getPropType ctx blockEnv symbol (PropName.String "iterator") false
+            getPropType
+              ctx
+              blockEnv
+              symbol
+              (PropName.String "iterator")
+              false
+              false // isLValue
 
           // TODO: only lookup Symbol.iterator on Array for arrays and tuples
           let arrayScheme =
@@ -3866,7 +3875,8 @@ module rec Infer =
             | TypeKind.UniqueSymbol id -> PropName.Symbol id
             | _ -> failwith "Symbol.iterator is not a unique symbol"
 
-          let! _ = getPropType ctx blockEnv arrayScheme.Type propName false
+          let! _ =
+            getPropType ctx blockEnv arrayScheme.Type propName false false
 
           // TODO: add a variant of `ExpandType` that allows us to specify a
           // predicate that can stop the expansion early.
@@ -3891,6 +3901,7 @@ module rec Infer =
                     rightType
                     (PropName.String "next")
                     false
+                    false
 
                 match next.Kind with
                 | TypeKind.Function f ->
@@ -3900,6 +3911,7 @@ module rec Infer =
                       blockEnv
                       f.Return
                       (PropName.String "value")
+                      false
                       false
                 | _ ->
                   return!

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -309,7 +309,7 @@ module rec ExprVisitor =
         List.iter
           (fun (param: FuncParam) -> Option.iter walk param.TypeAnn)
           f.ParamList
-      | Getter { ReturnType = retType } -> Option.iter walk retType
+      | Getter { ReturnType = retType } -> walk retType
       | Setter { Param = { TypeAnn = paramType } } -> Option.iter walk paramType
       | Property { TypeAnn = typeAnn } -> walk typeAnn
       | Mapped { TypeParam = typeParam


### PR DESCRIPTION
This PR also updated the Parser to be able to parse getters and setters in object type annotations.