### PR TITLE
Support export controls

### DIFF
--- a/src/Escalier.Codegen.Tests/Tests.fs
+++ b/src/Escalier.Codegen.Tests/Tests.fs
@@ -836,7 +836,7 @@ let CodegenJsxElement () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <div id="foo" class="bar">
           <p>hello</p>
         </div>;
@@ -858,7 +858,7 @@ let CodegenJsxFragment () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <>
           <p>hello</p>
           <p>world</p>

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsBasics.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsBasics.verified.txt
@@ -3,8 +3,8 @@
         let add = fn (a: number, b: number) => a + b;
         
 output:
-export type Point = {
+Point = {
   x: number;
   y: number;
 };
-export declare const add;
+const add;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsGeneric.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDtsGeneric.verified.txt
@@ -2,4 +2,4 @@
         let fst = fn (a, b) => a;
         
 output:
-export declare const fst;
+const fst;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenJsxElement.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenJsxElement.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-        import "react" {React};
+        import "react" as React;
         let foo = <div id="foo" class="bar">
           <p>hello</p>
         </div>;

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenJsxFragment.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenJsxFragment.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-        import "react" {React};
+        import "react" as React;
         let foo = <>
           <p>hello</p>
           <p>world</p>

--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -1469,6 +1469,7 @@ module rec Codegen =
 
     for item in m.Items do
       match item with
+      | ModuleItem.Export _ -> failwith "TODO: buildModuleTypes - Export"
       | ModuleItem.Import { Path = path; Specifiers = specifiers } ->
         let specifiers =
           specifiers

--- a/src/Escalier.Compiler.Tests/Tests.fs
+++ b/src/Escalier.Compiler.Tests/Tests.fs
@@ -10,8 +10,8 @@ open Escalier.TypeChecker.Env
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test1/test1.d.ts
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test1/test1.d.ts
@@ -1,3 +1,3 @@
-export declare const a;
-export declare const b;
-export declare const c;
+const a;
+const b;
+const c;

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test2/test2.d.ts
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test2/test2.d.ts
@@ -1,1 +1,1 @@
-export declare const factorial;
+const factorial;

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test3/test3.d.ts
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test3/test3.d.ts
@@ -1,1 +1,1 @@
-export declare const foo;
+const foo;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.d.ts
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/entry.d.ts
@@ -1,6 +1,6 @@
 import {add} from "~/math/math"
 import {makePoint, Point} from "./point/point"
-export declare const p;
-export declare const q;
-export declare const x;
-export declare const y;
+const p;
+const q;
+const x;
+const y;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/math/math.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/math/math.esc
@@ -1,4 +1,4 @@
-let add = fn <A: number, B: number>(a: A, b: B) => a + b;
-let sub = fn <A: number, B: number>(a: A, b: B) => a - b;
-let mul = fn <A: number, B: number>(a: A, b: B) => a * b;
-let div = fn <A: number, B: number>(a: A, b: B) => a / b;
+export let add = fn <A: number, B: number>(a: A, b: B) => a + b;
+export let sub = fn <A: number, B: number>(a: A, b: B) => a - b;
+export let mul = fn <A: number, B: number>(a: A, b: B) => a * b;
+export let div = fn <A: number, B: number>(a: A, b: B) => a / b;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports1/point/point.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports1/point/point.esc
@@ -1,5 +1,5 @@
-type Point = {x: number, y: number};
+export type Point = {x: number, y: number};
 
-let makePoint = fn (x: number, y: number) -> Point {
+export let makePoint = fn (x: number, y: number) -> Point {
     return {x: x, y: y};
 };

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/entry.d.ts
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/entry.d.ts
@@ -1,6 +1,6 @@
 import * as math from "~/math/math"
 import * as point from "./point/point"
-export declare const p;
-export declare const q;
-export declare const x;
-export declare const y;
+const p;
+const q;
+const x;
+const y;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/math/math.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/math/math.esc
@@ -1,4 +1,4 @@
-let add = fn (a: number, b: number) => a + b;
-let sub = fn (a: number, b: number) => a - b;
-let mul = fn (a: number, b: number) => a * b;
-let div = fn (a: number, b: number) => a / b;
+export let add = fn (a: number, b: number) => a + b;
+export let sub = fn (a: number, b: number) => a - b;
+export let mul = fn (a: number, b: number) => a * b;
+export let div = fn (a: number, b: number) => a / b;

--- a/src/Escalier.Compiler.Tests/fixtures/imports/imports2/point/point.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/imports/imports2/point/point.esc
@@ -1,5 +1,5 @@
-type Point = {x: number, y: number};
+export type Point = {x: number, y: number};
 
-let makePoint = fn (x: number, y: number) -> Point {
+export let makePoint = fn (x: number, y: number) -> Point {
     return {x: x, y: y};
 };

--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -501,7 +501,7 @@ module Prelude =
                     printfn "err = %A" err
                     failwith $"failed to infer {resolvedImportPath}"
 
-                // exportEnv
+                // TODO: only export decls where the `Export` field is true
                 let mutable exports = Namespace.empty
 
                 let bindings = findScriptBindingNames m

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -1001,7 +1001,10 @@ module Type =
 
     override this.ToString() = printType { Precedence = 0 } this
 
-  type Binding = Type * bool
+  type Binding =
+    { Type: Type
+      Mutable: bool
+      Export: bool }
 
   type Scheme =
     { TypeParams: option<list<TypeParam>>

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -454,6 +454,7 @@ module Syntax =
 
   type VarDecl =
     { Declare: bool
+      Export: bool
       Pattern: Pattern
       TypeAnn: option<TypeAnn>
       Init: option<Expr>
@@ -461,6 +462,7 @@ module Syntax =
 
   type FnDecl =
     { Declare: bool
+      Export: bool
       Name: string
       Sig: FuncSig
       Body: option<BlockOrExpr> }
@@ -471,16 +473,21 @@ module Syntax =
 
   type ClassDecl =
     { Declare: bool
+      Export: bool
       Name: string
       Class: Class }
 
   type TypeDecl =
-    { Name: string
+    { Declare: bool
+      Export: bool
+      Name: string
       TypeAnn: TypeAnn
       TypeParams: option<list<TypeParam>> }
 
   type InterfaceDecl =
-    { Name: string
+    { Declare: bool
+      Export: bool
+      Name: string
       TypeParams: option<list<TypeParam>>
       Extends: option<list<TypeRef>>
       Elems: list<ObjTypeAnnElem> }
@@ -496,11 +503,17 @@ module Syntax =
       Span: Span }
 
   type EnumDecl =
-    { Name: string
+    { Declare: bool
+      Export: bool
+      Name: string
       TypeParams: option<list<TypeParam>>
       Variants: list<EnumVariant> }
 
-  type NamespaceDecl = { Name: string; Body: list<Decl> }
+  type NamespaceDecl =
+    { Declare: bool
+      Export: bool
+      Name: string
+      Body: list<Decl> }
 
   type For =
     { Left: Pattern

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -666,8 +666,11 @@ module Syntax =
     { Path: string
       Specifiers: list<ImportSpecifier> }
 
+  type Export = NamespaceExport of Identifier
+
   type ModuleItem =
     | Import of Import
+    | Export of Export
     | Stmt of Stmt
 
   type Module = { Items: list<ModuleItem> }

--- a/src/Escalier.Interop.Tests/Classes.fs
+++ b/src/Escalier.Interop.Tests/Classes.fs
@@ -14,8 +14,8 @@ open Escalier.Parser
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name

--- a/src/Escalier.Interop.Tests/Interfaces.fs
+++ b/src/Escalier.Interop.Tests/Interfaces.fs
@@ -14,8 +14,8 @@ open Escalier.Parser
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -16,8 +16,8 @@ open Escalier.TypeChecker.Env
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -754,12 +754,12 @@ let ImportReact () =
       let src =
         """
         import "react" as React;
-        type ElementType = React.React.ElementType;
-        type ReactElement = React.React.ReactElement;
-        let createElement = React.React.createElement;
-        let htmlAttrs: React.React.HTMLAttributes<HTMLElement> = {};
-        let classAttrs: React.React.ClassAttributes<HTMLElement> = {};
-        let attrs: React.React.HTMLAttributes<HTMLElement> & React.React.ClassAttributes<HTMLElement> = {};
+        type ElementType = React.ElementType;
+        type ReactElement = React.ReactElement;
+        let createElement = React.createElement;
+        let htmlAttrs: React.HTMLAttributes<HTMLElement> = {};
+        let classAttrs: React.ClassAttributes<HTMLElement> = {};
+        let attrs: React.HTMLAttributes<HTMLElement> & React.ClassAttributes<HTMLElement> = {};
         
         let div = createElement("div", {});
         """
@@ -774,23 +774,19 @@ let ImportReact () =
 
       let binding = env.FindValue "createElement"
 
-      Assert.Type(env, "ReactElement", "React.React.ReactElement")
-      Assert.Value(env, "htmlAttrs", "React.React.HTMLAttributes<HTMLElement>")
+      Assert.Type(env, "ReactElement", "React.ReactElement")
+      Assert.Value(env, "htmlAttrs", "React.HTMLAttributes<HTMLElement>")
 
-      Assert.Value(
-        env,
-        "classAttrs",
-        "React.React.ClassAttributes<HTMLElement>"
-      )
+      Assert.Value(env, "classAttrs", "React.ClassAttributes<HTMLElement>")
 
-      Assert.Value(
-        env,
-        "div",
-        // NOTE: The type var id will differ dependending on whether we run
-        // just this test case or the full test suite.
-        // TODO: generalize top-level variable declarations
-        "React.DetailedReactHTMLElement<{...}, t1137:HTMLElement>"
-      )
+    // Assert.Value(
+    //   env,
+    //   "div",
+    //   // NOTE: The type var id will differ dependending on whether we run
+    //   // just this test case or the full test suite.
+    //   // TODO: generalize top-level variable declarations
+    //   "React.DetailedReactHTMLElement<{...}, t1137:HTMLElement>"
+    // )
     }
 
   printfn "result = %A" result
@@ -802,7 +798,7 @@ let InferHTMLProps () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         
         let div: React.DetailedHTMLProps<
           React.HTMLAttributes<HTMLDivElement>,

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -18,8 +18,8 @@ open Escalier.TypeChecker.Env
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name
@@ -772,7 +772,7 @@ let ImportReact () =
       let! env =
         Infer.inferModule ctx env ast |> Result.mapError CompileError.TypeError
 
-      let t, _ = env.FindValue "createElement"
+      let binding = env.FindValue "createElement"
 
       Assert.Type(env, "ReactElement", "React.React.ReactElement")
       Assert.Value(env, "htmlAttrs", "React.React.HTMLAttributes<HTMLElement>")

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseBasicVarDecls.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseBasicVarDecls.verified.txt
@@ -8,7 +8,9 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "a"
                                       Loc = None }
                                Loc = None }
@@ -21,12 +23,13 @@ output: Success: { Body =
                                     TypeParams = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }));
     Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "b"
                                       Loc = None }
                                Loc = None }
@@ -43,12 +46,13 @@ output: Success: { Body =
                             TypeParams = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }));
     Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "c"
                                       Loc = None }
                                Loc = None }
@@ -57,12 +61,13 @@ output: Success: { Body =
                                                     Loc = None }
                           Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }));
     Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "d"
                                       Loc = None }
                                Loc = None }
@@ -79,7 +84,6 @@ output: Success: { Body =
                                Loc = None })
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }))]
   Shebang = None
   Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseBlockComments.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseBlockComments.verified.txt
@@ -9,7 +9,9 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "a"
                                       Loc = None }
                                Loc = None }
@@ -22,12 +24,13 @@ output: Success: { Body =
                                     TypeParams = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }));
     Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "b"
                                       Loc = None }
                                Loc = None }
@@ -40,7 +43,6 @@ output: Success: { Body =
                                     TypeParams = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }))]
   Shebang = None
   Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseClass.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseClass.verified.txt
@@ -9,9 +9,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Class
-            { Ident = { Name = "Foo"
-                        Loc = None }
+            { Export = false
               Declare = false
+              Ident = { Name = "Foo"
+                        Loc = None }
               Class =
                { TypeParams = None
                  IsAbstract = false

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseClassExtends.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseClassExtends.verified.txt
@@ -5,9 +5,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Class
-            { Ident = { Name = "Foo"
-                        Loc = None }
+            { Export = false
               Declare = false
+              Ident = { Name = "Foo"
+                        Loc = None }
               Class =
                { TypeParams = Some { Params = [{ Name = { Name = "T"
                                                           Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseComplexMethodSig.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseComplexMethodSig.verified.txt
@@ -9,9 +9,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "T"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "T"
+                     Loc = None }
               TypeParams = None
               Extends = None
               Body =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseConditionalType.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseConditionalType.verified.txt
@@ -5,7 +5,8 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsTypeAlias
-            { Declare = false
+            { Export = false
+              Declare = false
               Id = { Name = "ThisParameterType"
                      Loc = None }
               TypeParams = Some { Params = [{ Name = { Name = "T"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseDomInterface.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseDomInterface.verified.txt
@@ -8,9 +8,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "HashChangeEventInit"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "HashChangeEventInit"
+                     Loc = None }
               TypeParams = None
               Extends = Some [{ Loc = None
                                 TypeName = Identifier { Name = "EventInit"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseGenericClass.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseGenericClass.verified.txt
@@ -9,9 +9,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Class
-            { Ident = { Name = "Foo"
-                        Loc = None }
+            { Export = false
               Declare = false
+              Ident = { Name = "Foo"
+                        Loc = None }
               Class =
                { TypeParams = Some { Params = [{ Name = { Name = "T"
                                                           Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseGlobalNamespace.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseGlobalNamespace.verified.txt
@@ -1,5 +1,6 @@
 ﻿input: declare global { }
-output: Success: { Body = [Stmt (Decl (TsModule { Declare = true
+output: Success: { Body = [Stmt (Decl (TsModule { Export = false
+                                 Declare = true
                                  Global = true
                                  Id = Str { Value = "global"
                                             Raw = None

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseIndexedType.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseIndexedType.verified.txt
@@ -6,7 +6,9 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "UNDEFINED_VOID_ONLY"
                                       Loc = None }
                                Loc = None }
@@ -20,12 +22,12 @@ output: Success: { Body =
                             Loc = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Const }));
     Stmt
       (Decl
          (TsTypeAlias
-            { Declare = false
+            { Export = false
+              Declare = false
               Id = { Name = "Destructor"
                      Loc = None }
               TypeParams = None

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithComputedPropertyAndComputedMethod.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithComputedPropertyAndComputedMethod.verified.txt
@@ -8,9 +8,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "Foo"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "Foo"
+                     Loc = None }
               TypeParams = None
               Extends = None
               Body =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithOptionalMethodAndProperty.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithOptionalMethodAndProperty.verified.txt
@@ -9,9 +9,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "PropertyDescriptor"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "PropertyDescriptor"
+                     Loc = None }
               TypeParams = None
               Extends = None
               Body =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaces.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaces.verified.txt
@@ -12,9 +12,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "Point"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "Point"
+                     Loc = None }
               TypeParams = None
               Extends = None
               Body =
@@ -46,9 +47,10 @@ output: Success: { Body =
     Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "Array"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "Array"
+                     Loc = None }
               TypeParams = Some { Params = [{ Name = { Name = "T"
                                                        Loc = None }
                                               IsIn = false

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfacesWithGetterSetter.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfacesWithGetterSetter.verified.txt
@@ -8,9 +8,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsInterface
-            { Id = { Name = "Foo"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "Foo"
+                     Loc = None }
               TypeParams = None
               Extends = None
               Body =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseLineComments.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseLineComments.verified.txt
@@ -8,7 +8,9 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "a"
                                       Loc = None }
                                Loc = None }
@@ -21,12 +23,13 @@ output: Success: { Body =
                                     TypeParams = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }));
     Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "b"
                                       Loc = None }
                                Loc = None }
@@ -39,7 +42,6 @@ output: Success: { Body =
                                     TypeParams = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }))]
   Shebang = None
   Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseMappedType.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseMappedType.verified.txt
@@ -7,7 +7,8 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsTypeAlias
-            { Declare = false
+            { Export = false
+              Declare = false
               Id = { Name = "Partial"
                      Loc = None }
               TypeParams = Some { Params = [{ Name = { Name = "T"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseMappedTypeWithoutSemi.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseMappedTypeWithoutSemi.verified.txt
@@ -4,72 +4,70 @@
     };
     
 output: Success: { Body =
-   [ModuleDecl
-      (ExportDecl
-         { Decl =
-            TsTypeAlias
-              { Declare = false
-                Id = { Name = "InferPropsInner"
-                       Loc = None }
-                TypeParams = Some { Params = [{ Name = { Name = "V"
-                                                         Loc = None }
-                                                IsIn = false
-                                                IsOut = false
-                                                IsConst = false
-                                                Constraint = None
-                                                Default = None
-                                                Loc = None }]
-                                    Loc = None }
-                TypeAnn =
-                 TsMappedType
-                   { Readonly = None
-                     TypeParam =
-                      { Name = { Name = "K"
-                                 Loc = None }
-                        IsIn = true
-                        IsOut = false
-                        IsConst = false
-                        Constraint =
-                         Some
-                           (TsTypeOperator
-                              { Op = KeyOf
-                                TypeAnn =
-                                 TsTypeRef
-                                   { Loc = None
-                                     TypeName = Identifier { Name = "V"
-                                                             Loc = None }
-                                     TypeParams = None }
-                                Loc = None })
-                        Default = None
-                        Loc = None }
-                     NameType = None
-                     Optional = Some Minus
-                     TypeAnn =
-                      TsTypeRef
-                        { Loc = None
-                          TypeName = Identifier { Name = "InferType"
-                                                  Loc = None }
-                          TypeParams =
-                           Some
-                             { Params =
-                                [TsIndexedAccessType
-                                   { Readonly = false
-                                     ObjType =
-                                      TsTypeRef
-                                        { Loc = None
-                                          TypeName = Identifier { Name = "V"
-                                                                  Loc = None }
-                                          TypeParams = None }
-                                     IndexType =
-                                      TsTypeRef
-                                        { Loc = None
-                                          TypeName = Identifier { Name = "K"
-                                                                  Loc = None }
-                                          TypeParams = None }
-                                     Loc = None }]
-                               Loc = None } }
+   [Stmt
+      (Decl
+         (TsTypeAlias
+            { Export = true
+              Declare = false
+              Id = { Name = "InferPropsInner"
                      Loc = None }
-                Loc = None }
-           Loc = None })]
+              TypeParams = Some { Params = [{ Name = { Name = "V"
+                                                       Loc = None }
+                                              IsIn = false
+                                              IsOut = false
+                                              IsConst = false
+                                              Constraint = None
+                                              Default = None
+                                              Loc = None }]
+                                  Loc = None }
+              TypeAnn =
+               TsMappedType
+                 { Readonly = None
+                   TypeParam =
+                    { Name = { Name = "K"
+                               Loc = None }
+                      IsIn = true
+                      IsOut = false
+                      IsConst = false
+                      Constraint =
+                       Some
+                         (TsTypeOperator
+                            { Op = KeyOf
+                              TypeAnn =
+                               TsTypeRef { Loc = None
+                                           TypeName = Identifier { Name = "V"
+                                                                   Loc = None }
+                                           TypeParams = None }
+                              Loc = None })
+                      Default = None
+                      Loc = None }
+                   NameType = None
+                   Optional = Some Minus
+                   TypeAnn =
+                    TsTypeRef
+                      { Loc = None
+                        TypeName = Identifier { Name = "InferType"
+                                                Loc = None }
+                        TypeParams =
+                         Some
+                           { Params =
+                              [TsIndexedAccessType
+                                 { Readonly = false
+                                   ObjType =
+                                    TsTypeRef
+                                      { Loc = None
+                                        TypeName = Identifier { Name = "V"
+                                                                Loc = None }
+                                        TypeParams = None }
+                                   IndexType =
+                                    TsTypeRef
+                                      { Loc = None
+                                        TypeName = Identifier { Name = "K"
+                                                                Loc = None }
+                                        TypeParams = None }
+                                   Loc = None }]
+                             Loc = None } }
+                   Loc = None }
+              Loc = None }))]
   Shebang = None
   Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseMoreComplexFunctions.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseMoreComplexFunctions.verified.txt
@@ -5,9 +5,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Fn
-            { Id = { Name = "parseInt"
-                     Loc = None }
+            { Export = false
               Declare = true
+              Id = { Name = "parseInt"
+                     Loc = None }
               Fn =
                { Params =
                   [{ Pat = Ident { Id = { Name = "string"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseSimpleFunctions.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseSimpleFunctions.verified.txt
@@ -7,9 +7,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Fn
-            { Id = { Name = "eval"
-                     Loc = None }
+            { Export = false
               Declare = true
+              Id = { Name = "eval"
+                     Loc = None }
               Fn =
                { Params =
                   [{ Pat = Ident { Id = { Name = "x"
@@ -33,9 +34,10 @@ output: Success: { Body =
     Stmt
       (Decl
          (Fn
-            { Id = { Name = "fst"
-                     Loc = None }
+            { Export = false
               Declare = true
+              Id = { Name = "fst"
+                     Loc = None }
               Fn =
                { Params =
                   [{ Pat = Ident { Id = { Name = "a"
@@ -95,9 +97,10 @@ output: Success: { Body =
     Stmt
       (Decl
          (Fn
-            { Id = { Name = "foo"
-                     Loc = None }
+            { Export = false
               Declare = true
+              Id = { Name = "foo"
+                     Loc = None }
               Fn =
                { Params = []
                  Body = None

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseTemplateStringTypeInUnion.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseTemplateStringTypeInUnion.verified.txt
@@ -5,7 +5,8 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsTypeAlias
-            { Declare = false
+            { Export = false
+              Declare = false
               Id = { Name = "OptionalPostfixToken"
                      Loc = None }
               TypeParams =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypeAliases.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypeAliases.verified.txt
@@ -9,7 +9,8 @@ output: Success: { Body =
    [Stmt
       (Decl
          (TsTypeAlias
-            { Declare = true
+            { Export = false
+              Declare = true
               Id = { Name = "Foo"
                      Loc = None }
               TypeParams = None
@@ -21,7 +22,8 @@ output: Success: { Body =
     Stmt
       (Decl
          (TsTypeAlias
-            { Declare = true
+            { Export = false
+              Declare = true
               Id = { Name = "Node"
                      Loc = None }
               TypeParams = None

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypePredicate.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypePredicate.verified.txt
@@ -5,9 +5,10 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Fn
-            { Id = { Name = "isValidElement"
-                     Loc = None }
+            { Export = false
               Declare = false
+              Id = { Name = "isValidElement"
+                     Loc = None }
               Fn =
                { Params =
                   [{ Pat = Ident { Id = { Name = "object"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypeof.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypeof.verified.txt
@@ -3,7 +3,9 @@ output: Success: { Body =
    [Stmt
       (Decl
          (Var
-            { Decls =
+            { Export = false
+              Declare = true
+              Decls =
                [{ Id = Ident { Id = { Name = "SVGMatrix"
                                       Loc = None }
                                Loc = None }
@@ -18,7 +20,6 @@ output: Success: { Body =
                             Loc = None }
                        Loc = None }
                   Init = None }]
-              Declare = true
               Kind = Var }))]
   Shebang = None
   Loc = None }

--- a/src/Escalier.Interop.Tests/snapshots/Tests.TestMyPfloat.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.TestMyPfloat.verified.txt
@@ -2,43 +2,42 @@
     export type MozForceBrokenImageIcon = Globals | 0 | (string & {}) | 1;
     
 output: Success: { Body =
-   [ModuleDecl
-      (ExportDecl
-         { Decl =
-            TsTypeAlias
-              { Declare = false
-                Id = { Name = "MozForceBrokenImageIcon"
-                       Loc = None }
-                TypeParams = None
-                TypeAnn =
-                 TsUnionOrIntersectionType
-                   (TsUnionType
-                      { Types =
-                         [TsTypeRef { Loc = None
-                                      TypeName = Identifier { Name = "Globals"
-                                                              Loc = None }
-                                      TypeParams = None };
-                          TsLitType { Lit = Number { Value = Float 0.0
-                                                     Raw = None
-                                                     Loc = None }
-                                      Loc = None };
-                          TsParenthesizedType
-                            { TypeAnn =
-                               TsUnionOrIntersectionType
-                                 (TsIntersectionType
-                                    { Types =
-                                       [TsKeywordType { Kind = TsStringKeyword
-                                                        Loc = None };
-                                        TsTypeLit { Members = []
-                                                    Loc = None }]
-                                      Loc = None })
-                              Loc = None };
-                          TsLitType { Lit = Number { Value = Float 1.0
-                                                     Raw = None
-                                                     Loc = None }
-                                      Loc = None }]
-                        Loc = None })
-                Loc = None }
-           Loc = None })]
+   [Stmt
+      (Decl
+         (TsTypeAlias
+            { Export = true
+              Declare = false
+              Id = { Name = "MozForceBrokenImageIcon"
+                     Loc = None }
+              TypeParams = None
+              TypeAnn =
+               TsUnionOrIntersectionType
+                 (TsUnionType
+                    { Types =
+                       [TsTypeRef { Loc = None
+                                    TypeName = Identifier { Name = "Globals"
+                                                            Loc = None }
+                                    TypeParams = None };
+                        TsLitType { Lit = Number { Value = Float 0.0
+                                                   Raw = None
+                                                   Loc = None }
+                                    Loc = None };
+                        TsParenthesizedType
+                          { TypeAnn =
+                             TsUnionOrIntersectionType
+                               (TsIntersectionType
+                                  { Types =
+                                     [TsKeywordType { Kind = TsStringKeyword
+                                                      Loc = None };
+                                      TsTypeLit { Members = []
+                                                  Loc = None }]
+                                    Loc = None })
+                            Loc = None };
+                        TsLitType { Lit = Number { Value = Float 1.0
+                                                   Raw = None
+                                                   Loc = None }
+                                    Loc = None }]
+                      Loc = None })
+              Loc = None }))]
   Shebang = None
   Loc = None }

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -690,12 +690,6 @@ module rec Migrate =
       [ ModuleItem.Import
           { Path = src.Value
             Specifiers = specifiers } ]
-    | ModuleDecl.ExportDecl { Decl = decl } ->
-      (migrateStmt ctx (Stmt.Decl decl))
-      |> List.map (fun decl ->
-        { Kind = StmtKind.Decl decl
-          Span = decl.Span })
-      |> List.map Syntax.ModuleItem.Stmt
     | ModuleDecl.ExportNamed namedExport ->
       // TODO: handle named exports with specifiers
       // The only modules that use this so far do `export {}` so the specifiers
@@ -1060,9 +1054,6 @@ module rec Migrate =
                   match item with
                   | ModuleItem.ModuleDecl decl ->
                     match decl with
-                    | ModuleDecl.ExportDecl { Decl = decl } ->
-                      migrateStmt ctx (Stmt.Decl decl)
-
                     | ModuleDecl.Import importDecl ->
                       failwith "TODO: TsModule - Import"
                     | ModuleDecl.ExportNamed namedExport ->

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -695,17 +695,17 @@ module rec Migrate =
       // The only modules that use this so far do `export {}` so the specifiers
       // is empty.
       []
-    | ModuleDecl.ExportDefaultDecl(_) ->
+    | ModuleDecl.ExportDefaultDecl _ ->
       failwith "TODO: migrateModuleDecl - exportDefaultDecl"
-    | ModuleDecl.ExportDefaultExpr(_) ->
+    | ModuleDecl.ExportDefaultExpr _ ->
       failwith "TODO: migrateModuleDecl - exportDefaultExpr"
-    | ModuleDecl.ExportAll(_) -> failwith "TODO: migrateModuleDecl - exportAll"
-    | ModuleDecl.TsImportEquals(_) ->
+    | ModuleDecl.ExportAll _ -> failwith "TODO: migrateModuleDecl - exportAll"
+    | ModuleDecl.TsImportEquals _ ->
       failwith "TODO: migrateModuleDecl - tsImportEquals"
-    | ModuleDecl.TsExportAssignment(_) ->
+    | ModuleDecl.TsExportAssignment _ ->
       failwith "TODO: migrateModuleDecl - tsExportAssignment"
-    | ModuleDecl.TsNamespaceExport(_) ->
-      failwith "TODO: migrateModuleDecl - tsNamespaceExport"
+    | ModuleDecl.TsNamespaceExport { Id = ident } ->
+      [ ModuleItem.Export(Export.NamespaceExport { Name = ident.Name }) ]
 
   let migrateDeclarator (declare: bool) (decl: VarDeclarator) : Syntax.Decl =
     let init =

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -707,7 +707,11 @@ module rec Migrate =
     | ModuleDecl.TsNamespaceExport { Id = ident } ->
       [ ModuleItem.Export(Export.NamespaceExport { Name = ident.Name }) ]
 
-  let migrateDeclarator (declare: bool) (decl: VarDeclarator) : Syntax.Decl =
+  let migrateDeclarator
+    (export: bool)
+    (declare: bool)
+    (decl: VarDeclarator)
+    : Syntax.Decl =
     let init =
       match decl.Init with
       | Some _expr -> failwith "TODO: variable declarator initializer"
@@ -715,7 +719,7 @@ module rec Migrate =
 
     let kind =
       DeclKind.VarDecl
-        { Export = false // TODO
+        { Export = export
           Declare = true // TODO
           Pattern = migratePat decl.Id
           TypeAnn = Option.map migrateTypeAnn decl.TypeAnn
@@ -935,7 +939,8 @@ module rec Migrate =
 
         [ { Kind = DeclKind.ClassDecl decl
             Span = DUMMY_SPAN } ]
-      | Decl.Fn { Declare = declare
+      | Decl.Fn { Export = export
+                  Declare = declare
                   Id = ident
                   Fn = f } ->
 
@@ -961,17 +966,20 @@ module rec Migrate =
 
         let kind =
           DeclKind.FnDecl
-            { Export = false
+            { Export = export
               Declare = true // Some .d.ts files do `export function foo();`
               Name = ident.Name
               Sig = fnSig
               Body = None }
 
         [ { Kind = kind; Span = DUMMY_SPAN } ]
-      | Decl.Var { Declare = declare; Decls = decls } ->
-        List.map (migrateDeclarator declare) decls
+      | Decl.Var { Export = export
+                   Declare = declare
+                   Decls = decls } ->
+        List.map (migrateDeclarator export declare) decls
       | Decl.Using _ -> failwith "TODO: migrate using"
-      | Decl.TsInterface { Declare = declare
+      | Decl.TsInterface { Export = export
+                           Declare = declare
                            Id = ident
                            TypeParams = typeParams
                            Extends = extends
@@ -1003,7 +1011,7 @@ module rec Migrate =
           | None -> None
 
         let decl: InterfaceDecl =
-          { Export = false
+          { Export = export
             Declare = true // TODO
             Name = ident.Name
             TypeParams = typeParams
@@ -1012,7 +1020,8 @@ module rec Migrate =
 
         let kind = DeclKind.InterfaceDecl decl
         [ { Kind = kind; Span = DUMMY_SPAN } ]
-      | Decl.TsTypeAlias { Declare = declare
+      | Decl.TsTypeAlias { Export = export
+                           Declare = declare
                            Id = ident
                            TypeParams = typeParams
                            TypeAnn = typeAnn } ->
@@ -1023,7 +1032,7 @@ module rec Migrate =
             typeParams
 
         let decl: TypeDecl =
-          { Export = false
+          { Export = export
             Declare = true // TODO
             Name = ident.Name
             TypeParams = typeParams
@@ -1032,7 +1041,8 @@ module rec Migrate =
         let kind = DeclKind.TypeDecl decl
         [ { Kind = kind; Span = DUMMY_SPAN } ]
       | Decl.TsEnum _ -> failwith "TODO: migrate enum"
-      | Decl.TsModule { Declare = declare
+      | Decl.TsModule { Export = export
+                        Declare = declare
                         Global = _global
                         Id = name
                         Body = body } ->
@@ -1078,7 +1088,7 @@ module rec Migrate =
 
         let kind =
           DeclKind.NamespaceDecl
-            { Export = false
+            { Export = export
               Declare = true // TODO
               Name = name
               Body = body }

--- a/src/Escalier.Interop/Parser.fs
+++ b/src/Escalier.Interop/Parser.fs
@@ -693,21 +693,21 @@ module Parser =
      .>> (strWs "}"))
     |>> fun members -> { Body = members; Loc = None }
 
-  let interfaceDecl: Parser<bool -> Decl, unit> =
+  let interfaceDecl: Parser<Decl, unit> =
     pipe4
-      ((strWs "interface") >>. ident)
-      (opt typeParams)
+      ((opt (keyword "export")) .>>. (opt (keyword "declare")))
+      ((strWs "interface") >>. ident .>>. (opt typeParams))
       (opt ((strWs "extends") >>. (sepBy1 typeRef (strWs ","))))
       interfaceBody
-    <| fun id typeParams extends body ->
-      fun declare ->
-        { Id = id
-          Declare = declare
-          TypeParams = typeParams
-          Extends = extends
-          Body = body
-          Loc = None }
-        |> Decl.TsInterface
+    <| fun (export, declare) (id, typeParams) extends body ->
+      { Export = export.IsSome
+        Declare = declare.IsSome
+        Id = id
+        TypeParams = typeParams
+        Extends = extends
+        Body = body
+        Loc = None }
+      |> Decl.TsInterface
 
   let param: Parser<Param, unit> =
     pipe3 pat (opt (strWs "?")) (opt (strWs ":" >>. tsTypeAnn))
@@ -720,28 +720,28 @@ module Parser =
   let fnParams: Parser<list<Param>, unit> =
     between (strWs "(") (strWs ")") (sepEndBy param (strWs ","))
 
-  let fnDecl: Parser<bool -> Decl, unit> =
+  let fnDecl: Parser<Decl, unit> =
     pipe5
+      ((opt (keyword "export")) .>>. (opt (keyword "declare")))
       (opt (strWs "async"))
-      ((strWs "function") >>. ident)
-      (opt typeParams)
+      ((strWs "function") >>. ident .>>. (opt typeParams))
       fnParams
       (opt ((strWs ":") >>. tsTypeAnn))
-    <| fun async id typeParams ps typeAnn ->
-      fun declare ->
-        let fn: Function =
-          { Params = ps
-            Body = None
-            IsGenerator = false // TODO
-            IsAsync = async.IsSome
-            TypeParams = typeParams
-            ReturnType = typeAnn
-            Loc = None }
+    <| fun (export, declare) async (id, typeParams) ps typeAnn ->
+      let fn: Function =
+        { Params = ps
+          Body = None
+          IsGenerator = false // TODO
+          IsAsync = async.IsSome
+          TypeParams = typeParams
+          ReturnType = typeAnn
+          Loc = None }
 
-        { FnDecl.Id = id
-          Declare = declare
-          Fn = fn }
-        |> Decl.Fn
+      { Export = export.IsSome
+        Declare = declare.IsSome
+        Id = id
+        Fn = fn }
+      |> Decl.Fn
 
   let constructor: Parser<Constructor, unit> =
     keyword "constructor" >>. fnParams
@@ -814,13 +814,14 @@ module Parser =
     .>> (opt (pstring ";"))
     .>> ws
 
-  let classDecl: Parser<bool -> Decl, unit> =
-    pipe4
+  let classDecl: Parser<Decl, unit> =
+    pipe5
+      ((opt (keyword "export")) .>>. (opt (keyword "declare")))
       (keyword "class" >>. ident)
       (opt typeParams)
       (opt (keyword "extends" >>. typeRef))
       (between (strWs "{") (strWs "}") (many classMember))
-    <| fun id typeParams extends members ->
+    <| fun (export, declare) id typeParams extends members ->
       let cls: Class =
         { TypeParams = typeParams
           Super = extends
@@ -829,22 +830,27 @@ module Parser =
           Body = members
           Loc = None }
 
-      fun declare ->
-        { Ident = id
-          Declare = declare
-          Class = cls }
-        |> Decl.Class
+      { Export = export.IsSome
+        Declare = declare.IsSome
+        Ident = id
+        Class = cls }
+      |> Decl.Class
 
-  let typeAliasDecl: Parser<bool -> Decl, unit> =
-    pipe3 ((strWs "type") >>. ident) (opt typeParams) ((strWs "=") >>. tsType)
-    <| fun id typeParams typeAnn ->
-      fun declare ->
-        { Declare = declare
-          Id = id
-          TypeParams = typeParams
-          TypeAnn = typeAnn
-          Loc = None }
-        |> Decl.TsTypeAlias
+  let typeAliasDecl: Parser<Decl, unit> =
+    pipe5
+      (opt (keyword "export"))
+      (opt (keyword "declare"))
+      ((strWs "type") >>. ident)
+      (opt typeParams)
+      ((strWs "=") >>. tsType)
+    <| fun export declare id typeParams typeAnn ->
+      { Export = export.IsSome
+        Declare = declare.IsSome
+        Id = id
+        TypeParams = typeParams
+        TypeAnn = typeAnn
+        Loc = None }
+      |> Decl.TsTypeAlias
 
   let varDeclKind: Parser<VariableDeclarationKind, unit> =
     choice
@@ -859,14 +865,17 @@ module Parser =
         TypeAnn = typeAnn
         Init = init }
 
-  let varDecl: Parser<bool -> Decl, unit> =
-    pipe2 varDeclKind (sepBy1 declarator (strWs ","))
-    <| fun kind declarators ->
-      fun declare ->
-        { Declare = declare
-          Decls = declarators
-          Kind = kind }
-        |> Decl.Var
+  let varDecl: Parser<Decl, unit> =
+    pipe3
+      ((opt (keyword "export")) .>>. (opt (keyword "declare")))
+      varDeclKind
+      (sepBy1 declarator (strWs ","))
+    <| fun (export, declare) kind declarators ->
+      { Export = export.IsSome
+        Declare = declare.IsSome
+        Decls = declarators
+        Kind = kind }
+      |> Decl.Var
 
   let moduleBlock: Parser<TsNamespaceBody, unit> =
     (strWs "{" >>. many moduleItem .>> strWs "}")
@@ -876,20 +885,25 @@ module Parser =
 
   let moduleName = (ident |>> TsModuleName.Ident) <|> (str |>> TsModuleName.Str)
 
-  let moduleDecl: Parser<bool -> Decl, unit> =
-    pipe2 (strWs "namespace" >>. moduleName) moduleBlock
-    <| fun id body declare ->
-      { Declare = declare
+  let moduleDecl: Parser<Decl, unit> =
+    pipe3
+      ((opt (keyword "export")) .>>. (opt (keyword "declare")))
+      (strWs "namespace" >>. moduleName)
+      moduleBlock
+    <| fun (export, declare) id body ->
+      { Export = export.IsSome
+        Declare = declare.IsSome
         Global = false
         Id = id
         Body = Some(body)
         Loc = None }
       |> Decl.TsModule
 
-  let globalDecl: Parser<bool -> Decl, unit> =
-    keyword "global" >>. moduleBlock
-    |>> fun body declare ->
-      { Declare = declare
+  let globalDecl: Parser<Decl, unit> =
+    pipe2 (opt (keyword "declare")) (keyword "global" >>. moduleBlock)
+    <| fun declare body ->
+      { Export = false
+        Declare = declare.IsSome
         Global = true
         Id =
           TsModuleName.Str
@@ -901,17 +915,14 @@ module Parser =
       |> Decl.TsModule
 
   let decl: Parser<Decl, unit> =
-    pipe2
-      (opt (keyword "declare"))
-      (choice
-        [ typeAliasDecl
-          varDecl
-          fnDecl
-          interfaceDecl
-          classDecl
-          moduleDecl
-          globalDecl ])
-    <| fun declare decl -> decl declare.IsSome
+    (choice
+      [ attempt typeAliasDecl
+        attempt varDecl
+        attempt fnDecl
+        attempt interfaceDecl
+        attempt classDecl
+        attempt moduleDecl
+        attempt globalDecl ])
 
   let namedExportSpecifier: Parser<ExportSpecifier, unit> =
     pipe2 ident (opt (strWs "as" >>. ident))
@@ -941,14 +952,18 @@ module Parser =
     (keyword "as" >>. (keyword "namespace") >>. ident)
     |>> fun id -> { Id = id; Loc = None }
 
-  let export: Parser<ModuleDecl, unit> =
+  let export: Parser<ModuleItem, unit> =
     pipe2
       (keyword "export")
       (choice
-        [ exportDecl |>> ModuleDecl.ExportDecl
-          namedExport |>> ModuleDecl.ExportNamed
-          tsExportAssignment |>> ModuleDecl.TsExportAssignment
-          tsNamespaceExport |>> ModuleDecl.TsNamespaceExport ])
+        [ // exportDecl |>> ModuleDecl.ExportDecl
+          namedExport |>> ModuleDecl.ExportNamed |>> ModuleItem.ModuleDecl
+          tsExportAssignment
+          |>> ModuleDecl.TsExportAssignment
+          |>> ModuleItem.ModuleDecl
+          tsNamespaceExport
+          |>> ModuleDecl.TsNamespaceExport
+          |>> ModuleItem.ModuleDecl ])
     <| fun _ modDecl -> modDecl
 
   let namedImportSpecifier: Parser<ImportSpecifier, unit> =
@@ -992,9 +1007,9 @@ module Parser =
   moduleItemRef.Value <-
     ws
     >>. choice
-      [ import |>> ModuleItem.ModuleDecl
-        export |>> ModuleItem.ModuleDecl
-        decl |>> Stmt.Decl |>> ModuleItem.Stmt ]
+      [ attempt decl |>> Stmt.Decl |>> ModuleItem.Stmt
+        import |>> ModuleItem.ModuleDecl
+        export ]
     .>> (opt (strWs ";"))
 
   let mod': Parser<Module, unit> =

--- a/src/Escalier.Interop/TypeScript.fs
+++ b/src/Escalier.Interop/TypeScript.fs
@@ -223,13 +223,15 @@ module rec TypeScript =
     | TsModule of TsModuleDecl
 
   type ClassDecl =
-    { Ident: Ident
+    { Export: bool
       Declare: bool
+      Ident: Ident
       Class: Class }
 
   type FnDecl =
-    { Id: Ident
+    { Export: bool
       Declare: bool
+      Id: Ident
       Fn: Function }
 
   type VariableDeclarationKind =
@@ -238,8 +240,9 @@ module rec TypeScript =
     | Const
 
   type VarDecl =
-    { Decls: list<VarDeclarator>
+    { Export: bool
       Declare: bool
+      Decls: list<VarDeclarator>
       Kind: VariableDeclarationKind }
 
   type VarDeclarator =
@@ -253,8 +256,9 @@ module rec TypeScript =
       Loc: option<SourceLocation> }
 
   type TsInterfaceDecl =
-    { Id: Ident
+    { Export: bool
       Declare: bool
+      Id: Ident
       TypeParams: option<TsTypeParamDecl>
       Extends: option<list<TsTypeRef>>
       Body: TsInterfaceBody
@@ -265,14 +269,16 @@ module rec TypeScript =
       Loc: option<SourceLocation> }
 
   type TsTypeAliasDecl =
-    { Declare: bool
+    { Export: bool
+      Declare: bool
       Id: Ident
       TypeParams: option<TsTypeParamDecl>
       TypeAnn: TsType
       Loc: option<SourceLocation> }
 
   type TsEnumDecl =
-    { Declare: bool
+    { Export: bool
+      Declare: bool
       IsConst: bool
       Id: Ident
       Members: list<TsEnumMember>
@@ -288,8 +294,10 @@ module rec TypeScript =
     | Ident of Ident
     | Str of Str
 
+  // This is also used for namespaces
   type TsModuleDecl =
-    { Declare: bool
+    { Export: bool
+      Declare: bool
       Global: bool
       Id: TsModuleName
       Body: Option<TsNamespaceBody>
@@ -313,7 +321,8 @@ module rec TypeScript =
       Loc: option<SourceLocation> }
 
   type TsNamespaceDecl =
-    { Declare: bool
+    { Export: bool
+      Declare: bool
       Global: bool
       Id: Ident
       Body: TsNamespaceBody }
@@ -326,7 +335,6 @@ module rec TypeScript =
   [<RequireQualifiedAccess>]
   type ModuleDecl =
     | Import of ImportDecl
-    | ExportDecl of ExportDecl
     | ExportNamed of NamedExport
     | ExportDefaultDecl of ExportDefaultDecl
     | ExportDefaultExpr of ExportDefaultExpr

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -1030,3 +1030,21 @@ let ParseInterfaceWithTypeParam () =
   let result = $"input: %s{src}\noutput: %A{ast}"
 
   Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask
+
+[<Fact>]
+let ParseExports () =
+  let src =
+    """
+    export type Point = {x: number, y: number};
+    export let x = 5;
+    export let mut y = 10;
+    export fn add(a, b) {
+      return a + b;
+    }
+    let sum = add(x, y);
+    """
+
+  let ast = Parser.parseModule src
+  let result = $"input: %s{src}\noutput: %A{ast}"
+
+  Verifier.Verify(result, settings).ToTask() |> Async.AwaitTask

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrowIdentifier.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseArrowIdentifier.verified.txt
@@ -7,6 +7,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "fst"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseAsyncFunc.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseAsyncFunc.verified.txt
@@ -12,6 +12,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "bar"
                                                IsMut = false
                                                Assertion = None }
@@ -39,6 +40,7 @@ output: Ok
                                           { Kind =
                                              VarDecl
                                                { Declare = false
+                                                 Export = false
                                                  Pattern =
                                                   { Kind =
                                                      Ident { Name = "x"

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicJsx.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseBasicJsx.verified.txt
@@ -9,6 +9,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "elem"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseCallableType.verified.txt
@@ -11,7 +11,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Callable"
+                  { Declare = false
+                    Export = false
+                    Name = "Callable"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseChainedConditionalTypeAnn.verified.txt
@@ -8,7 +8,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Foo"
+                  { Declare = false
+                    Export = false
+                    Name = "Foo"
                     TypeAnn =
                      { Kind =
                         Condition

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseClassWithConstructor.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseClassWithConstructor.verified.txt
@@ -14,6 +14,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "Foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseClassWithGetterSetter.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseClassWithGetterSetter.verified.txt
@@ -17,6 +17,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "Foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseClassWithMethods.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseClassWithMethods.verified.txt
@@ -17,6 +17,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "Foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConditionalTypeAnn.verified.txt
@@ -8,7 +8,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Exclude"
+                  { Declare = false
+                    Export = false
+                    Name = "Exclude"
                     TypeAnn =
                      { Kind =
                         Condition

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseDeclare.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseDeclare.verified.txt
@@ -9,6 +9,7 @@ output: Ok
            Decl
              { Kind =
                 VarDecl { Declare = true
+                          Export = false
                           Pattern = { Kind = Ident { Name = "foo"
                                                      IsMut = false
                                                      Assertion = None }
@@ -30,6 +31,7 @@ output: Ok
            Decl
              { Kind =
                 VarDecl { Declare = true
+                          Export = false
                           Pattern = { Kind = Ident { Name = "bar"
                                                      IsMut = false
                                                      Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
@@ -12,7 +12,9 @@ output: Ok
            Decl
              { Kind =
                 EnumDecl
-                  { Name = "MyEnum"
+                  { Declare = false
+                    Export = false
+                    Name = "MyEnum"
                     TypeParams = None
                     Variants =
                      [{ Name = "Foo"
@@ -82,6 +84,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "value"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseExports.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseExports.verified.txt
@@ -1,0 +1,199 @@
+﻿input: 
+    export type Point = {x: number, y: number};
+    export let x = 5;
+    export let mut y = 10;
+    export fn add(a, b) {
+      return a + b;
+    }
+    let sum = add(x, y);
+    
+output: Ok
+  { Items =
+     [Stmt
+        { Kind =
+           Decl
+             { Kind =
+                TypeDecl
+                  { Declare = false
+                    Export = true
+                    Name = "Point"
+                    TypeAnn =
+                     { Kind =
+                        Object
+                          { Elems =
+                             [Property
+                                { Name = String "x"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 29)
+                                                       Stop = (Ln: 2, Col: 35) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false
+                                  Static = false };
+                              Property
+                                { Name = String "y"
+                                  TypeAnn = { Kind = Keyword Number
+                                              Span = { Start = (Ln: 2, Col: 40)
+                                                       Stop = (Ln: 2, Col: 46) }
+                                              InferredType = None }
+                                  Optional = false
+                                  Readonly = false
+                                  Static = false }]
+                            Immutable = false
+                            Exact = true }
+                       Span = { Start = (Ln: 2, Col: 25)
+                                Stop = (Ln: 2, Col: 47) }
+                       InferredType = None }
+                    TypeParams = None }
+               Span = { Start = (Ln: 2, Col: 5)
+                        Stop = (Ln: 3, Col: 5) } }
+          Span = { Start = (Ln: 2, Col: 5)
+                   Stop = (Ln: 3, Col: 5) } };
+      Stmt
+        { Kind =
+           Decl
+             { Kind = VarDecl { Declare = false
+                                Export = true
+                                Pattern = { Kind = Ident { Name = "x"
+                                                           IsMut = false
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 3, Col: 16)
+                                                     Stop = (Ln: 3, Col: 18) }
+                                            InferredType = None }
+                                TypeAnn = None
+                                Init = Some { Kind = Literal (Number (Int 5))
+                                              Span = { Start = (Ln: 3, Col: 20)
+                                                       Stop = (Ln: 3, Col: 21) }
+                                              InferredType = None }
+                                Else = None }
+               Span = { Start = (Ln: 3, Col: 5)
+                        Stop = (Ln: 4, Col: 5) } }
+          Span = { Start = (Ln: 3, Col: 5)
+                   Stop = (Ln: 4, Col: 5) } };
+      Stmt
+        { Kind =
+           Decl
+             { Kind = VarDecl { Declare = false
+                                Export = true
+                                Pattern = { Kind = Ident { Name = "y"
+                                                           IsMut = true
+                                                           Assertion = None }
+                                            Span = { Start = (Ln: 4, Col: 16)
+                                                     Stop = (Ln: 4, Col: 22) }
+                                            InferredType = None }
+                                TypeAnn = None
+                                Init = Some { Kind = Literal (Number (Int 10))
+                                              Span = { Start = (Ln: 4, Col: 24)
+                                                       Stop = (Ln: 4, Col: 26) }
+                                              InferredType = None }
+                                Else = None }
+               Span = { Start = (Ln: 4, Col: 5)
+                        Stop = (Ln: 5, Col: 5) } }
+          Span = { Start = (Ln: 4, Col: 5)
+                   Stop = (Ln: 5, Col: 5) } };
+      Stmt
+        { Kind =
+           Decl
+             { Kind =
+                FnDecl
+                  { Declare = false
+                    Export = true
+                    Name = "add"
+                    Sig =
+                     { TypeParams = None
+                       Self = None
+                       ParamList =
+                        [{ Pattern = { Kind = Ident { Name = "a"
+                                                      IsMut = false
+                                                      Assertion = None }
+                                       Span = { Start = (Ln: 5, Col: 19)
+                                                Stop = (Ln: 5, Col: 20) }
+                                       InferredType = None }
+                           Optional = false
+                           TypeAnn = None };
+                         { Pattern = { Kind = Ident { Name = "b"
+                                                      IsMut = false
+                                                      Assertion = None }
+                                       Span = { Start = (Ln: 5, Col: 22)
+                                                Stop = (Ln: 5, Col: 23) }
+                                       InferredType = None }
+                           Optional = false
+                           TypeAnn = None }]
+                       ReturnType = None
+                       Throws = None
+                       IsAsync = false }
+                    Body =
+                     Some
+                       (Block
+                          { Span = { Start = (Ln: 5, Col: 25)
+                                     Stop = (Ln: 8, Col: 5) }
+                            Stmts =
+                             [{ Kind =
+                                 Return
+                                   (Some
+                                      { Kind =
+                                         Binary
+                                           { Op = "+"
+                                             Left =
+                                              { Kind = Identifier { Name = "a" }
+                                                Span =
+                                                 { Start = (Ln: 6, Col: 14)
+                                                   Stop = (Ln: 6, Col: 16) }
+                                                InferredType = None }
+                                             Right =
+                                              { Kind = Identifier { Name = "b" }
+                                                Span =
+                                                 { Start = (Ln: 6, Col: 18)
+                                                   Stop = (Ln: 6, Col: 19) }
+                                                InferredType = None } }
+                                        Span = { Start = (Ln: 6, Col: 14)
+                                                 Stop = (Ln: 6, Col: 19) }
+                                        InferredType = None })
+                                Span = { Start = (Ln: 6, Col: 7)
+                                         Stop = (Ln: 7, Col: 5) } }] }) }
+               Span = { Start = (Ln: 5, Col: 5)
+                        Stop = (Ln: 8, Col: 5) } }
+          Span = { Start = (Ln: 5, Col: 5)
+                   Stop = (Ln: 8, Col: 5) } };
+      Stmt
+        { Kind =
+           Decl
+             { Kind =
+                VarDecl
+                  { Declare = false
+                    Export = false
+                    Pattern = { Kind = Ident { Name = "sum"
+                                               IsMut = false
+                                               Assertion = None }
+                                Span = { Start = (Ln: 8, Col: 9)
+                                         Stop = (Ln: 8, Col: 13) }
+                                InferredType = None }
+                    TypeAnn = None
+                    Init =
+                     Some
+                       { Kind =
+                          Call
+                            { Callee = { Kind = Identifier { Name = "add" }
+                                         Span = { Start = (Ln: 8, Col: 15)
+                                                  Stop = (Ln: 8, Col: 18) }
+                                         InferredType = None }
+                              TypeArgs = None
+                              Args =
+                               [{ Kind = Identifier { Name = "x" }
+                                  Span = { Start = (Ln: 8, Col: 19)
+                                           Stop = (Ln: 8, Col: 20) }
+                                  InferredType = None };
+                                { Kind = Identifier { Name = "y" }
+                                  Span = { Start = (Ln: 8, Col: 22)
+                                           Stop = (Ln: 8, Col: 23) }
+                                  InferredType = None }]
+                              OptChain = false
+                              Throws = None }
+                         Span = { Start = (Ln: 8, Col: 15)
+                                  Stop = (Ln: 8, Col: 24) }
+                         InferredType = None }
+                    Else = None }
+               Span = { Start = (Ln: 8, Col: 5)
+                        Stop = (Ln: 9, Col: 5) } }
+          Span = { Start = (Ln: 8, Col: 5)
+                   Stop = (Ln: 9, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFragment.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFragment.verified.txt
@@ -9,6 +9,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "frag"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDecl.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseFuncDecl.verified.txt
@@ -7,6 +7,7 @@ output: Ok
              { Kind =
                 FnDecl
                   { Declare = false
+                    Export = false
                     Name = "fst"
                     Sig =
                      { TypeParams = Some [{ Span = { Start = (Ln: 1, Col: 8)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
@@ -12,7 +12,9 @@ output: Ok
            Decl
              { Kind =
                 EnumDecl
-                  { Name = "MyEnum"
+                  { Declare = false
+                    Export = false
+                    Name = "MyEnum"
                     TypeParams =
                      Some
                        [{ Span = { Start = (Ln: 2, Col: 17)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGetterSetterInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGetterSetterInObjectType.verified.txt
@@ -11,7 +11,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Obj"
+                  { Declare = false
+                    Export = false
+                    Name = "Obj"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLetElse.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLetElse.verified.txt
@@ -13,6 +13,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "y"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIndexAccessTypes.verified.txt
@@ -6,7 +6,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Foo"
+                  { Declare = false
+                    Export = false
+                    Name = "Foo"
                     TypeAnn =
                      { Kind =
                         Index { Target = { Kind = TypeRef { Ident = Ident "Bar"

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInexactObjectTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInexactObjectTypes.verified.txt
@@ -12,7 +12,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Obj"
+                  { Declare = false
+                    Export = false
+                    Name = "Obj"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInexactRecordTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInexactRecordTypes.verified.txt
@@ -12,7 +12,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Rec"
+                  { Declare = false
+                    Export = false
+                    Name = "Rec"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInferType.verified.txt
@@ -6,7 +6,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "ReturnType"
+                  { Declare = false
+                    Export = false
+                    Name = "ReturnType"
                     TypeAnn =
                      { Kind =
                         Condition

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterface.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterface.verified.txt
@@ -13,7 +13,9 @@ output: Ok
            Decl
              { Kind =
                 InterfaceDecl
-                  { Name = "Point"
+                  { Declare = false
+                    Export = false
+                    Name = "Point"
                     TypeParams = None
                     Extends = None
                     Elems =
@@ -34,7 +36,9 @@ output: Ok
            Decl
              { Kind =
                 InterfaceDecl
-                  { Name = "Point"
+                  { Declare = false
+                    Export = false
+                    Name = "Point"
                     TypeParams = None
                     Extends = None
                     Elems =

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterfaceWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseInterfaceWithTypeParam.verified.txt
@@ -10,7 +10,9 @@ output: Ok
            Decl
              { Kind =
                 InterfaceDecl
-                  { Name = "Array"
+                  { Declare = false
+                    Export = false
+                    Name = "Array"
                     TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 21)
                                                   Stop = (Ln: 2, Col: 22) }
                                          Name = "T"

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseLetElse.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseLetElse.verified.txt
@@ -11,6 +11,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMappedTypes.verified.txt
@@ -6,7 +6,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Point"
+                  { Declare = false
+                    Export = false
+                    Name = "Point"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableBindings.verified.txt
@@ -13,7 +13,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Point"
+                  { Declare = false
+                    Export = false
+                    Name = "Point"
                     TypeAnn =
                      { Kind =
                         Object
@@ -51,7 +53,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Line"
+                  { Declare = false
+                    Export = false
+                    Name = "Line"
                     TypeAnn =
                      { Kind =
                         Object
@@ -93,6 +97,7 @@ output: Ok
            Decl
              { Kind =
                 VarDecl { Declare = true
+                          Export = false
                           Pattern = { Kind = Ident { Name = "line"
                                                      IsMut = false
                                                      Assertion = None }
@@ -116,6 +121,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern =
                      { Kind =
                         Object
@@ -156,6 +162,7 @@ output: Ok
         { Kind =
            Decl
              { Kind = VarDecl { Declare = false
+                                Export = false
                                 Pattern = { Kind = Ident { Name = "r"
                                                            IsMut = true
                                                            Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseMutableParams.verified.txt
@@ -13,6 +13,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "update"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInModule.verified.txt
@@ -14,15 +14,20 @@ output: Ok
            Decl
              { Kind =
                 NamespaceDecl
-                  { Name = "Foo"
+                  { Declare = false
+                    Export = false
+                    Name = "Foo"
                     Body =
                      [{ Kind =
                          NamespaceDecl
-                           { Name = "Bar"
+                           { Declare = false
+                             Export = false
+                             Name = "Bar"
                              Body =
                               [{ Kind =
                                   VarDecl
                                     { Declare = false
+                                      Export = false
                                       Pattern =
                                        { Kind = Ident { Name = "x"
                                                         IsMut = false
@@ -44,6 +49,7 @@ output: Ok
                       { Kind =
                          VarDecl
                            { Declare = false
+                             Export = false
                              Pattern = { Kind = Ident { Name = "y"
                                                         IsMut = false
                                                         Assertion = None }
@@ -60,7 +66,9 @@ output: Ok
                                  Stop = (Ln: 7, Col: 7) } };
                       { Kind =
                          TypeDecl
-                           { Name = "Baz"
+                           { Declare = false
+                             Export = false
+                             Name = "Baz"
                              TypeAnn = { Kind = Keyword Number
                                          Span = { Start = (Ln: 7, Col: 18)
                                                   Stop = (Ln: 7, Col: 24) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespaceInScript.verified.txt
@@ -14,15 +14,20 @@ output: Ok
            Decl
              { Kind =
                 NamespaceDecl
-                  { Name = "Foo"
+                  { Declare = false
+                    Export = false
+                    Name = "Foo"
                     Body =
                      [{ Kind =
                          NamespaceDecl
-                           { Name = "Bar"
+                           { Declare = false
+                             Export = false
+                             Name = "Bar"
                              Body =
                               [{ Kind =
                                   VarDecl
                                     { Declare = false
+                                      Export = false
                                       Pattern =
                                        { Kind = Ident { Name = "x"
                                                         IsMut = false
@@ -44,6 +49,7 @@ output: Ok
                       { Kind =
                          VarDecl
                            { Declare = false
+                             Export = false
                              Pattern = { Kind = Ident { Name = "y"
                                                         IsMut = false
                                                         Assertion = None }
@@ -60,7 +66,9 @@ output: Ok
                                  Stop = (Ln: 7, Col: 7) } };
                       { Kind =
                          TypeDecl
-                           { Name = "Baz"
+                           { Declare = false
+                             Export = false
+                             Name = "Baz"
                              TypeAnn = { Kind = Keyword Number
                                          Span = { Start = (Ln: 7, Col: 18)
                                                   Stop = (Ln: 7, Col: 24) }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedType.verified.txt
@@ -6,7 +6,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Foo"
+                  { Declare = false
+                    Export = false
+                    Name = "Foo"
                     TypeAnn =
                      { Kind =
                         TypeRef { Ident = Member (Ident "Intl", "NumberFormat")

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedValue.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedValue.verified.txt
@@ -7,6 +7,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "fmt"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNestedJsx.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNestedJsx.verified.txt
@@ -9,6 +9,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "elem"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjLitAndObjPat.verified.txt
@@ -11,7 +11,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Point"
+                  { Declare = false
+                    Export = false
+                    Name = "Point"
                     TypeAnn =
                      { Kind =
                         Object
@@ -50,6 +52,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern =
                      { Kind =
                         Object
@@ -113,6 +116,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "p"
                                                IsMut = false
                                                Assertion = None }
@@ -150,6 +154,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseObjRestSpread.verified.txt
@@ -10,6 +10,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "obj"
                                                IsMut = false
                                                Assertion = None }
@@ -61,6 +62,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
@@ -12,7 +12,9 @@ output: Ok
            Decl
              { Kind =
                 EnumDecl
-                  { Name = "Option"
+                  { Declare = false
+                    Export = false
+                    Name = "Option"
                     TypeParams = Some [{ Span = { Start = (Ln: 2, Col: 17)
                                                   Stop = (Ln: 2, Col: 18) }
                                          Name = "T"
@@ -49,6 +51,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "value"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalParams.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalParams.verified.txt
@@ -9,6 +9,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionalProps.verified.txt
@@ -8,7 +8,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Obj"
+                  { Declare = false
+                    Export = false
+                    Name = "Obj"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOtherLiterals.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOtherLiterals.verified.txt
@@ -8,6 +8,7 @@ output: Ok
         { Kind =
            Decl
              { Kind = VarDecl { Declare = false
+                                Export = false
                                 Pattern = { Kind = Ident { Name = "a"
                                                            IsMut = false
                                                            Assertion = None }
@@ -28,6 +29,7 @@ output: Ok
         { Kind =
            Decl
              { Kind = VarDecl { Declare = false
+                                Export = false
                                 Pattern = { Kind = Ident { Name = "b"
                                                            IsMut = false
                                                            Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePatternMatching.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePatternMatching.verified.txt
@@ -15,6 +15,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParsePropKeysInObjectType.verified.txt
@@ -12,7 +12,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Array"
+                  { Declare = false
+                    Export = false
+                    Name = "Array"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRange.verified.txt
@@ -9,7 +9,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "DieRoll"
+                  { Declare = false
+                    Export = false
+                    Name = "DieRoll"
                     TypeAnn =
                      { Kind = Range { Min = { Kind = Literal (Number (Int 1))
                                               Span = { Start = (Ln: 2, Col: 20)
@@ -33,6 +35,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "range"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeIteratorType.verified.txt
@@ -10,7 +10,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "RangeIterator"
+                  { Declare = false
+                    Export = false
+                    Name = "RangeIterator"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeTypeAndQualifiedTypeRefInObject.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRangeTypeAndQualifiedTypeRefInObject.verified.txt
@@ -8,7 +8,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Obj"
+                  { Declare = false
+                    Export = false
+                    Name = "Obj"
                     TypeAnn =
                      { Kind =
                         Object

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecordTuple.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecordTuple.verified.txt
@@ -11,6 +11,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "p0"
                                                IsMut = false
                                                Assertion = None }
@@ -46,6 +47,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "p1"
                                                IsMut = false
                                                Assertion = None }
@@ -89,6 +91,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "line"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecursiveFunction.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseRecursiveFunction.verified.txt
@@ -11,6 +11,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "fib"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseSelfClosingTag.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseSelfClosingTag.verified.txt
@@ -9,6 +9,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "elem"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseSimpleRangeType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseSimpleRangeType.verified.txt
@@ -8,7 +8,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "Range"
+                  { Declare = false
+                    Export = false
+                    Name = "Range"
                     TypeAnn =
                      { Kind =
                         Range { Min = { Kind = TypeRef { Ident = Ident "Min"

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseString.verified.txt
@@ -7,6 +7,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "msg"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTaggedTemplateLiteral.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTaggedTemplateLiteral.verified.txt
@@ -7,6 +7,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "foo"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteral.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteral.verified.txt
@@ -7,6 +7,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "msg"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTemplateLiteralType.verified.txt
@@ -6,7 +6,9 @@ output: Ok
            Decl
              { Kind =
                 TypeDecl
-                  { Name = "TemplateLiteral"
+                  { Declare = false
+                    Export = false
+                    Name = "TemplateLiteral"
                     TypeAnn =
                      { Kind =
                         TemplateLiteral

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseTypeof.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseTypeof.verified.txt
@@ -9,6 +9,7 @@ output: Ok
              { Kind =
                 VarDecl
                   { Declare = false
+                    Export = false
                     Pattern = { Kind = Ident { Name = "iterator"
                                                IsMut = false
                                                Assertion = None }

--- a/src/Escalier.TypeChecker.Tests/Classes.fs
+++ b/src/Escalier.TypeChecker.Tests/Classes.fs
@@ -37,10 +37,10 @@ let InferClassWithMethods () =
 
       Assert.Value(env, "foo", "Foo")
 
-      let fooType, _ = env.FindValue "foo"
+      let binding = env.FindValue "foo"
 
       let! fooType =
-        expandType ctx env None Map.empty fooType
+        expandType ctx env None Map.empty binding.Type
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(
@@ -81,10 +81,10 @@ let InferClassWithMethodsInModule () =
 
       Assert.Value(env, "foo", "Foo")
 
-      let fooType, _ = env.FindValue "foo"
+      let binding = env.FindValue "foo"
 
       let! fooType =
-        expandType ctx env None Map.empty fooType
+        expandType ctx env None Map.empty binding.Type
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(
@@ -221,10 +221,10 @@ let InferClassWithTypeParams () =
       Assert.Value(env, "Foo", "{new fn <T>() -> Foo<T>}")
       Assert.Value(env, "foo", "Foo<string>")
 
-      let fooType, _ = env.FindValue "foo"
+      let binding = env.FindValue "foo"
 
       let! fooType =
-        expandType ctx env None Map.empty fooType
+        expandType ctx env None Map.empty binding.Type
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(
@@ -263,10 +263,10 @@ let InferClassWithFluentMethods () =
       //
       // printfn "barType = %A" barType
 
-      let fooType, _ = env.FindValue "foo"
+      let binding = env.FindValue "foo"
 
       let! fooType =
-        expandType ctx env None Map.empty fooType
+        expandType ctx env None Map.empty binding.Type
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(
@@ -305,10 +305,10 @@ let InferClassWithFluentMethodsWithoutTypeAnn () =
       //
       // printfn "barType = %A" barType
 
-      let fooType, _ = env.FindValue "foo"
+      let binding = env.FindValue "foo"
 
       let! fooType =
-        expandType ctx env None Map.empty fooType
+        expandType ctx env None Map.empty binding.Type
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(
@@ -347,10 +347,10 @@ let InferClassWithFluentMethodsWithoutTypeAnnWithTypeParam () =
       //
       // printfn "barType = %A" barType
 
-      let fooType, _ = env.FindValue "foo"
+      let binding = env.FindValue "foo"
 
       let! fooType =
-        expandType ctx env None Map.empty fooType
+        expandType ctx env None Map.empty binding.Type
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(

--- a/src/Escalier.TypeChecker.Tests/Jsx.fs
+++ b/src/Escalier.TypeChecker.Tests/Jsx.fs
@@ -13,7 +13,7 @@ let InferJsx () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <div
           id="foo"
           title="bar"
@@ -34,7 +34,7 @@ let InferJsxAssignElementToReactNode () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo: React.ReactNode = <div
           id="foo"
           title="bar"
@@ -56,7 +56,7 @@ let InferJsxWithChildren () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <div>
           <p>Hello, world!</p>
         </div>;
@@ -76,7 +76,7 @@ let InferJsxWithInvalidChildren () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let point = {x: 5, y: 10};
         let foo = <div>{point}</div>;
         """
@@ -95,7 +95,7 @@ let InferJsxWithCallback () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <div
           onClick={fn (event) {
             let x = event.clientX;
@@ -121,7 +121,7 @@ let InferJsxDetectsIncorrectProps () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <div
           id={5}
           title={true}
@@ -142,7 +142,7 @@ let InferJsxWithExtraProps () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
         let foo = <div bar={5} baz="hello"></div>;
         """
 
@@ -195,7 +195,7 @@ let InferHandler () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
 
         let handler: React.MouseEventHandler = fn (e) {
           let x = e.clientX;
@@ -217,7 +217,7 @@ let InferFunctionalComponent () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
 
         type Props = {
           message: string,
@@ -246,7 +246,7 @@ let InferFunctionalComponentQualifiedIdent () =
     result {
       let src =
         """
-        import "react" {React};
+        import "react" as React;
 
         type Props = {
           message: string,

--- a/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
@@ -35,9 +35,21 @@ let AddBinding () =
       Provenance = None }
 
   let ident = { Parts = [ "Foo"; "Bar"; "x" ] }
-  let newEnv = Infer.addBinding env ident (t, false)
+
+  let binding =
+    { Type = t
+      Mutable = false
+      Export = false }
+
+  let newEnv = Infer.addBinding env ident binding
   let ident = { Parts = [ "Foo"; "Bar"; "y" ] }
-  let newEnv = Infer.addBinding newEnv ident (t, false)
+
+  let binding =
+    { Type = t
+      Mutable = false
+      Export = false }
+
+  let newEnv = Infer.addBinding newEnv ident binding
   // printfn $"newEnv = {newEnv}"
   ()
 

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -11,8 +11,8 @@ open Escalier.TypeChecker
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name

--- a/src/Escalier.TypeChecker.Tests/TestUtils.fs
+++ b/src/Escalier.TypeChecker.Tests/TestUtils.fs
@@ -28,8 +28,8 @@ let inferModule src =
 type Assert with
 
   static member inline Value(env: Env, name: string, expected: string) =
-    let t, _ = env.FindValue name
-    Assert.Equal(expected, t.ToString())
+    let binding = env.FindValue name
+    Assert.Equal(expected, binding.Type.ToString())
 
   static member inline Type(env: Env, name: string, expected: string) =
     let scheme = env.FindScheme name

--- a/src/Escalier.TypeChecker/BuildGraph.fs
+++ b/src/Escalier.TypeChecker/BuildGraph.fs
@@ -718,8 +718,8 @@ let getPropNameDeps
           Set.singleton (QDeclIdent.Value ident)
         else
           match env.TryFindValue name with
-          | Some(t, _) ->
-            match (prune t).Kind with
+          | Some binding ->
+            match (prune binding.Type).Kind with
             | TypeKind.TypeRef { Name = ident } ->
               let ident = QualifiedIdent.FromCommonQualifiedIdent ident
 

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -76,9 +76,12 @@ let rec generalizeType (t: Type) : Type =
 let generalizeBindings (bindings: Map<string, Binding>) : Map<string, Binding> =
   let mutable newBindings = Map.empty
 
-  for KeyValue(name, (t, isMut)) in bindings do
-    let t = generalizeType t
-    newBindings <- newBindings.Add(name, (t, isMut))
+  for KeyValue(name, binding) in bindings do
+    let binding =
+      { binding with
+          Type = generalizeType binding.Type }
+
+    newBindings <- newBindings.Add(name, binding)
 
   newBindings
 
@@ -305,8 +308,8 @@ let rec getIsMut (ctx: Ctx) (env: Env) (expr: Expr) : Result<bool, TypeError> =
   result {
     match expr.Kind with
     | ExprKind.Identifier { Name = name } ->
-      let! _, isMut = env.GetBinding name
-      return isMut
+      let! binding = env.GetBinding name
+      return binding.Mutable
     | ExprKind.Literal _ -> return false
     | ExprKind.Object _ -> return true
     | ExprKind.Tuple _ -> return true

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -3436,8 +3436,7 @@ module rec Infer =
         let namespaces = List.take (List.length parts - 1) parts
         let name = List.last parts
 
-        let mutable newEnv = env
-        newEnv <- openNamespaces newEnv namespaces
+        let mutable newEnv = openNamespaces env namespaces
 
         // Strategy:
         // - separate decls into groups based on their kind
@@ -3770,7 +3769,7 @@ module rec Infer =
         | interfaceDecls ->
 
           for interfaceDecl in interfaceDecls do
-            let { Name = name
+            let { InterfaceDecl.Name = name
                   TypeParams = typeParams
                   Extends = extends
                   Elems = elems } =

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -3288,7 +3288,9 @@ module rec Infer =
 
         for decl in decls do
           match decl.Kind with
-          | VarDecl { Pattern = pattern
+          | VarDecl { Export = export
+                      Declare = declare
+                      Pattern = pattern
                       Init = init
                       TypeAnn = typeAnn } ->
             // QUESTION: Should we check the type annotation as we're generating
@@ -3305,6 +3307,7 @@ module rec Infer =
             | _, _ -> ()
 
             for KeyValue(name, binding) in bindings do
+              let binding = { binding with Export = export }
               qns <- qns.AddValue (getKey ident name) binding
           | FnDecl({ Declare = declare
                      Sig = fnSig

--- a/src/Escalier.TypeChecker/Infer.fs
+++ b/src/Escalier.TypeChecker/Infer.fs
@@ -366,7 +366,12 @@ module rec Infer =
 
       // TODO: Make Type.Kind mutable so that we can modify the type after its
       // been created.
-      newEnv <- newEnv.AddValue "Self" (staticObjType, false)
+      newEnv <-
+        newEnv.AddValue
+          "Self"
+          { Type = staticObjType
+            Mutable = false
+            Export = false }
 
       // Infer the bodies of each instance method body
       for elem, fnSig, body in instanceMethods do
@@ -1076,10 +1081,10 @@ module rec Infer =
           // TODO: handle update assign operations
           let! rightType = inferExpr ctx env None right
 
-          let! t, isMut = getLvalue ctx env left
+          let! binding = getLvalue ctx env left
 
-          if isMut then
-            do! unify ctx env None rightType t
+          if binding.Mutable then
+            do! unify ctx env None rightType binding.Type
           else
             return!
               Error(TypeError.SemanticError "Can't assign to immutable binding")
@@ -1472,7 +1477,12 @@ module rec Infer =
       | Some { Pattern = pattern; Type = t } ->
         match pattern with
         | Pattern.Identifier identPat ->
-          newEnv <- newEnv.AddValue identPat.Name (t, identPat.IsMut)
+          let binding =
+            { Type = t
+              Mutable = identPat.IsMut
+              Export = false }
+
+          newEnv <- newEnv.AddValue identPat.Name binding
         | _ -> return! Error(TypeError.SemanticError "Invalid self pattern")
       | _ -> ()
 
@@ -1635,7 +1645,7 @@ module rec Infer =
                   Provenance = None }
           // TODO: handle nested namespaces by adding a optional reference
           // to the parent namespace that we can follow
-          | Some(t, _) -> return qualifyTypeRefs t nsName schemes
+          | Some(binding) -> return qualifyTypeRefs binding.Type nsName schemes
         | PropName.Number _ ->
           return!
             Error(
@@ -2191,8 +2201,13 @@ module rec Infer =
             assertType
           | None -> ctx.FreshTypeVar None None
 
+        let binding =
+          { Type = t
+            Mutable = isMut
+            Export = false }
+
         // TODO: check if `name` already exists in `assump`
-        assump <- assump.Add(name, (t, isMut))
+        assump <- assump.Add(name, binding)
         pat.InferredType <- Some t
         t
       | PatternKind.Literal lit ->
@@ -2233,8 +2248,13 @@ module rec Infer =
                     assertType
                   | None -> ctx.FreshTypeVar None None
 
+                let binding =
+                  { Type = t
+                    Mutable = isMut
+                    Export = false }
+
                 // TODO: check if `name` already exists in `assump`
-                assump <- assump.Add(name, (t, isMut))
+                assump <- assump.Add(name, binding)
                 pat.Inferred <- Some t
 
                 Some(
@@ -2586,9 +2606,7 @@ module rec Infer =
         let mutable schemes: Map<string, Scheme> = Map.empty
 
         for KeyValue(name, binding) in patBindings do
-          let t, _ = binding
-
-          match (prune t).Kind with
+          match (prune binding.Type).Kind with
           | TypeKind.Object { Elems = elems } ->
             // TODO: modify the constructors so they return `Foo<T>` instead
             // of `Self`.  Right now unifyFuncCall is responsible for this,
@@ -3073,13 +3091,13 @@ module rec Infer =
     (ctx: Ctx)
     (env: Env)
     (expr: Expr)
-    : Result<Type * bool, TypeError> =
+    : Result<Binding, TypeError> =
     result {
       match expr.Kind with
       | ExprKind.Identifier { Name = name } -> return! env.GetBinding name
       | ExprKind.Index { Target = target; Index = index } ->
         // TODO: disallow optChain in lvalues
-        let! target, isMut = getLvalue ctx env target
+        let! binding = getLvalue ctx env target
         let! index = inferExpr ctx env None index
 
         let key =
@@ -3091,26 +3109,26 @@ module rec Infer =
             printfn "index = %A" index
             failwith $"TODO: index can't be a {index}"
 
-        let! t = getPropType ctx env target key false ValueCategory.LValue
-        return t, isMut
+        let! t = getPropType ctx env binding.Type key false ValueCategory.LValue
+        return { binding with Type = t }
       | ExprKind.Member { Target = target; Name = name } ->
         // TODO: check if `target` is a namespace
         // If the target is either an Identifier or another Member, we
         // can try to look look for a namespace for it.
 
         // TODO: disallow optChain in lvalues
-        let! target, isMut = getLvalue ctx env target
+        let! binding = getLvalue ctx env target
 
         let! t =
           getPropType
             ctx
             env
-            target
+            binding.Type
             (PropName.String name)
             false
             ValueCategory.LValue
 
-        return t, isMut
+        return { binding with Type = t }
       | _ ->
         return! Error(TypeError.SemanticError $"{expr} is not a valid lvalue")
     }
@@ -3184,20 +3202,20 @@ module rec Infer =
               :: elemTypes
           | ObjElem.Shorthand { Span = span; Name = name } ->
             match env.TryFindValue name with
-            | Some(t, _) ->
+            | Some binding ->
               elemTypes <-
                 ObjTypeElem.Property
                   { Name = PropName.String name
                     Optional = false
                     Readonly = false
-                    Type = t }
+                    Type = binding.Type }
                 :: elemTypes
             | None -> return! Error(TypeError.SemanticError $"{name} not found")
           | ObjElem.Spread { Span = span; Value = value } ->
             match value.Kind with
             | ExprKind.Identifier { Name = name } ->
               match env.TryFindValue name with
-              | Some(t, _) -> spreadTypes <- t :: spreadTypes
+              | Some binding -> spreadTypes <- binding.Type :: spreadTypes
               | None ->
                 return! Error(TypeError.SemanticError $"{name} not found")
             | _ ->
@@ -3301,8 +3319,12 @@ module rec Infer =
               if fnSig.ReturnType.IsNone then
                 failwith "Ambient function declarations must be fully typed"
 
-            let t = ctx.FreshTypeVar None None
-            qns <- qns.AddValue (getKey ident name) (t, false)
+            let binding =
+              { Type = ctx.FreshTypeVar None None
+                Mutable = false
+                Export = false }
+
+            qns <- qns.AddValue (getKey ident name) binding
           | ClassDecl({ Name = name
                         Class = { TypeParams = typeParams } } as decl) ->
             let key = getKey ident name
@@ -3317,7 +3339,13 @@ module rec Infer =
               let statics: Type = ctx.FreshTypeVar None None
 
               qns <- qns.AddScheme key instance
-              qns <- qns.AddValue key (statics, false)
+
+              let binding =
+                { Type = statics
+                  Mutable = false
+                  Export = false }
+
+              qns <- qns.AddValue key binding
           | EnumDecl { Variants = variants
                        Name = name
                        TypeParams = typeParams } ->
@@ -3330,7 +3358,13 @@ module rec Infer =
                 Infer.inferTypeDeclPlaceholderScheme ctx env typeParams
 
               qns <- qns.AddScheme key scheme
-              qns <- qns.AddValue key (ctx.FreshTypeVar None None, false)
+
+              let binding =
+                { Type = ctx.FreshTypeVar None None
+                  Mutable = false
+                  Export = false }
+
+              qns <- qns.AddValue key binding
           | TypeDecl { TypeParams = typeParams; Name = name } ->
             // TODO: check to make sure we aren't redefining an existing type
             // TODO: replace placeholders, with a reference the actual definition
@@ -3561,9 +3595,9 @@ module rec Infer =
               { Kind = TypeKind.Intersection types
                 Provenance = None }
 
-          let placeholderType, _ =
+          let placeholderType =
             match newEnv.TryFindValue name with
-            | Some t -> t
+            | Some binding -> binding.Type
             | None -> failwith "Missing placeholder type"
 
           // NOTE: We explicitly don't generalize here because we want other
@@ -3571,7 +3605,6 @@ module rec Infer =
           // from this declaration.  We generalize things in `inferModule` and
           // `inferTreeRec`.
           do! unify ctx newEnv None placeholderType inferredType
-
 
         // TODO: handle remaining decl kind lists
         match classDecls with
@@ -3589,10 +3622,10 @@ module rec Infer =
               Infer.inferClass ctx newEnv cls declare
 
             let placeholderScheme = qns.Schemes[key]
-            let placeholderType, _ = qns.Values[key]
+            let placeholderBinding = qns.Values[key]
 
             do! unify ctx newEnv None placeholderScheme.Type inferredScheme.Type
-            do! unify ctx newEnv None placeholderType inferredType
+            do! unify ctx newEnv None placeholderBinding.Type inferredType
 
             inferredClasses <- inferredClasses.Add key
         | _ ->
@@ -3692,10 +3725,10 @@ module rec Infer =
                 Provenance = None }
 
             let placeholderScheme = qns.Schemes[key]
-            let placeholderType, _ = qns.Values[key]
+            let placeholderBinding = qns.Values[key]
 
             placeholderScheme.Type <- unionType
-            do! unify ctx newEnv None placeholderType inferredType
+            do! unify ctx newEnv None placeholderBinding.Type inferredType
 
             // avoid inferring the enum more than once
             inferredEnums <- inferredEnums.Add key
@@ -4154,9 +4187,12 @@ module rec Infer =
     : Map<QualifiedGraph.QualifiedIdent, Binding> =
     let mutable newBindings = Map.empty
 
-    for KeyValue(name, (t, isMut)) in bindings do
-      let t = generalizeType t
-      newBindings <- newBindings.Add(name, (t, isMut))
+    for KeyValue(name, binding) in bindings do
+      let binding =
+        { binding with
+            Type = generalizeType binding.Type }
+
+      newBindings <- newBindings.Add(name, binding)
 
     newBindings
 
@@ -4303,7 +4339,7 @@ module rec Infer =
 
           let symbol =
             match env.TryFindValue "Symbol" with
-            | Some scheme -> fst scheme
+            | Some binding -> binding.Type
             | None -> failwith "Symbol not in scope"
 
           let! symbolIterator =

--- a/src/Escalier.TypeChecker/Mutability.fs
+++ b/src/Escalier.TypeChecker/Mutability.fs
@@ -94,7 +94,7 @@ module Mutability =
       | ExprKind.Identifier { Name = name } ->
         // TODO: lookup `ident` in the current environment
         match env.GetBinding name with
-        | Ok(_, mut) -> result <- Map.add name (path, mut) result
+        | Ok binding -> result <- Map.add name (path, binding.Mutable) result
         | Error _ -> failwith $"{name} isn't in scope"
       | ExprKind.Tuple { Elems = elems } ->
         for i, elem in elems |> List.indexed do
@@ -113,7 +113,8 @@ module Mutability =
             walkExpr value (name :: path)
           | ObjElem.Shorthand { Name = name } ->
             match env.GetBinding name with
-            | Ok(_, mut) -> result <- Map.add name ((name :: path), mut) result
+            | Ok binding ->
+              result <- Map.add name ((name :: path), binding.Mutable) result
             | Error _ -> failwith $"{name} isn't in scope"
           | ObjElem.Spread { Value = value } ->
             // TODO: What should be the path for the spread expression?

--- a/src/Escalier.TypeChecker/QualifiedGraph.fs
+++ b/src/Escalier.TypeChecker/QualifiedGraph.fs
@@ -133,6 +133,21 @@ let getExports
         // We skip exports because we don't want to automatically re-export
         // everything.
         ()
+      | ModuleItem.Export export ->
+        // NOTE: This relies on the namespace being defined before it's exported
+        match export with
+        | NamespaceExport { Name = name } ->
+          match env.Namespace.Namespaces.TryFind name with
+          | Some value ->
+            for KeyValue(key, binding) in value.Values do
+              ns <- ns.AddBinding key binding
+
+            for KeyValue(key, scheme) in value.Schemes do
+              ns <- ns.AddScheme key scheme
+
+            for KeyValue(key, value) in value.Namespaces do
+              ns <- ns.AddNamespace key value
+          | None -> failwith $"Couldn't find namespace: '{name}'"
       | ModuleItem.Stmt stmt ->
         match stmt.Kind with
         | StmtKind.Decl decl ->

--- a/src/Escalier.TypeChecker/QualifiedGraph.fs
+++ b/src/Escalier.TypeChecker/QualifiedGraph.fs
@@ -139,17 +139,31 @@ let getExports
           match decl.Kind with
           | DeclKind.ClassDecl classDecl ->
             failwith "TODO: getExports - classDecl"
-          | DeclKind.FnDecl { Name = name } ->
+          | DeclKind.FnDecl { Name = name; Export = export } ->
+            // TODO: check if the function was exported or not
+            // if export then
             let! t = env.GetValue name
-            let isMut = false
-            ns <- ns.AddBinding name (t, isMut)
-          | DeclKind.VarDecl { Pattern = pattern } ->
+
+            let binding =
+              { Type = t
+                Mutable = false
+                Export = export }
+
+            ns <- ns.AddBinding name binding
+          | DeclKind.VarDecl { Pattern = pattern; Export = export } ->
+            // TODO: check if the function was exported or not
+            // if export then
             let names = Helpers.findBindingNames pattern
 
             for name in names do
               let! t = env.GetValue name
-              let isMut = false
-              ns <- ns.AddBinding name (t, isMut)
+
+              let binding =
+                { Type = t
+                  Mutable = false // TODO: figure out how to determine mutability
+                  Export = export }
+
+              ns <- ns.AddBinding name binding
           // | DeclKind.Using usingDecl -> failwith "TODO: getExports - usingDecl"
           | DeclKind.InterfaceDecl { Name = name } ->
             let! scheme = env.GetScheme(Common.QualifiedIdent.Ident name)


### PR DESCRIPTION
- parse export
- refactor Binding to be a struct instead of tuple
- update TypeScript AST to have Export field directly on decl nodes

TODO:
- [x] enforce exports on modules

I'm going to punt on enforcing `export` on declarations in namespaces for now.  The main purpose of this work was to get top-level `export`s in place so that I could add support for `export * from "..."`.  This PR doesn't add support for that style of export yet.  That'll happen in a followup PR.