### PR TITLE
Rethrow exceptions when codegen'ing catch clauses

### DIFF
--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenTryCatch.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenTryCatch.verified.txt
@@ -19,6 +19,8 @@ try {
     var temp2;
     if (__error__ == "RangeError") {
       temp2 = null;
+    } else {
+      throw __error__;
     }
     temp1 = temp2;
   }

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenTryCatchFinally.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenTryCatchFinally.verified.txt
@@ -21,6 +21,8 @@ try {
     var temp2;
     if (__error__ == "RangeError") {
       temp2 = null;
+    } else {
+      throw __error__;
     }
     temp1 = temp2;
   }


### PR DESCRIPTION
It's impossible to know if we've handle all possible exceptions that could be thrown from the code inside the `try` block so we rethrow after the handling the exceptions in the `catch` clause to avoid silently swallowing an error.