### PR TITLE
Handle member access on literals and primitives

### DIFF
--- a/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
+++ b/src/Escalier.TypeChecker.Tests/Escalier.TypeChecker.Tests.fsproj
@@ -22,6 +22,7 @@
         <Compile Include="BuildGraphTests.fs"/>
         <Compile Include="Jsx.fs"/>
         <Compile Include="Exact.fs"/>
+        <Compile Include="Primitives.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Escalier.TypeChecker.Tests/Primitives.fs
+++ b/src/Escalier.TypeChecker.Tests/Primitives.fs
@@ -1,0 +1,164 @@
+module Escalier.TypeChecker.Tests.Primitives
+
+open FsToolkit.ErrorHandling
+open Xunit
+
+open Escalier.TypeChecker.Error
+
+open TestUtils
+
+[<Fact>]
+let StringLiteralProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let msg = "hello";
+        let len = msg.length;
+        let upper = msg.toUpperCase();
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "len", "number")
+      Assert.Value(env, "upper", "string")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let StringPrimitiveProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let msg: string = "hello";
+        let len = msg.length;
+        let upper = msg.toUpperCase();
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "len", "number")
+      Assert.Value(env, "upper", "string")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let NumberLiteralProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let num = 5;
+        let currency = num.toFixed(2);
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "currency", "string")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let NumberPrimitiveProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let num: number = 5;
+        let currency = num.toFixed(2);
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "currency", "string")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let BooleanLiteralProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let flag = true;
+        let value = flag.valueOf();
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "value", "boolean")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let BooleanPrimitiveProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let flag: boolean = true;
+        let value = flag.valueOf();
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "value", "boolean")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let SymbolProperties () =
+  let res =
+    result {
+      let src =
+        """
+        let sym = Symbol();
+        let name = sym.toString();
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "name", "string")
+    }
+
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let UniqueSymbolProperties () =
+  let res =
+    result {
+      let src =
+        """
+        declare let sym: unique symbol;
+        let name = sym.toString();
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "name", "string")
+    }
+
+  Assert.False(Result.isError res)

--- a/src/Escalier.TypeChecker.Tests/Primitives.fs
+++ b/src/Escalier.TypeChecker.Tests/Primitives.fs
@@ -29,6 +29,25 @@ let StringLiteralProperties () =
   Assert.False(Result.isError res)
 
 [<Fact>]
+let StringPropertyOnDirectLiteral () =
+  let res =
+    result {
+      let src =
+        """
+        let len = "hello".length;
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "len", "number")
+    }
+
+  Assert.False(Result.isError res)
+
+
+[<Fact>]
 let StringPrimitiveProperties () =
   let res =
     result {
@@ -66,6 +85,25 @@ let NumberLiteralProperties () =
       Assert.Value(env, "currency", "string")
     }
 
+  Assert.False(Result.isError res)
+
+[<Fact>]
+let NumberPropertyDirectOnLiteral () =
+  let res =
+    result {
+      let src =
+        """
+        let currency = (5).toFixed(2);
+        """
+
+      let! ctx, env = inferModule src
+
+      Assert.Empty(ctx.Report.Diagnostics)
+
+      Assert.Value(env, "currency", "string")
+    }
+
+  printfn "res = %A" res
   Assert.False(Result.isError res)
 
 [<Fact>]

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -313,12 +313,16 @@ let rec getIsMut (ctx: Ctx) (env: Env) (expr: Expr) : Result<bool, TypeError> =
     | ExprKind.Identifier name ->
       let! _, isMut = env.GetBinding name
       return isMut
+    | ExprKind.Literal _ -> return false
+    | ExprKind.Object _ -> return true
+    | ExprKind.Tuple _ -> return true
     | ExprKind.Index(target, _index, _optChain) ->
       return! getIsMut ctx env target
     | ExprKind.Member(target, _name, _optChain) ->
       return! getIsMut ctx env target
     | _ ->
-      return! Error(TypeError.SemanticError $"{expr} is not a valid lvalue")
+      return!
+        Error(TypeError.NotImplemented $"determine the mutability of {expr}")
   }
 
 // Return a structure which indicates whether the object represented by the property


### PR DESCRIPTION
This PR also handles making function on objects with a callable signature.  This was to support a call to `Symbol()` in one of the test cases.