### PR TITLE
maintain exactness

### DIFF
--- a/src/Escalier.TypeChecker.Tests/Exact.fs
+++ b/src/Escalier.TypeChecker.Tests/Exact.fs
@@ -1,8 +1,10 @@
 module Escalier.TypeChecker.Tests.Exact
 
-open Escalier.TypeChecker.Error
 open FsToolkit.ErrorHandling
 open Xunit
+
+open Escalier.TypeChecker.Error
+open Escalier.TypeChecker.Unify
 
 open TestUtils
 
@@ -142,6 +144,84 @@ let SpreadingAnExactObjectAndInexactObjectIsInexact () =
 
       Assert.Empty(ctx.Report.Diagnostics)
       Assert.Value(env, "foobar", "{msg: string, flag: boolean, ...}")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let InexactMappedTypesPreserveExactness () =
+  let res =
+    result {
+      let src =
+        """
+        type MyPartial<T> = {[K]?: T[K] for K in keyof T, ...};
+        type Exact = {msg: string, flag: boolean};
+        type Inexact = {msg: string, flag: boolean, ...};
+        
+        type PartialExact = MyPartial<Exact>;
+        type PartialInexact = MyPartial<Inexact>;
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      let! t =
+        expandScheme ctx env None (env.FindScheme "PartialExact") Map.empty None
+        |> Result.mapError CompileError.TypeError
+
+      Assert.Equal(t.ToString(), "{flag?: boolean, msg?: string}")
+
+      let! t =
+        expandScheme
+          ctx
+          env
+          None
+          (env.FindScheme "PartialInexact")
+          Map.empty
+          None
+        |> Result.mapError CompileError.TypeError
+
+      Assert.Equal(t.ToString(), "{flag?: boolean, msg?: string, ...}")
+    }
+
+  Assert.False(Result.isError res)
+
+
+let ExactMappedTypesPreserveExactness () =
+  let res =
+    result {
+      let src =
+        """
+        type MyPartial<T> = {[K]?: T[K] for K in keyof T};
+        type Exact = {msg: string, flag: boolean};
+        type Inexact = {msg: string, flag: boolean, ...};
+        
+        type PartialExact = MyPartial<Exact>;
+        type PartialInexact = MyPartial<Inexact>;
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      let! t =
+        expandScheme ctx env None (env.FindScheme "PartialExact") Map.empty None
+        |> Result.mapError CompileError.TypeError
+
+      Assert.Equal(t.ToString(), "{flag?: boolean, msg?: string}")
+
+      let! t =
+        expandScheme
+          ctx
+          env
+          None
+          (env.FindScheme "PartialInexact")
+          Map.empty
+          None
+        |> Result.mapError CompileError.TypeError
+
+      Assert.Equal(t.ToString(), "{flag?: boolean, msg?: string, ...}")
     }
 
   Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/PatternMatching.fs
+++ b/src/Escalier.TypeChecker.Tests/PatternMatching.fs
@@ -330,3 +330,30 @@ let PatternMatchingDisallowsPartialMappingOfTuples () =
   | Error errorValue -> printfn $"res = Error({errorValue})"
 
   Assert.True(Result.isError res)
+
+[<Fact>]
+let PatternMatchingNestedTypes () =
+  let res =
+    result {
+      let src =
+        """
+        declare let value: {a: [number] | {x: number}} | {b: [number] | {y: number}};
+        let result = match value {
+          {a: [x]} => x,
+          {a: {x}} => x,
+          {b: [y]} => y,
+          {b: {y}} => y,
+        };
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+      Assert.Value(env, "result", "number")
+    }
+
+  match res with
+  | Ok resultValue -> printfn $"res = Ok({resultValue})"
+  | Error errorValue -> printfn $"res = Error({errorValue})"
+
+  Assert.False(Result.isError res)


### PR DESCRIPTION
- add test case for nested pattern matching
- Maintain exactness of object being passed to utility types
