### PR TITLE
Add react deps to the playground file descriptors

### DIFF
--- a/playground/typecheck.ts
+++ b/playground/typecheck.ts
@@ -4,6 +4,7 @@ import { File, PreopenDirectory, Directory } from "@bjorn3/browser_wasi_shim";
 // @ts-expect-error: TypeScript doesn't know about import.meta
 const base = import.meta.env.BASE_URL;
 const url = new URL(`${location.protocol}/${location.host}${base}Escalier.Playground.wasm`);
+console.log(`loading wasm bundle from ${url}`);
 
 export async function greet () {
     const inputTxt = await fetch(`${base}input.txt`);
@@ -39,12 +40,44 @@ export async function loadPlugin(): Promise<Plugin> {
         dom: await fetch(`${base}node_modules/typescript/lib/lib.dom.d.ts`).then((res) => res.arrayBuffer()),
     };
 
+    const reactIndex = await fetch(`${base}node_modules/@types/react/index.d.ts`).then((res) => res.arrayBuffer());
+    const reactPkg = await fetch(`${base}node_modules/@types/react/package.json`).then((res) => res.arrayBuffer());
+
+    const csstypeIndex = await fetch(`${base}node_modules/csstype/index.d.ts`).then((res) => res.arrayBuffer());
+    const csstypePkg = await fetch(`${base}node_modules/csstype/package.json`).then((res) => res.arrayBuffer());
+
+    const propTypesIndex = await fetch(`${base}node_modules/@types/prop-types/index.d.ts`).then((res) => res.arrayBuffer());
+    const propTypesPkg = await fetch(`${base}node_modules/@types/prop-types/package.json`).then((res) => res.arrayBuffer());
+
+    const schedulerIndex = await fetch(`${base}node_modules/@types/scheduler/index.d.ts`).then((res) => res.arrayBuffer());
+    const schedulerPkg = await fetch(`${base}node_modules/@types/scheduler/package.json`).then((res) => res.arrayBuffer());
+    const schedulerTracing = await fetch(`${base}node_modules/@types/scheduler/tracing.d.ts`).then((res) => res.arrayBuffer());
+
     const options = {
         useWasi: true,
         enableWasiOutput: true,
         fileDescriptors: [
             new PreopenDirectory(".", {
                 "node_modules": new Directory({
+                    "@types": new Directory({
+                        "prop-types": new Directory({
+                            "index.d.ts": new File(propTypesIndex),
+                            "package.json": new File(propTypesPkg),
+                        }),
+                        "react": new Directory({
+                            "index.d.ts": new File(reactIndex),
+                            "package.json": new File(reactPkg),
+                        }),
+                        "scheduler": new Directory({
+                            "index.d.ts": new File(schedulerIndex),
+                            "package.json": new File(schedulerPkg),
+                            "tracing.d.ts": new File(schedulerTracing),
+                        }),
+                    }),
+                    "csstype": new Directory({
+                        "index.d.ts": new File(csstypeIndex),
+                        "package.json": new File(csstypePkg),
+                    }),
                     "typescript": new Directory({
                         "lib": new Directory({
                             "lib.es5.d.ts": new File(libs.es5),

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -789,7 +789,7 @@ let ImportReact () =
         // NOTE: The type var id will differ dependending on whether we run
         // just this test case or the full test suite.
         // TODO: generalize top-level variable declarations
-        "React.DetailedReactHTMLElement<{}, t2695:HTMLElement>"
+        "React.DetailedReactHTMLElement<{}, t1137:HTMLElement>"
       )
     }
 


### PR DESCRIPTION
This PR also updates Prelude.fs to cache imports after they've been inferred once.