### PR TITLE
Handle parsing more syntax in .d.ts files

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -1721,7 +1721,11 @@ module rec Codegen =
       let elemTypes: list<TsTupleElement> =
         elems
         |> List.map (buildType ctx)
-        |> List.map (fun t -> { Label = None; Type = t; Loc = None })
+        |> List.map (fun t ->
+          { Label = None
+            Type = t
+            IsRest = false
+            Loc = None })
 
       TsType.TsTupleType { ElemTypes = elemTypes; Loc = None }
     | TypeKind.Array { Elem = elem; Length = length } ->

--- a/src/Escalier.Interop.Tests/Escalier.Interop.Tests.fsproj
+++ b/src/Escalier.Interop.Tests/Escalier.Interop.Tests.fsproj
@@ -69,6 +69,7 @@
         <Compile Include="Interfaces.fs"/>
         <Compile Include="Classes.fs"/>
         <Compile Include="Tests.fs"/>
+        <Compile Include="MergeLib.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>
 </Project>

--- a/src/Escalier.Interop.Tests/MergeLib.fs
+++ b/src/Escalier.Interop.Tests/MergeLib.fs
@@ -1,0 +1,36 @@
+module Escalier.Interop.Tests.MergeLib
+
+open FsToolkit.ErrorHandling
+open Xunit
+open System.IO
+
+open Escalier.Interop.MergeLib
+
+[<Fact>]
+let testResolvePath () =
+  let projectRoot = __SOURCE_DIRECTORY__
+
+  let resolvedPath = resolvePath projectRoot projectRoot "@apollo/client"
+
+  let combinedPath = Path.Combine("/foo/bar", "../baz")
+  let di = DirectoryInfo(combinedPath)
+  printfn $"di.FullName = {di.FullName}"
+
+  Assert.Equal(
+    "/Users/kevinbarabash/projects/escalier-next/node_modules/@apollo/client/index.d.ts",
+    resolvedPath
+  )
+
+[<Fact>]
+let testGetDependencies () =
+  let res =
+    result {
+      let projectRoot = __SOURCE_DIRECTORY__
+
+      let! deps = getDependencies projectRoot "@apollo/client"
+
+      printfn $"deps = {deps}"
+    }
+
+  printfn $"res = %A{res}"
+  Assert.True(Result.isOk res)

--- a/src/Escalier.Interop.Tests/MergeLib.fs
+++ b/src/Escalier.Interop.Tests/MergeLib.fs
@@ -2,24 +2,8 @@ module Escalier.Interop.Tests.MergeLib
 
 open FsToolkit.ErrorHandling
 open Xunit
-open System.IO
 
 open Escalier.Interop.MergeLib
-
-[<Fact>]
-let testResolvePath () =
-  let projectRoot = __SOURCE_DIRECTORY__
-
-  let resolvedPath = resolvePath projectRoot projectRoot "@apollo/client"
-
-  let combinedPath = Path.Combine("/foo/bar", "../baz")
-  let di = DirectoryInfo(combinedPath)
-  printfn $"di.FullName = {di.FullName}"
-
-  Assert.Equal(
-    "/Users/kevinbarabash/projects/escalier-next/node_modules/@apollo/client/index.d.ts",
-    resolvedPath
-  )
 
 [<Fact>]
 let testGetDependencies () =
@@ -29,7 +13,7 @@ let testGetDependencies () =
 
       let! deps = getDependencies projectRoot "@apollo/client"
 
-      printfn $"deps = {deps}"
+      printfn $"deps.Length = {deps.Length}"
     }
 
   printfn $"res = %A{res}"

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -399,7 +399,6 @@ let ParseAndInferPropertyKey () =
   printfn "res = %A" res
   Assert.True(Result.isOk res)
 
-
 [<Fact>]
 let ParseAndMigrateExportDeclareFunction () =
   let res =
@@ -428,6 +427,24 @@ let ParseAndMigrateExportDeclareFunction () =
   printfn "res = %A" res
   Assert.True(Result.isOk res)
 
+[<Fact>]
+let ParseAndMigrateCommentOnly () =
+  let res =
+    result {
+      let input = "// This is a comment"
+
+      let! ast =
+        match parseModule input with
+        | Success(ast, _, _) -> Result.Ok ast
+        | Failure(_, error, _) -> Result.Error(CompileError.ParseError error)
+
+      let _ = migrateModule ast
+
+      ()
+    }
+
+  printfn "res = %A" res
+  Assert.True(Result.isOk res)
 
 [<Fact>]
 let ParseAndInferLibEs5 () =

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -447,6 +447,79 @@ let ParseAndMigrateCommentOnly () =
   Assert.True(Result.isOk res)
 
 [<Fact>]
+let ParseAndMigrateEnum () =
+  let res =
+    result {
+      let input =
+        """
+        export declare const enum CacheWriteBehavior {
+          FORBID = 0,
+          OVERWRITE = 1,
+          MERGE = 2
+        }
+        """
+
+      let! ast =
+        match parseModule input with
+        | Success(ast, _, _) -> Result.Ok ast
+        | Failure(_, error, _) -> Result.Error(CompileError.ParseError error)
+
+      let _ = migrateModule ast
+
+      ()
+    }
+
+  printfn "res = %A" res
+  Assert.True(Result.isOk res)
+
+[<Fact>]
+let ParseAndMigrateMappedTypeWithRenaming () =
+  let res =
+    result {
+      let input =
+        """
+        type OnlyRequiredProperties<T> = {
+          [K in keyof T as {} extends Pick<T, K> ? never : K]: T[K];
+        };
+        """
+
+
+      let! ast =
+        match parseModule input with
+        | Success(ast, _, _) -> Result.Ok ast
+        | Failure(_, error, _) -> Result.Error(CompileError.ParseError error)
+
+      let _ = migrateModule ast
+
+      ()
+    }
+
+  printfn "res = %A" res
+  Assert.True(Result.isOk res)
+
+[<Fact>]
+let ParseAndMigrateNamedTuples () =
+  let res =
+    result {
+      let input =
+        """
+        type Point = [x: number, y?: number];
+        """
+
+      let! ast =
+        match parseModule input with
+        | Success(ast, _, _) -> Result.Ok ast
+        | Failure(_, error, _) -> Result.Error(CompileError.ParseError error)
+
+      let _ = migrateModule ast
+
+      ()
+    }
+
+  printfn "res = %A" res
+  Assert.True(Result.isOk res)
+
+[<Fact>]
 let ParseAndInferLibEs5 () =
   let res =
     result {

--- a/src/Escalier.Interop/Escalier.Interop.fsproj
+++ b/src/Escalier.Interop/Escalier.Interop.fsproj
@@ -1,23 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
-
     <ItemGroup>
         <Compile Include="TypeScript.fs"/>
         <Compile Include="Parser.fs"/>
         <Compile Include="Migrate.fs"/>
+        <Compile Include="MergeLib.fs"/>
     </ItemGroup>
-
     <ItemGroup>
         <PackageReference Include="FParsec" Version="1.1.1"/>
+        <PackageReference Include="FSharp.Data" Version="6.4.0"/>
     </ItemGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\Escalier.Data\Escalier.Data.fsproj"/>
         <ProjectReference Include="..\Escalier.TypeChecker\Escalier.TypeChecker.fsproj"/>
     </ItemGroup>
-
 </Project>

--- a/src/Escalier.Interop/MergeLib.fs
+++ b/src/Escalier.Interop/MergeLib.fs
@@ -139,7 +139,6 @@ module MergeLib =
           return ()
         else
           let resolvedPath = resolvePath projectRoot currentPath importSrc
-          printfn $"resolvedPath = {resolvedPath}"
 
           if List.contains resolvedPath visitedPaths then
             return ()

--- a/src/Escalier.Interop/MergeLib.fs
+++ b/src/Escalier.Interop/MergeLib.fs
@@ -1,0 +1,174 @@
+namespace Escalier.Interop
+
+open FParsec.Error
+open FsToolkit.ErrorHandling
+open FSharp.Data
+open System.IO
+
+open Escalier.Data.Syntax
+
+module MergeLib =
+  let mutable memoizedNodeModulesDir: Map<string, string> = Map.empty
+
+  let rec findNearestAncestorWithNodeModules (currentDir: string) =
+    match memoizedNodeModulesDir.TryFind currentDir with
+    | Some(nodeModulesDir) -> nodeModulesDir
+    | None ->
+      let nodeModulesDir = Path.Combine(currentDir, "node_modules")
+
+      if Directory.Exists(nodeModulesDir) then
+        currentDir
+      else
+        let parentDir = Directory.GetParent(currentDir)
+
+        match parentDir with
+        | null ->
+          failwith "node_modules directory not found in any ancestor directory."
+        | _ -> findNearestAncestorWithNodeModules parentDir.FullName
+
+  let private packageJsonHasTypes (packageJsonPath: string) : bool =
+    if File.Exists packageJsonPath then
+      let packageJson = File.ReadAllText(packageJsonPath)
+      let packageJsonObj = JsonValue.Parse(packageJson)
+
+      match packageJsonObj.TryGetProperty("types") with
+      | None -> false
+      | Some _ -> true
+    else
+      false
+
+  let resolvePath
+    (projectRoot: string)
+    (currentPath: string)
+    (importPath: string)
+    : string =
+    if importPath.StartsWith "~" then
+      Path.GetFullPath(Path.Join(projectRoot, importPath.Substring(1)))
+    else if importPath.StartsWith "." then
+      let resolvedPath =
+        Path.GetFullPath(
+          Path.Join(Path.GetDirectoryName(currentPath), importPath)
+        )
+
+      if currentPath.EndsWith(".d.ts") then
+        Path.ChangeExtension(resolvedPath, ".d.ts")
+      else
+        resolvedPath
+    else
+      // TODO: once this is implemented, move it over to Escalier.Interop
+      // TODO: check if there's `/` in the import path, if so, the first
+      // part before the `/` is the name of the module and the rost is a
+      // path to a .d.ts file within the module.
+
+      // determine if importPath contains a '/' and split on it
+      // if it does, the first part is the module name and the second part is
+      // the path to the .d.ts file within the module
+
+      // It's possible that the module name is a scoped package, in which case
+      // the module name will be the first part of the second part of the split
+      // and the second part will be the path to the .d.ts file within the module.
+      let moduleName, subpath =
+        match importPath.Split('/') |> List.ofArray with
+        | [] -> failwith "This should never happen."
+        | [ name ] -> name, None
+        | name :: path ->
+          if name.StartsWith("@") then
+            let ns = name
+
+            match path with
+            | [] -> failwith "This should never happen."
+            | [ name ] ->
+              let moduleName = String.concat "/" [ ns; name ]
+              moduleName, None
+            | name :: path ->
+              let moduleName = String.concat "/" [ ns; name ]
+              moduleName, Some(String.concat "/" path)
+          else
+            name, Some(String.concat "/" path)
+
+      let rootDir = findNearestAncestorWithNodeModules projectRoot
+      let nodeModulesDir = Path.Combine(rootDir, "node_modules")
+
+      let pkgJsonPath1 =
+        Path.Combine(nodeModulesDir, moduleName, "package.json")
+
+      let pkgJsonPath2 =
+        Path.Combine(nodeModulesDir, "@types", moduleName, "package.json")
+
+      let pkgJsonPath =
+        if packageJsonHasTypes pkgJsonPath1 then
+          pkgJsonPath1
+        elif packageJsonHasTypes pkgJsonPath2 then
+          pkgJsonPath2
+        else
+          failwith
+            $"package.json not found for module {moduleName}, rootDir = {rootDir}, nodeModulesDir = {nodeModulesDir}."
+
+      // read package.json and parse it
+      let pkgJson = File.ReadAllText(pkgJsonPath)
+      let pkgJsonObj = JsonValue.Parse(pkgJson)
+
+      let combinedPath =
+        match subpath with
+        | None ->
+          match pkgJsonObj.TryGetProperty("types") with
+          | None -> failwith "Invalid package.json: missing `types` field."
+          | Some value ->
+            let types = value.InnerText()
+
+            if types.EndsWith(".d.ts") then
+              Path.Combine(Path.GetDirectoryName(pkgJsonPath), types)
+            else
+              Path.Combine(Path.GetDirectoryName(pkgJsonPath), $"{types}.d.ts")
+        // Path.Combine(Path.GetDirectoryName(pkgJsonPath), types)
+        | Some value ->
+          Path.Combine(Path.GetDirectoryName(pkgJsonPath), $"{value}.d.ts")
+
+      let di = DirectoryInfo(combinedPath)
+      di.FullName
+
+  let getDependencies
+    (projectRoot: string)
+    (importSrc: string)
+    : Result<list<string>, ParserError> =
+    let mutable visitedPaths: list<string> = []
+
+    let rec traverse (currentPath: string) (importSrc: string) =
+      result {
+        if not (importSrc.StartsWith ".") && visitedPaths.Length <> 0 then
+          return ()
+        else
+          let resolvedPath = resolvePath projectRoot currentPath importSrc
+          printfn $"resolvedPath = {resolvedPath}"
+
+          if List.contains resolvedPath visitedPaths then
+            return ()
+          else
+            visitedPaths <- resolvedPath :: visitedPaths
+
+            let contents = File.ReadAllText(resolvedPath)
+
+            let! ast =
+              match Parser.parseModule contents with
+              | FParsec.CharParsers.Success(value, _, _) -> Result.Ok(value)
+              | FParsec.CharParsers.Failure(_, parserError, _) ->
+                printfn $"parserError = {parserError}"
+                Result.Error(parserError)
+
+            let ast = Migrate.migrateModule ast
+
+            for item in ast.Items do
+              match item with
+              | Import { Path = path } -> do! traverse resolvedPath path
+              | Export(Export.NamedExport { Src = src }) ->
+                do! traverse resolvedPath src
+              | Export(Export.ExportAll { Src = src }) ->
+                do! traverse resolvedPath src
+              | _ -> ()
+
+        return ()
+      }
+
+    match traverse projectRoot importSrc with
+    | Ok _ -> Ok(visitedPaths)
+    | Error e -> Error(e)

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -726,7 +726,7 @@ module rec Migrate =
       | None ->
         // TODO: handle renaming named exports, e.g.
         // export { setVerbosity as setLogVerbosity };
-        printfn $"namedExport = %A{namedExport}"
+        printfn "TODO: migrate named export without src"
         []
     | ModuleDecl.ExportDefaultDecl _ ->
       failwith "TODO: migrateModuleDecl - exportDefaultDecl"

--- a/src/Escalier.Interop/Parser.fs
+++ b/src/Escalier.Interop/Parser.fs
@@ -1090,11 +1090,16 @@ module Parser =
         export ]
     .>> (opt (strWs ";"))
 
-  let mod': Parser<Module, unit> =
-    many moduleItem .>> eof
+  let m: Parser<Module, unit> =
+    ws >>. (opt (many moduleItem)) .>> eof
     |>> fun items ->
+      let items =
+        match items with
+        | Some items -> items
+        | None -> []
+
       { Body = items
         Shebang = None
         Loc = None }
 
-  let parseModule (input: string) = run mod' input
+  let parseModule (input: string) = run m input

--- a/src/Escalier.Interop/TypeScript.fs
+++ b/src/Escalier.Interop/TypeScript.fs
@@ -1221,8 +1221,9 @@ module rec TypeScript =
       Loc: option<SourceLocation> }
 
   type TsTupleElement =
-    { Label: option<Pat>
+    { Label: option<Ident>
       Type: TsType
+      IsRest: bool
       Loc: option<SourceLocation> }
 
   type TsOptionalType =
@@ -1319,5 +1320,5 @@ module rec TypeScript =
   type TsImportType =
     { Arg: Str
       Qualifier: Option<TsEntityName>
-      Type_args: Option<TsTypeParamInstantiation>
+      TypeArgs: Option<TsTypeParamInstantiation>
       Loc: option<SourceLocation> }


### PR DESCRIPTION
This is to support work on merging .d.ts to avoid import cycles in `graphql`.  Merging of .d.ts files will be tackled in a future PR.