### PR TITLE
Update inferExpr to take a 'typeAnn' param

### DIFF
--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -830,7 +830,7 @@ let InferHTMLProps () =
       )
     }
 
-  // printfn "result = %A" result
+  printfn "result = %A" result
   Assert.False(Result.isError result)
 
 

--- a/src/Escalier.TypeChecker.Tests/Jsx.fs
+++ b/src/Escalier.TypeChecker.Tests/Jsx.fs
@@ -28,6 +28,44 @@ let InferJsx () =
 
   Assert.False(Result.isError res)
 
+// unify(React.JSX.Element, React.ReactNode)
+// expands to
+// unify({
+//   type: _, props: _, key: string | null, type: _, props: _, key: string | null,
+//   type: _, props: _, key: string | null, type: _, props: _, key: string | null,
+//   type: _, props: _, key: string | null, type: _, props: _, key: string | null,
+//   type: _, props: _, key: string | null, type: _, props: _, key: string | null
+// },
+//    ReactElement | string | number | Iterable<ReactNode> | ReactPortal | boolean |
+//    null | undefined | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES]
+// )
+// TODO: figure out why React.JSX.Element is repeated multiple times when it's expanded
+// TODO: come up with a better way to unify type aliases
+// - maybe we can create a function that returns a list of type aliases that are
+//   expanded from a given type alias and then do fast checks like are the names
+//   equal or does one appear in the `implements` clause of the other
+[<Fact(Skip = "TODO")>]
+let InferJsxAssignElementToReactNode () =
+  let res =
+    result {
+      let src =
+        """
+        import "react" {React};
+        let foo: React.ReactNode = <div
+          id="foo"
+          title="bar"
+        ></div>;
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+      Assert.Value(env, "foo", "React.JSX.Element")
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)
+
 [<Fact(Skip = "TODO: infer and use defaults in type params correctly")>]
 let InferJsxWithCallback () =
   let res =
@@ -63,17 +101,17 @@ let InferJsxDetectsIncorrectProps () =
         import "react" {React};
         let foo = <div
           id={5}
-          title="bar"
+          title={true}
         ></div>;
         """
 
       let! ctx, env = inferModule src
 
-      Assert.Empty(ctx.Report.Diagnostics)
+      Assert.Equal(ctx.Report.Diagnostics.Length, 2)
       Assert.Value(env, "foo", "React.JSX.Element")
     }
 
-  Assert.True(Result.isError res)
+  Assert.False(Result.isError res)
 
 [<Fact>]
 let InferJsxWithExtraProps () =

--- a/src/Escalier.TypeChecker.Tests/Jsx.fs
+++ b/src/Escalier.TypeChecker.Tests/Jsx.fs
@@ -1,6 +1,7 @@
 module Escalier.TypeChecker.Tests.Jsx
 
 
+open Escalier.TypeChecker.Error
 open FsToolkit.ErrorHandling
 open Xunit
 
@@ -27,7 +28,7 @@ let InferJsx () =
 
   Assert.False(Result.isError res)
 
-[<Fact(Skip = "TODO")>]
+[<Fact(Skip = "TODO: infer and use defaults in type params correctly")>]
 let InferJsxWithCallback () =
   let res =
     result {
@@ -75,6 +76,31 @@ let InferJsxDetectsIncorrectProps () =
   Assert.True(Result.isError res)
 
 [<Fact>]
+let InferJsxWithExtraProps () =
+  let res =
+    result {
+      let src =
+        """
+        import "react" {React};
+        let foo = <div bar="baz"></div>;
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+      Assert.Value(env, "foo", "React.JSX.Element")
+    }
+
+  Assert.Equal(
+    res,
+    Result.Error(
+      CompileError.TypeError(
+        TypeError.SemanticError "bar is not a valid prop for this component"
+      )
+    )
+  )
+
+[<Fact(Skip = "TODO")>]
 let InferPropsTypeObject () =
   let res =
     result {

--- a/src/Escalier.TypeChecker.Tests/Jsx.fs
+++ b/src/Escalier.TypeChecker.Tests/Jsx.fs
@@ -82,23 +82,23 @@ let InferJsxWithExtraProps () =
       let src =
         """
         import "react" {React};
-        let foo = <div bar="baz"></div>;
+        let foo = <div bar={5} baz="hello"></div>;
         """
 
       let! ctx, env = inferModule src
 
-      Assert.Empty(ctx.Report.Diagnostics)
+      Assert.Equal<Diagnostic list>(
+        ctx.Report.Diagnostics,
+        [ { Description = "No prop named 'bar' exists in div's props"
+            Reasons = [] }
+          { Description = "No prop named 'baz' exists in div's props"
+            Reasons = [] } ]
+      )
+
       Assert.Value(env, "foo", "React.JSX.Element")
     }
 
-  Assert.Equal(
-    res,
-    Result.Error(
-      CompileError.TypeError(
-        TypeError.SemanticError "bar is not a valid prop for this component"
-      )
-    )
-  )
+  Assert.False(Result.isError res)
 
 [<Fact(Skip = "TODO")>]
 let InferPropsTypeObject () =

--- a/src/Escalier.TypeChecker.Tests/Jsx.fs
+++ b/src/Escalier.TypeChecker.Tests/Jsx.fs
@@ -73,3 +73,31 @@ let InferJsxDetectsIncorrectProps () =
     }
 
   Assert.True(Result.isError res)
+
+[<Fact>]
+let InferPropsTypeObject () =
+  let res =
+    result {
+      let src =
+        """
+        type Props = {
+          id: string,
+          onClick: fn (event: MouseEvent) -> undefined,
+        };
+        let props: Props = {
+          id: "foo",
+          onClick: fn (event) {
+            let x = event.clientX;
+            let y = event.clientY;
+            let slope = y / x;
+          },
+        };
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+    }
+
+  printfn "res = %A" res
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Mutability.fs
+++ b/src/Escalier.TypeChecker.Tests/Mutability.fs
@@ -22,7 +22,7 @@ let infer src =
     let projectRoot = __SOURCE_DIRECTORY__
     let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
-    let! t = Result.mapError CompileError.TypeError (inferExpr ctx env ast)
+    let! t = Result.mapError CompileError.TypeError (inferExpr ctx env None ast)
 
     return simplify t
   }

--- a/src/Escalier.TypeChecker.Tests/NoParseTests.fs
+++ b/src/Escalier.TypeChecker.Tests/NoParseTests.fs
@@ -275,7 +275,7 @@ let UnificationFailure () =
     )
 
   try
-    inferExpr ctx env ast |> ignore
+    inferExpr ctx env None ast |> ignore
   with ex ->
     Assert.Equal("Type mismatch 3 != true", ex.Message)
 
@@ -291,7 +291,7 @@ let UndefinedSymbol () =
     )
 
   try
-    inferExpr ctx env ast |> ignore
+    inferExpr ctx env None ast |> ignore
   with ex ->
     Assert.Equal("Undefined symbol foo", ex.Message)
 
@@ -345,7 +345,7 @@ let RecursiveUnification () =
     )
 
   try
-    inferExpr ctx env ast |> ignore
+    inferExpr ctx env None ast |> ignore
   with ex ->
     Assert.Equal("Recursive unification", ex.Message)
 

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -24,7 +24,7 @@ let infer src =
     let projectRoot = __SOURCE_DIRECTORY__
     let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
-    let! t = Result.mapError CompileError.TypeError (inferExpr ctx env ast)
+    let! t = Result.mapError CompileError.TypeError (inferExpr ctx env None ast)
 
     return simplify t
   }

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -244,6 +244,29 @@ let InferTypeAnn () =
 
   Assert.False(Result.isError result)
 
+[<Fact(Skip = "TODO(#287): Excess property checking")>]
+let InferObjectExcessPropertyCheck () =
+  let result =
+    result {
+      let src =
+        """
+        type Point = {x: number, y: number};
+        let p: Point = {x: 5, y: 10, z: 15};
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Equal<Diagnostic list>(
+        ctx.Report.Diagnostics,
+        [ { Description = "Excess property 'z' in object literal"
+            Reasons = [] } ]
+      )
+
+      Assert.Value(env, "p", "Point")
+    }
+
+  Assert.False(Result.isError result)
+
 [<Fact>]
 let InferObjectDestructuring () =
   let result =

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -758,36 +758,8 @@ module rec Infer =
               match typeAnn with
               | Some typeAnn ->
                 let! t = expandType ctx env None Map.empty typeAnn
-
-                // TODO: extract into a helper function and dedupe with
-                // inferJsxElement
-                match t.Kind with
-                | TypeKind.Object { Elems = elems } ->
-                  let mutable map = Map.empty
-
-                  for elem in elems do
-                    match elem with
-                    | Callable ``function`` ->
-                      return!
-                        Error(
-                          TypeError.SemanticError
-                            "Callable signatures cannot appear in object literals"
-                        )
-                    | Constructor ``function`` ->
-                      return!
-                        Error(
-                          TypeError.SemanticError
-                            "Constructor signatures cannot appear in object literals"
-                        )
-                    | Method(name, fn) -> failwith "todo"
-                    | Getter(name, fn) -> failwith "todo"
-                    | Setter(name, fn) -> failwith "todo"
-                    | Mapped mapped -> failwith "todo"
-                    | Property { Name = name; Type = t } ->
-                      map <- Map.add name t map
-
-                  return Some(map)
-                | _ -> return None
+                let! map = getPropertyMap t
+                return Some map
               | None -> return None
             }
 
@@ -1112,129 +1084,103 @@ module rec Infer =
     (env: Env)
     (jsxElem: JSXElement)
     : Result<Type, TypeError> =
-    result {
-      printfn "inferJsxElement"
+    ctx.PushReport()
 
-      let { JSXElement.Opening = { Attrs = attrs }
-            Children = children } =
-        jsxElem
+    let r =
+      result {
 
-      let retType =
-        { Kind =
-            TypeKind.TypeRef
-              { Name =
-                  QualifiedIdent.Member(
-                    QualifiedIdent.Member(QualifiedIdent.Ident "React", "JSX"),
-                    "Element"
-                  )
-                TypeArgs = None
-                Scheme = None }
-          Provenance = None }
+        let { JSXElement.Opening = { Attrs = attrs }
+              Children = children } =
+          jsxElem
 
-      let intrinsics =
-        { Kind =
-            TypeKind.TypeRef
-              { Name =
-                  QualifiedIdent.Member(
-                    QualifiedIdent.Member(QualifiedIdent.Ident "React", "JSX"),
-                    "IntrinsicElements"
-                  )
-                TypeArgs = None
-                Scheme = None }
-          Provenance = None }
+        let retType =
+          { Kind =
+              TypeKind.TypeRef
+                { Name =
+                    QualifiedIdent.Member(
+                      QualifiedIdent.Member(QualifiedIdent.Ident "React", "JSX"),
+                      "Element"
+                    )
+                  TypeArgs = None
+                  Scheme = None }
+            Provenance = None }
 
-      let! componentProps =
-        match jsxElem.Opening.Name with
-        | QualifiedIdent.Ident s ->
-          if System.Char.IsLower(s, 0) then
-            let key =
-              { Kind = TypeKind.Literal(Literal.String s)
-                Provenance = None }
+        let intrinsics =
+          { Kind =
+              TypeKind.TypeRef
+                { Name =
+                    QualifiedIdent.Member(
+                      QualifiedIdent.Member(QualifiedIdent.Ident "React", "JSX"),
+                      "IntrinsicElements"
+                    )
+                  TypeArgs = None
+                  Scheme = None }
+            Provenance = None }
 
-            let tag =
-              { Kind = TypeKind.Index(intrinsics, key)
-                Provenance = None }
-
-            expandType ctx env None Map.empty tag
-          else
-            Result.Error(
-              TypeError.NotImplemented
-                "TODO: inferJsxElement - handle capitalized JSXElements"
-            )
-
-        | QualifiedIdent.Member(left, right) ->
-          failwith "TODO: inferJsxElement - handle qualified idents"
-
-      // TODO: extract into a helper function and dedupe with inferExpr
-      let! componentPropsMap =
-        result {
-          match componentProps.Kind with
-          | TypeKind.Object { Elems = elems } ->
-            let mutable map = Map.empty
-
-            for elem in elems do
-              match elem with
-              | Callable ``function`` ->
-                return!
-                  Error(
-                    TypeError.SemanticError
-                      "Callable signatures cannot appear in object literals"
-                  )
-              | Constructor ``function`` ->
-                return!
-                  Error(
-                    TypeError.SemanticError
-                      "Constructor signatures cannot appear in object literals"
-                  )
-              | Method(name, fn) -> failwith "todo"
-              | Getter(name, fn) -> failwith "todo"
-              | Setter(name, fn) -> failwith "todo"
-              | Mapped mapped -> failwith "todo"
-              | Property { Name = name; Type = t } -> map <- Map.add name t map
-
-            return map
-          | _ ->
-            return!
-              Error(TypeError.SemanticError "componentProps is not an object")
-        }
-
-      for attr in attrs do
-        match Map.tryFind (PropName.String(attr.Name)) componentPropsMap with
-        | None ->
-          // TODO: report as diagnostics so we can collect multiple errors
-          return!
-            Error(
-              TypeError.SemanticError
-                $"{attr.Name} is not a valid prop for this component"
-            )
-        | Some t ->
-          match attr.Value with
-          | None ->
-            failwith "TODO: inferJsxElement - attr.Value should not be optional"
-          | Some value ->
-            match value with
-            | Str literal ->
-              let prop =
-                { Kind = TypeKind.Literal literal
+        let! componentProps =
+          match jsxElem.Opening.Name with
+          | QualifiedIdent.Ident s ->
+            if System.Char.IsLower(s, 0) then
+              let key =
+                { Kind = TypeKind.Literal(Literal.String s)
                   Provenance = None }
 
-              do! unify ctx env None prop t
-            | JSXAttrValue.JSXExprContainer jsxExprContainer ->
-              let! propType = inferExpr ctx env (Some t) jsxExprContainer.Expr
+              let tag =
+                { Kind = TypeKind.Index(intrinsics, key)
+                  Provenance = None }
 
-              // QUESTION: Do we still need to unify if we have a type annotation
-              // that we pass to `inferExpr`?
-              do! unify ctx env None propType t
-            | JSXAttrValue.JSXElement jsxElement ->
-              // We'll need to pass a type annotation to `inferJsxElement` similar
-              // to what we do for `inferExpr` to handle cases where a prop expects
-              // a certain type of JSX Element
-              failwith "TODO: inferJsxElement - JSXElement"
-            | JSXAttrValue.JSXFragment jsxFragment ->
-              failwith "TODO: inferJsxElement - JSXFragment"
+              expandType ctx env None Map.empty tag
+            else
+              Result.Error(
+                TypeError.NotImplemented
+                  "TODO: inferJsxElement - handle capitalized JSXElements"
+              )
 
-      return retType
-    }
+          | QualifiedIdent.Member(left, right) ->
+            failwith "TODO: inferJsxElement - handle qualified idents"
+
+        let! componentPropsMap = getPropertyMap componentProps
+
+        for attr in attrs do
+          match Map.tryFind (PropName.String(attr.Name)) componentPropsMap with
+          | None ->
+            ctx.Report.AddDiagnostic
+              { Description =
+                  $"No prop named '{attr.Name}' exists in {jsxElem.Opening.Name}'s props"
+                Reasons = [] }
+          | Some t ->
+            match attr.Value with
+            | None ->
+              failwith
+                "TODO: inferJsxElement - attr.Value should not be optional"
+            | Some value ->
+              match value with
+              | Str literal ->
+                let prop =
+                  { Kind = TypeKind.Literal literal
+                    Provenance = None }
+
+                do! unify ctx env None prop t
+              | JSXAttrValue.JSXExprContainer jsxExprContainer ->
+                let! propType = inferExpr ctx env (Some t) jsxExprContainer.Expr
+
+                // QUESTION: Do we still need to unify if we have a type annotation
+                // that we pass to `inferExpr`?
+                do! unify ctx env None propType t
+              | JSXAttrValue.JSXElement jsxElement ->
+                // We'll need to pass a type annotation to `inferJsxElement` similar
+                // to what we do for `inferExpr` to handle cases where a prop expects
+                // a certain type of JSX Element
+                failwith "TODO: inferJsxElement - JSXElement"
+              | JSXAttrValue.JSXFragment jsxFragment ->
+                failwith "TODO: inferJsxElement - JSXFragment"
+
+        return retType
+      }
+
+    ctx.MergeUpReport()
+
+    r
 
   let inferFuncSig
     (ctx: Ctx)


### PR DESCRIPTION
This allows us to infer the type of functions in an expression from type annotations in variable declarations.

TODO:
- [x] add excess property checks for JSX elements
- [x] make this work with JSX elements