### PR TITLE
Refactor how enums are parsed and type-checked

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -1498,7 +1498,6 @@ module rec Codegen =
       // TODO: Use `any`?
       failwith "TODO: buildType - Wildcard"
     | TypeKind.Namespace(_) -> failwith "TODO: buildType - Namespace"
-    | TypeKind.EnumVariant(_) -> failwith "TODO: buildType - EnumVariant"
     | TypeKind.Range(_) -> failwith "TODO: buildType - Range"
     | TypeKind.UniqueSymbol(id) -> failwith "TODO: buildType - UniqueSymbol"
     | TypeKind.UniqueNumber(id) -> failwith "TODO: buildType - UniqueNumber"

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -478,10 +478,25 @@ let ParseEnum () =
     """
     enum MyEnum {
       Foo(number, string, boolean),
-      Bar([number, number]),
-      Baz(number | string),
+      Bar {x: number, y: number},
     }
     let value = MyEnum.Foo(5, "hello", true);
+    """
+
+  let ast = Parser.parseScript src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseOptionEnum () =
+  let src =
+    """
+    enum Option<T> {
+      None,
+      Some(T),
+    }
+    let value: Option<string> = Option.Some("hello");
     """
 
   let ast = Parser.parseScript src
@@ -510,9 +525,9 @@ let ParseEnumPatternMatching () =
   let src =
     """
     match value {
-      MyEnum.Foo(a, b, c) => a + b + c,
-      MyEnum.Bar([x, y]) => x * y,
-      MyEnum.Baz(z) => z,
+      MyEnum.Foo[a, b, c] => a + b + c,
+      MyEnum.Bar[x, y] => x * y,
+      MyEnum.Baz[z] => z,
     }
     """
 
@@ -728,7 +743,7 @@ let ParseTypeof () =
 let ParseIfLet () =
   let src =
     """
-    if let Option.Some(x) = maybe {
+    if let Option.Some[x] = maybe {
       print(x);
     };
     """
@@ -760,7 +775,7 @@ let ParseIfLetChaining () =
     """
     if let x = maybe1?.x {
       print(x);
-    } else if let Result.Ok(y) = result {
+    } else if let Result.Ok[y] = result {
       print(y);
     };
     """

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -477,7 +477,7 @@ let ParseEnum () =
   let src =
     """
     enum MyEnum {
-      Foo(number, string, boolean),
+      Foo[number, string, boolean],
       Bar {x: number, y: number},
     }
     let value = MyEnum.Foo(5, "hello", true);
@@ -494,7 +494,7 @@ let ParseOptionEnum () =
     """
     enum Option<T> {
       None,
-      Some(T),
+      Some[T],
     }
     let value: Option<string> = Option.Some("hello");
     """
@@ -509,9 +509,9 @@ let ParseGenericEnum () =
   let src =
     """
     enum MyEnum<A, B, C> {
-      Foo(A),
-      Bar(B),
-      Baz(C),
+      Foo[A],
+      Bar[B],
+      Baz[C],
     }
     """
 

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
@@ -1,8 +1,7 @@
 ﻿input: 
     enum MyEnum {
       Foo(number, string, boolean),
-      Bar([number, number]),
-      Baz(number | string),
+      Bar {x: number, y: number},
     }
     let value = MyEnum.Foo(5, "hello", true);
     
@@ -17,55 +16,65 @@ output: Ok
                     TypeParams = None
                     Variants =
                      [{ Name = "Foo"
-                        TypeAnns =
-                         [{ Kind = Keyword Number
-                            Span = { Start = (Ln: 3, Col: 11)
-                                     Stop = (Ln: 3, Col: 17) }
-                            InferredType = None };
-                          { Kind = Keyword String
-                            Span = { Start = (Ln: 3, Col: 19)
-                                     Stop = (Ln: 3, Col: 25) }
-                            InferredType = None };
-                          { Kind = Keyword Boolean
-                            Span = { Start = (Ln: 3, Col: 27)
-                                     Stop = (Ln: 3, Col: 34) }
-                            InferredType = None }] };
+                        TypeAnn =
+                         Some
+                           { Kind =
+                              Tuple
+                                { Elems =
+                                   [{ Kind = Keyword Number
+                                      Span = { Start = (Ln: 3, Col: 11)
+                                               Stop = (Ln: 3, Col: 17) }
+                                      InferredType = None };
+                                    { Kind = Keyword String
+                                      Span = { Start = (Ln: 3, Col: 19)
+                                               Stop = (Ln: 3, Col: 25) }
+                                      InferredType = None };
+                                    { Kind = Keyword Boolean
+                                      Span = { Start = (Ln: 3, Col: 27)
+                                               Stop = (Ln: 3, Col: 34) }
+                                      InferredType = None }]
+                                  Immutable = false }
+                             Span = { Start = (Ln: 3, Col: 10)
+                                      Stop = (Ln: 3, Col: 35) }
+                             InferredType = None }
+                        Span = { Start = (Ln: 3, Col: 7)
+                                 Stop = (Ln: 4, Col: 7) } };
                       { Name = "Bar"
-                        TypeAnns =
-                         [{ Kind =
-                             Tuple
-                               { Elems =
-                                  [{ Kind = Keyword Number
-                                     Span = { Start = (Ln: 4, Col: 12)
-                                              Stop = (Ln: 4, Col: 18) }
-                                     InferredType = None };
-                                   { Kind = Keyword Number
-                                     Span = { Start = (Ln: 4, Col: 20)
-                                              Stop = (Ln: 4, Col: 26) }
-                                     InferredType = None }]
-                                 Immutable = false }
-                            Span = { Start = (Ln: 4, Col: 11)
-                                     Stop = (Ln: 4, Col: 27) }
-                            InferredType = None }] };
-                      { Name = "Baz"
-                        TypeAnns =
-                         [{ Kind =
-                             Union
-                               [{ Kind = Keyword Number
-                                  Span = { Start = (Ln: 5, Col: 11)
-                                           Stop = (Ln: 5, Col: 18) }
-                                  InferredType = None };
-                                { Kind = Keyword String
-                                  Span = { Start = (Ln: 5, Col: 20)
-                                           Stop = (Ln: 5, Col: 26) }
-                                  InferredType = None }]
-                            Span = { Start = (Ln: 5, Col: 11)
-                                     Stop = (Ln: 5, Col: 26) }
-                            InferredType = None }] }] }
+                        TypeAnn =
+                         Some
+                           { Kind =
+                              Object
+                                { Elems =
+                                   [Property
+                                      { Name = String "x"
+                                        TypeAnn =
+                                         { Kind = Keyword Number
+                                           Span = { Start = (Ln: 4, Col: 15)
+                                                    Stop = (Ln: 4, Col: 21) }
+                                           InferredType = None }
+                                        Optional = false
+                                        Readonly = false
+                                        Static = false };
+                                    Property
+                                      { Name = String "y"
+                                        TypeAnn =
+                                         { Kind = Keyword Number
+                                           Span = { Start = (Ln: 4, Col: 26)
+                                                    Stop = (Ln: 4, Col: 32) }
+                                           InferredType = None }
+                                        Optional = false
+                                        Readonly = false
+                                        Static = false }]
+                                  Immutable = false }
+                             Span = { Start = (Ln: 4, Col: 11)
+                                      Stop = (Ln: 4, Col: 33) }
+                             InferredType = None }
+                        Span = { Start = (Ln: 4, Col: 7)
+                                 Stop = (Ln: 5, Col: 5) } }] }
                Span = { Start = (Ln: 2, Col: 5)
-                        Stop = (Ln: 7, Col: 5) } }
+                        Stop = (Ln: 6, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)
-                   Stop = (Ln: 7, Col: 5) } };
+                   Stop = (Ln: 6, Col: 5) } };
       Stmt
         { Kind =
            Decl
@@ -75,8 +84,8 @@ output: Ok
                     Pattern = { Kind = Ident { Name = "value"
                                                IsMut = false
                                                Assertion = None }
-                                Span = { Start = (Ln: 7, Col: 9)
-                                         Stop = (Ln: 7, Col: 15) }
+                                Span = { Start = (Ln: 6, Col: 9)
+                                         Stop = (Ln: 6, Col: 15) }
                                 InferredType = None }
                     TypeAnn = None
                     Init =
@@ -86,33 +95,33 @@ output: Ok
                             { Callee =
                                { Kind =
                                   Member ({ Kind = Identifier "MyEnum"
-                                            Span = { Start = (Ln: 7, Col: 17)
-                                                     Stop = (Ln: 7, Col: 23) }
+                                            Span = { Start = (Ln: 6, Col: 17)
+                                                     Stop = (Ln: 6, Col: 23) }
                                             InferredType = None }, "Foo", false)
-                                 Span = { Start = (Ln: 7, Col: 17)
-                                          Stop = (Ln: 7, Col: 27) }
+                                 Span = { Start = (Ln: 6, Col: 17)
+                                          Stop = (Ln: 6, Col: 27) }
                                  InferredType = None }
                               TypeArgs = None
                               Args =
                                [{ Kind = Literal (Number (Int 5))
-                                  Span = { Start = (Ln: 7, Col: 28)
-                                           Stop = (Ln: 7, Col: 29) }
+                                  Span = { Start = (Ln: 6, Col: 28)
+                                           Stop = (Ln: 6, Col: 29) }
                                   InferredType = None };
                                 { Kind = Literal (String "hello")
-                                  Span = { Start = (Ln: 7, Col: 31)
-                                           Stop = (Ln: 7, Col: 38) }
+                                  Span = { Start = (Ln: 6, Col: 31)
+                                           Stop = (Ln: 6, Col: 38) }
                                   InferredType = None };
                                 { Kind = Literal (Boolean true)
-                                  Span = { Start = (Ln: 7, Col: 40)
-                                           Stop = (Ln: 7, Col: 44) }
+                                  Span = { Start = (Ln: 6, Col: 40)
+                                           Stop = (Ln: 6, Col: 44) }
                                   InferredType = None }]
                               OptChain = false
                               Throws = None }
-                         Span = { Start = (Ln: 7, Col: 17)
-                                  Stop = (Ln: 7, Col: 45) }
+                         Span = { Start = (Ln: 6, Col: 17)
+                                  Stop = (Ln: 6, Col: 45) }
                          InferredType = None }
                     Else = None }
-               Span = { Start = (Ln: 7, Col: 5)
-                        Stop = (Ln: 8, Col: 5) } }
-          Span = { Start = (Ln: 7, Col: 5)
-                   Stop = (Ln: 8, Col: 5) } }] }
+               Span = { Start = (Ln: 6, Col: 5)
+                        Stop = (Ln: 7, Col: 5) } }
+          Span = { Start = (Ln: 6, Col: 5)
+                   Stop = (Ln: 7, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
@@ -1,6 +1,6 @@
 ﻿input: 
     enum MyEnum {
-      Foo(number, string, boolean),
+      Foo[number, string, boolean],
       Bar {x: number, y: number},
     }
     let value = MyEnum.Foo(5, "hello", true);

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnumPatternMatching.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnumPatternMatching.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: 
     match value {
-      MyEnum.Foo(a, b, c) => a + b + c,
-      MyEnum.Bar([x, y]) => x * y,
-      MyEnum.Baz(z) => z,
+      MyEnum.Foo[a, b, c] => a + b + c,
+      MyEnum.Bar[x, y] => x * y,
+      MyEnum.Baz[z] => z,
     }
     
 output: Ok
@@ -22,26 +22,33 @@ output: Ok
                        { Kind =
                           Enum
                             { Ident = Member (Ident "MyEnum", "Foo")
-                              Args =
+                              Arg =
                                Some
-                                 [{ Kind = Ident { Name = "a"
-                                                   IsMut = false
-                                                   Assertion = None }
-                                    Span = { Start = (Ln: 3, Col: 18)
-                                             Stop = (Ln: 3, Col: 19) }
-                                    InferredType = None };
-                                  { Kind = Ident { Name = "b"
-                                                   IsMut = false
-                                                   Assertion = None }
-                                    Span = { Start = (Ln: 3, Col: 21)
-                                             Stop = (Ln: 3, Col: 22) }
-                                    InferredType = None };
-                                  { Kind = Ident { Name = "c"
-                                                   IsMut = false
-                                                   Assertion = None }
-                                    Span = { Start = (Ln: 3, Col: 24)
-                                             Stop = (Ln: 3, Col: 25) }
-                                    InferredType = None }] }
+                                 { Kind =
+                                    Tuple
+                                      { Elems =
+                                         [{ Kind = Ident { Name = "a"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 3, Col: 18)
+                                                     Stop = (Ln: 3, Col: 19) }
+                                            InferredType = None };
+                                          { Kind = Ident { Name = "b"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 3, Col: 21)
+                                                     Stop = (Ln: 3, Col: 22) }
+                                            InferredType = None };
+                                          { Kind = Ident { Name = "c"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 3, Col: 24)
+                                                     Stop = (Ln: 3, Col: 25) }
+                                            InferredType = None }]
+                                        Immutable = false }
+                                   Span = { Start = (Ln: 3, Col: 17)
+                                            Stop = (Ln: 3, Col: 27) }
+                                   InferredType = None } }
                          Span = { Start = (Ln: 3, Col: 7)
                                   Stop = (Ln: 3, Col: 27) }
                          InferredType = None }
@@ -77,29 +84,29 @@ output: Ok
                        { Kind =
                           Enum
                             { Ident = Member (Ident "MyEnum", "Bar")
-                              Args =
+                              Arg =
                                Some
-                                 [{ Kind =
-                                     Tuple
-                                       { Elems =
-                                          [{ Kind = Ident { Name = "x"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 4, Col: 19)
-                                                      Stop = (Ln: 4, Col: 20) }
-                                             InferredType = None };
-                                           { Kind = Ident { Name = "y"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 4, Col: 22)
-                                                      Stop = (Ln: 4, Col: 23) }
-                                             InferredType = None }]
-                                         Immutable = false }
-                                    Span = { Start = (Ln: 4, Col: 18)
-                                             Stop = (Ln: 4, Col: 24) }
-                                    InferredType = None }] }
+                                 { Kind =
+                                    Tuple
+                                      { Elems =
+                                         [{ Kind = Ident { Name = "x"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 4, Col: 18)
+                                                     Stop = (Ln: 4, Col: 19) }
+                                            InferredType = None };
+                                          { Kind = Ident { Name = "y"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 4, Col: 21)
+                                                     Stop = (Ln: 4, Col: 22) }
+                                            InferredType = None }]
+                                        Immutable = false }
+                                   Span = { Start = (Ln: 4, Col: 17)
+                                            Stop = (Ln: 4, Col: 24) }
+                                   InferredType = None } }
                          Span = { Start = (Ln: 4, Col: 7)
-                                  Stop = (Ln: 4, Col: 26) }
+                                  Stop = (Ln: 4, Col: 24) }
                          InferredType = None }
                       Guard = None
                       Body =
@@ -107,15 +114,15 @@ output: Ok
                          { Kind =
                             Binary
                               ("*", { Kind = Identifier "x"
-                                      Span = { Start = (Ln: 4, Col: 29)
-                                               Stop = (Ln: 4, Col: 31) }
+                                      Span = { Start = (Ln: 4, Col: 27)
+                                               Stop = (Ln: 4, Col: 29) }
                                       InferredType = None },
                                { Kind = Identifier "y"
-                                 Span = { Start = (Ln: 4, Col: 33)
-                                          Stop = (Ln: 4, Col: 34) }
+                                 Span = { Start = (Ln: 4, Col: 31)
+                                          Stop = (Ln: 4, Col: 32) }
                                  InferredType = None })
-                           Span = { Start = (Ln: 4, Col: 29)
-                                    Stop = (Ln: 4, Col: 34) }
+                           Span = { Start = (Ln: 4, Col: 27)
+                                    Stop = (Ln: 4, Col: 32) }
                            InferredType = None } };
                     { Span = { Start = (Ln: 5, Col: 7)
                                Stop = (Ln: 6, Col: 5) }
@@ -123,12 +130,21 @@ output: Ok
                        { Kind =
                           Enum
                             { Ident = Member (Ident "MyEnum", "Baz")
-                              Args = Some [{ Kind = Ident { Name = "z"
-                                                            IsMut = false
-                                                            Assertion = None }
-                                             Span = { Start = (Ln: 5, Col: 18)
-                                                      Stop = (Ln: 5, Col: 19) }
-                                             InferredType = None }] }
+                              Arg =
+                               Some
+                                 { Kind =
+                                    Tuple
+                                      { Elems =
+                                         [{ Kind = Ident { Name = "z"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 5, Col: 18)
+                                                     Stop = (Ln: 5, Col: 19) }
+                                            InferredType = None }]
+                                        Immutable = false }
+                                   Span = { Start = (Ln: 5, Col: 17)
+                                            Stop = (Ln: 5, Col: 21) }
+                                   InferredType = None } }
                          Span = { Start = (Ln: 5, Col: 7)
                                   Stop = (Ln: 5, Col: 21) }
                          InferredType = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
@@ -31,23 +31,53 @@ output: Ok
                           Default = None }]
                     Variants =
                      [{ Name = "Foo"
-                        TypeAnns = [{ Kind = TypeRef { Ident = Ident "A"
-                                                       TypeArgs = None }
-                                      Span = { Start = (Ln: 3, Col: 11)
-                                               Stop = (Ln: 3, Col: 12) }
-                                      InferredType = None }] };
+                        TypeAnn =
+                         Some
+                           { Kind =
+                              Tuple
+                                { Elems = [{ Kind = TypeRef { Ident = Ident "A"
+                                                              TypeArgs = None }
+                                             Span = { Start = (Ln: 3, Col: 11)
+                                                      Stop = (Ln: 3, Col: 12) }
+                                             InferredType = None }]
+                                  Immutable = false }
+                             Span = { Start = (Ln: 3, Col: 10)
+                                      Stop = (Ln: 3, Col: 13) }
+                             InferredType = None }
+                        Span = { Start = (Ln: 3, Col: 7)
+                                 Stop = (Ln: 4, Col: 7) } };
                       { Name = "Bar"
-                        TypeAnns = [{ Kind = TypeRef { Ident = Ident "B"
-                                                       TypeArgs = None }
-                                      Span = { Start = (Ln: 4, Col: 11)
-                                               Stop = (Ln: 4, Col: 12) }
-                                      InferredType = None }] };
+                        TypeAnn =
+                         Some
+                           { Kind =
+                              Tuple
+                                { Elems = [{ Kind = TypeRef { Ident = Ident "B"
+                                                              TypeArgs = None }
+                                             Span = { Start = (Ln: 4, Col: 11)
+                                                      Stop = (Ln: 4, Col: 12) }
+                                             InferredType = None }]
+                                  Immutable = false }
+                             Span = { Start = (Ln: 4, Col: 10)
+                                      Stop = (Ln: 4, Col: 13) }
+                             InferredType = None }
+                        Span = { Start = (Ln: 4, Col: 7)
+                                 Stop = (Ln: 5, Col: 7) } };
                       { Name = "Baz"
-                        TypeAnns = [{ Kind = TypeRef { Ident = Ident "C"
-                                                       TypeArgs = None }
-                                      Span = { Start = (Ln: 5, Col: 11)
-                                               Stop = (Ln: 5, Col: 12) }
-                                      InferredType = None }] }] }
+                        TypeAnn =
+                         Some
+                           { Kind =
+                              Tuple
+                                { Elems = [{ Kind = TypeRef { Ident = Ident "C"
+                                                              TypeArgs = None }
+                                             Span = { Start = (Ln: 5, Col: 11)
+                                                      Stop = (Ln: 5, Col: 12) }
+                                             InferredType = None }]
+                                  Immutable = false }
+                             Span = { Start = (Ln: 5, Col: 10)
+                                      Stop = (Ln: 5, Col: 13) }
+                             InferredType = None }
+                        Span = { Start = (Ln: 5, Col: 7)
+                                 Stop = (Ln: 6, Col: 5) } }] }
                Span = { Start = (Ln: 2, Col: 5)
                         Stop = (Ln: 7, Col: 5) } }
           Span = { Start = (Ln: 2, Col: 5)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: 
     enum MyEnum<A, B, C> {
-      Foo(A),
-      Bar(B),
-      Baz(C),
+      Foo[A],
+      Bar[B],
+      Baz[C],
     }
     
 output: Ok

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLet.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLet.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    if let Option.Some(x) = maybe {
+    if let Option.Some[x] = maybe {
       print(x);
     };
     
@@ -11,13 +11,23 @@ output: Ok
              { Kind =
                 IfLet
                   ({ Kind =
-                      Enum { Ident = Member (Ident "Option", "Some")
-                             Args = Some [{ Kind = Ident { Name = "x"
-                                                           IsMut = false
-                                                           Assertion = None }
-                                            Span = { Start = (Ln: 2, Col: 24)
-                                                     Stop = (Ln: 2, Col: 25) }
-                                            InferredType = None }] }
+                      Enum
+                        { Ident = Member (Ident "Option", "Some")
+                          Arg =
+                           Some
+                             { Kind =
+                                Tuple
+                                  { Elems =
+                                     [{ Kind = Ident { Name = "x"
+                                                       IsMut = false
+                                                       Assertion = None }
+                                        Span = { Start = (Ln: 2, Col: 24)
+                                                 Stop = (Ln: 2, Col: 25) }
+                                        InferredType = None }]
+                                    Immutable = false }
+                               Span = { Start = (Ln: 2, Col: 23)
+                                        Stop = (Ln: 2, Col: 27) }
+                               InferredType = None } }
                      Span = { Start = (Ln: 2, Col: 12)
                               Stop = (Ln: 2, Col: 27) }
                      InferredType = None }, { Kind = Identifier "maybe"

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLetChaining.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLetChaining.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
     if let x = maybe1?.x {
       print(x);
-    } else if let Result.Ok(y) = result {
+    } else if let Result.Ok[y] = result {
       print(y);
     };
     
@@ -55,13 +55,23 @@ output: Ok
                              ({ Kind =
                                  Enum
                                    { Ident = Member (Ident "Result", "Ok")
-                                     Args =
-                                      Some [{ Kind = Ident { Name = "y"
-                                                             IsMut = false
-                                                             Assertion = None }
-                                              Span = { Start = (Ln: 4, Col: 29)
-                                                       Stop = (Ln: 4, Col: 30) }
-                                              InferredType = None }] }
+                                     Arg =
+                                      Some
+                                        { Kind =
+                                           Tuple
+                                             { Elems =
+                                                [{ Kind =
+                                                    Ident { Name = "y"
+                                                            IsMut = false
+                                                            Assertion = None }
+                                                   Span =
+                                                    { Start = (Ln: 4, Col: 29)
+                                                      Stop = (Ln: 4, Col: 30) }
+                                                   InferredType = None }]
+                                               Immutable = false }
+                                          Span = { Start = (Ln: 4, Col: 28)
+                                                   Stop = (Ln: 4, Col: 32) }
+                                          InferredType = None } }
                                 Span = { Start = (Ln: 4, Col: 19)
                                          Stop = (Ln: 4, Col: 32) }
                                 InferredType = None },

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
@@ -1,0 +1,99 @@
+﻿input: 
+    enum Option<T> {
+      None,
+      Some(T),
+    }
+    let value: Option<string> = Option.Some("hello");
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                EnumDecl
+                  { Name = "Option"
+                    TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 17)
+                                                  Stop = (Ln: 2, Col: 18) }
+                                         Name = "T"
+                                         Constraint = None
+                                         Default = None }]
+                    Variants =
+                     [{ Name = "None"
+                        TypeAnn = None
+                        Span = { Start = (Ln: 3, Col: 7)
+                                 Stop = (Ln: 4, Col: 7) } };
+                      { Name = "Some"
+                        TypeAnn =
+                         Some
+                           { Kind =
+                              Tuple
+                                { Elems = [{ Kind = TypeRef { Ident = Ident "T"
+                                                              TypeArgs = None }
+                                             Span = { Start = (Ln: 4, Col: 12)
+                                                      Stop = (Ln: 4, Col: 13) }
+                                             InferredType = None }]
+                                  Immutable = false }
+                             Span = { Start = (Ln: 4, Col: 11)
+                                      Stop = (Ln: 4, Col: 14) }
+                             InferredType = None }
+                        Span = { Start = (Ln: 4, Col: 7)
+                                 Stop = (Ln: 5, Col: 5) } }] }
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 6, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 6, Col: 5) } };
+      Stmt
+        { Kind =
+           Decl
+             { Kind =
+                VarDecl
+                  { Declare = false
+                    Pattern = { Kind = Ident { Name = "value"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 6, Col: 9)
+                                         Stop = (Ln: 6, Col: 14) }
+                                InferredType = None }
+                    TypeAnn =
+                     Some
+                       { Kind =
+                          TypeRef
+                            { Ident = Ident "Option"
+                              TypeArgs =
+                               Some [{ Kind = Keyword String
+                                       Span = { Start = (Ln: 6, Col: 23)
+                                                Stop = (Ln: 6, Col: 29) }
+                                       InferredType = None }] }
+                         Span = { Start = (Ln: 6, Col: 16)
+                                  Stop = (Ln: 6, Col: 31) }
+                         InferredType = None }
+                    Init =
+                     Some
+                       { Kind =
+                          Call
+                            { Callee =
+                               { Kind =
+                                  Member
+                                    ({ Kind = Identifier "Option"
+                                       Span = { Start = (Ln: 6, Col: 33)
+                                                Stop = (Ln: 6, Col: 39) }
+                                       InferredType = None }, "Some", false)
+                                 Span = { Start = (Ln: 6, Col: 33)
+                                          Stop = (Ln: 6, Col: 44) }
+                                 InferredType = None }
+                              TypeArgs = None
+                              Args = [{ Kind = Literal (String "hello")
+                                        Span = { Start = (Ln: 6, Col: 45)
+                                                 Stop = (Ln: 6, Col: 52) }
+                                        InferredType = None }]
+                              OptChain = false
+                              Throws = None }
+                         Span = { Start = (Ln: 6, Col: 33)
+                                  Stop = (Ln: 6, Col: 53) }
+                         InferredType = None }
+                    Else = None }
+               Span = { Start = (Ln: 6, Col: 5)
+                        Stop = (Ln: 7, Col: 5) } }
+          Span = { Start = (Ln: 6, Col: 5)
+                   Stop = (Ln: 7, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
     enum Option<T> {
       None,
-      Some(T),
+      Some[T],
     }
     let value: Option<string> = Option.Some("hello");
     

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -1564,7 +1564,7 @@ module Parser =
         InferredType = None }
 
   let private tupleVariant: Parser<TypeAnn, unit> =
-    between (strWs "(") (strWs ")") (sepEndBy typeAnn (strWs ",")) |> withSpan
+    between (strWs "[") (strWs "]") (sepEndBy typeAnn (strWs ",")) |> withSpan
     |>> fun (typeAnns, span) ->
       { Kind = TypeAnnKind.Tuple { Elems = typeAnns; Immutable = false }
         Span = span

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -1554,17 +1554,33 @@ module Parser =
               Elems = objTypeElems }
         Span = span }
 
+  let private objectVariant: Parser<TypeAnn, unit> =
+    withSpan (
+      between (strWs "{") (strWs "}") (sepEndBy objTypeAnnElem (strWs ","))
+    )
+    |>> fun (objElems, span) ->
+      { Kind = TypeAnnKind.Object { Elems = objElems; Immutable = false }
+        Span = span
+        InferredType = None }
+
+  let private tupleVariant: Parser<TypeAnn, unit> =
+    between (strWs "(") (strWs ")") (sepEndBy typeAnn (strWs ",")) |> withSpan
+    |>> fun (typeAnns, span) ->
+      { Kind = TypeAnnKind.Tuple { Elems = typeAnns; Immutable = false }
+        Span = span
+        InferredType = None }
+
   let private enumVariant: Parser<EnumVariant, unit> =
     pipe4
       getPosition
       ident
-      (between (strWs "(") (strWs ")") (sepEndBy typeAnn (strWs ",")))
+      (opt (choice [ objectVariant; tupleVariant ]))
       (strWs "," >>. getPosition)
-    <| fun start name typeAnns stop ->
+    <| fun start name kind stop ->
 
-      let span = { Start = start; Stop = stop }
-
-      { Name = name; TypeAnns = typeAnns }
+      { Name = name
+        TypeAnn = kind
+        Span = { Start = start; Stop = stop } }
 
   let private enumDecl: Parser<Decl, unit> =
     pipe5
@@ -1729,12 +1745,12 @@ module Parser =
       tuple3
         ident
         (strWs "." >>. ident)
-        (opt (between (strWs "(") (strWs ")") (sepEndBy pattern (strWs ","))))
+        (opt (choice [ objectPattern; tuplePattern ]))
     )
-    |>> fun ((qualifier, ident, args), span) ->
+    |>> fun ((qualifier, ident, arg), span) ->
       let ident = QualifiedIdent.Member(QualifiedIdent.Ident qualifier, ident)
 
-      { Pattern.Kind = PatternKind.Enum { Ident = ident; Args = args }
+      { Pattern.Kind = PatternKind.Enum { Ident = ident; Arg = arg }
         Span = span
         InferredType = None }
 

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -58,7 +58,7 @@ let InfersTypeofWellknownSymbol () =
       let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Report.Diagnostics)
-      Assert.Value(env, "iterator", "symbol()")
+      Assert.Value(env, "iterator", "unique symbol")
     }
 
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -1,5 +1,6 @@
 module Tests
 
+open Escalier.Data.Common
 open FParsec
 open FsToolkit.ErrorHandling
 open Xunit
@@ -897,12 +898,16 @@ let InferEnum () =
       Assert.Type(
         env,
         "MyEnum",
-        "Foo(number, string, boolean) | Bar([number, number]) | Baz((number | string))"
+        "{readonly __TAG__: unique symbol} & [number, string, boolean] | {readonly __TAG__: unique symbol} & [[number, number]] | {readonly __TAG__: unique symbol} & [number | string]"
       )
 
       // TODO: how do we include `MyEnum.` in the type?
       // What does this mean in the context of creating new enums from existings enums
-      Assert.Value(env, "value", "Foo(number, string, boolean)")
+      Assert.Value(
+        env,
+        "value",
+        "{readonly __TAG__: unique symbol} & [number, string, boolean]"
+      )
     }
 
   printfn "result = %A" result
@@ -929,7 +934,7 @@ let InferEnumVariantIsSubtypeOfEnum () =
       Assert.Type(
         env,
         "MyEnum",
-        "Foo(number, string, boolean) | Bar([number, number]) | Baz((number | string))"
+        "{readonly __TAG__: unique symbol} & [number, string, boolean] | {readonly __TAG__: unique symbol} & [[number, number]] | {readonly __TAG__: unique symbol} & [number | string]"
       )
 
       Assert.Value(env, "value", "MyEnum")
@@ -954,11 +959,22 @@ let InferGenericEnum () =
       let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Report.Diagnostics)
-      Assert.Type(env, "MyEnum", "<A, B, C>(Foo(A) | Bar(B) | Baz(C))")
+
+      let! enumType =
+        env.GetScheme(QualifiedIdent.Ident "MyEnum")
+        |> Result.mapError CompileError.TypeError
+
+      printfn $"enumType = {enumType}"
+
+      Assert.Type(
+        env,
+        "MyEnum",
+        "<A, B, C>({readonly __TAG__: unique symbol} & [A] | {readonly __TAG__: unique symbol} & [B] | {readonly __TAG__: unique symbol} & [C])"
+      )
 
       // TODO: how do we include `MyEnum.` in the type?
       // What does this mean in the context of creating new enums from existings enums
-      Assert.Value(env, "value", "Foo(5)")
+      Assert.Value(env, "value", "{readonly __TAG__: unique symbol} & [5]")
     }
 
   printfn "result = %A" result
@@ -977,16 +993,28 @@ let InferGenericEnumWithSubtyping () =
         }
         let value: MyEnum<number, string, boolean> = MyEnum.Foo(5);
         let x = match value {
-          MyEnum.Foo(a) => a,
-          MyEnum.Bar(b) => b,
-          MyEnum.Baz(c) => c,
+          MyEnum.Foo[a] => a,
+          MyEnum.Bar[b] => b,
+          MyEnum.Baz[c] => c,
         };
         """
 
       let! ctx, env = inferModule src
 
       Assert.Empty(ctx.Report.Diagnostics)
-      Assert.Type(env, "MyEnum", "<A, B, C>(Foo(A) | Bar(B) | Baz(C))")
+
+      let! enumType =
+        env.GetScheme(QualifiedIdent.Ident "MyEnum")
+        |> Result.mapError CompileError.TypeError
+
+      printfn $"enumType = {enumType}"
+
+      Assert.Type(
+        env,
+        "MyEnum",
+        "<A, B, C>({readonly __TAG__: unique symbol} & [A] | {readonly __TAG__: unique symbol} & [B] | {readonly __TAG__: unique symbol} & [C])"
+      )
+
       Assert.Value(env, "value", "MyEnum<number, string, boolean>")
       Assert.Value(env, "x", "number | string | boolean")
     }
@@ -1008,9 +1036,9 @@ let InferEnumPatternMatching () =
         let value: MyEnum = MyEnum.Foo(5, "hello", true);
 
         let x = match value {
-          MyEnum.Foo(x, y, z) => x,
-          MyEnum.Bar([x, y]) => x,
-          MyEnum.Baz({x, y}) => x,
+          MyEnum.Foo[x, y, z] => x,
+          MyEnum.Bar[[x, y]] => x,
+          MyEnum.Baz[{x, y}] => x,
         };
         """
 
@@ -1018,10 +1046,16 @@ let InferEnumPatternMatching () =
 
       Assert.Empty(ctx.Report.Diagnostics)
 
+      let! enumType =
+        env.GetScheme(QualifiedIdent.Ident "MyEnum")
+        |> Result.mapError CompileError.TypeError
+
+      printfn $"enumType = {enumType}"
+
       Assert.Type(
         env,
         "MyEnum",
-        "Foo(number, string, boolean) | Bar([number, number]) | Baz({x: number, y: number})"
+        "{readonly __TAG__: unique symbol} & [number, string, boolean] | {readonly __TAG__: unique symbol} & [[number, number]] | {readonly __TAG__: unique symbol} & [{x: number, y: number}]"
       )
 
       Assert.Value(env, "x", "number")

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -884,9 +884,9 @@ let InferEnum () =
       let src =
         """
         enum MyEnum {
-          Foo(number, string, boolean),
-          Bar([number, number]),
-          Baz(number | string),
+          Foo[number, string, boolean],
+          Bar[[number, number]],
+          Baz[number | string],
         }
         let value = MyEnum.Foo(5, "hello", true);
         """
@@ -920,9 +920,9 @@ let InferEnumVariantIsSubtypeOfEnum () =
       let src =
         """
         enum MyEnum {
-          Foo(number, string, boolean),
-          Bar([number, number]),
-          Baz(number | string),
+          Foo[number, string, boolean],
+          Bar[[number, number]],
+          Baz[number | string],
         }
         let value: MyEnum = MyEnum.Foo(5, "hello", true);
         """
@@ -949,9 +949,9 @@ let InferGenericEnum () =
       let src =
         """
         enum MyEnum<A, B, C> {
-          Foo(A),
-          Bar(B),
-          Baz(C),
+          Foo[A],
+          Bar[B],
+          Baz[C],
         }
         let value = MyEnum.Foo(5);
         """
@@ -987,9 +987,9 @@ let InferGenericEnumWithSubtyping () =
       let src =
         """
         enum MyEnum<A, B, C> {
-          Foo(A),
-          Bar(B),
-          Baz(C),
+          Foo[A],
+          Bar[B],
+          Baz[C],
         }
         let value: MyEnum<number, string, boolean> = MyEnum.Foo(5);
         let x = match value {
@@ -1029,16 +1029,16 @@ let InferEnumPatternMatching () =
       let src =
         """
         enum MyEnum {
-          Foo(number, string, boolean),
-          Bar([number, number]),
-          Baz({x: number, y: number}),
+          Foo[number, string, boolean],
+          Bar[[number, number]],
+          Baz {x: number, y: number},
         }
         let value: MyEnum = MyEnum.Foo(5, "hello", true);
 
         let x = match value {
           MyEnum.Foo[x, y, z] => x,
           MyEnum.Bar[[x, y]] => x,
-          MyEnum.Baz[{x, y}] => x,
+          MyEnum.Baz {x, y} => x,
         };
         """
 
@@ -1055,7 +1055,7 @@ let InferEnumPatternMatching () =
       Assert.Type(
         env,
         "MyEnum",
-        "{readonly __TAG__: unique symbol} & [number, string, boolean] | {readonly __TAG__: unique symbol} & [[number, number]] | {readonly __TAG__: unique symbol} & [{x: number, y: number}]"
+        "{readonly __TAG__: unique symbol} & [number, string, boolean] | {readonly __TAG__: unique symbol} & [[number, number]] | {readonly __TAG__: unique symbol} & {x: number, y: number}"
       )
 
       Assert.Value(env, "x", "number")

--- a/src/Escalier.TypeChecker/Folder.fs
+++ b/src/Escalier.TypeChecker/Folder.fs
@@ -94,11 +94,6 @@ module Folder =
                   Immutable = immutable
                   Interface = int }
             Provenance = None }
-        | TypeKind.EnumVariant variant ->
-          let types = List.map fold variant.Types
-
-          { Kind = TypeKind.EnumVariant { variant with Types = types }
-            Provenance = None }
         | TypeKind.Rest t ->
           { Kind = TypeKind.Rest(fold t)
             Provenance = None }

--- a/src/Escalier.TypeChecker/QualifiedGraph.fs
+++ b/src/Escalier.TypeChecker/QualifiedGraph.fs
@@ -32,6 +32,7 @@ type QualifiedIdent =
 // - infer them in the correct order
 
 // TODO: use a list instead of QualifiedIdent which is recursive
+[<RequireQualifiedAccess>]
 type QDeclIdent =
   | Type of QualifiedIdent
   | Value of QualifiedIdent

--- a/src/Escalier.TypeChecker/Visitor.fs
+++ b/src/Escalier.TypeChecker/Visitor.fs
@@ -1,8 +1,9 @@
 namespace Escalier.TypeChecker
 
+open Escalier.Data.Syntax
+
 // TODO: move to Escalier.Data.Visitor
 module rec ExprVisitor =
-  open Escalier.Data.Syntax
 
   type SyntaxVisitor<'S> =
     { VisitExpr: Expr * 'S -> bool * 'S
@@ -237,7 +238,7 @@ module rec ExprVisitor =
     | DeclKind.EnumDecl { Variants = variants } ->
       List.iter
         (fun (variant: EnumVariant) ->
-          List.iter (walkTypeAnn visitor state) variant.TypeAnns)
+          Option.iter (walkTypeAnn visitor state) variant.TypeAnn)
         variants
     | DeclKind.NamespaceDecl { Body = body } ->
       List.iter (walkDecl visitor state) body
@@ -287,8 +288,7 @@ module rec ExprVisitor =
         | PatternKind.Wildcard _ -> ()
         | PatternKind.Literal _ -> ()
         | PatternKind.Rest arg -> (walk state) arg
-        | PatternKind.Enum { Args = args } ->
-          Option.iter (List.iter (walk state)) args
+        | PatternKind.Enum { Arg = arg } -> Option.iter (walk state) arg
 
     walk state pat
 
@@ -436,7 +436,6 @@ module rec TypeVisitor =
       | TypeKind.Array { Elem = elem; Length = length } ->
         walk elem
         walk length
-      | TypeKind.EnumVariant { Types = types } -> List.iter walk types
       | TypeKind.KeyOf t -> walk t
       | TypeKind.Index(target, index) ->
         walk target


### PR DESCRIPTION
In particular, enum variants can be wrap either a tuple or an object or be empty.  The variants are inferred as:
```ts
{ __TAG__: unique symbol}; // empty 
{ __TAG__: unique symbol} & [number, string]; // tuple
{ __TAG__: unique symbol} & {x: number, y: number}; // object
```
The `__TAG__` is the unique symbol assigned to `MyEnum.MyVariant`.

The reason for odd variant types is that we want to support both tuple and object payloads while also support interop with TypeScript tagged unions in the future.