### PR TITLE
Replace sync file I/O with async in preparation for moving playground to Bolero

### DIFF
--- a/src/Escalier.Codegen.Tests/Tests.fs
+++ b/src/Escalier.Codegen.Tests/Tests.fs
@@ -26,14 +26,14 @@ let projectRoot = __SOURCE_DIRECTORY__
 let printCtx: PrintCtx = { Indent = 0; Precedence = 0 }
 
 let parseAndCodegen (src: string) =
-  result {
+  asyncResult {
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
 
     let! ctx, env = Prelude.getEnvAndCtx projectRoot
 
     let! env =
       InferModule.inferModule ctx env ast
-      |> Result.mapError CompileError.TypeError
+      |> AsyncResult.mapError CompileError.TypeError
 
     let ctx: Ctx =
       { NextTempId = 0
@@ -194,7 +194,7 @@ let CodegenTemplateLiteral () =
         let escapes = `"hello"\n\r\t'world'`;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -222,7 +222,7 @@ let CodegenTaggedTemplateLiteral () =
         }`;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -244,7 +244,7 @@ let CodegenAssignment () =
         x = 10;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -266,7 +266,7 @@ let CodegenIndexing () =
         arr[2] = arr[0] + arr[1];
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -290,7 +290,7 @@ let CodegenMemberAccess () =
         let c = a?.b?.c;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -315,7 +315,7 @@ let CodegenDoExpression () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -347,7 +347,7 @@ let CodegenDoExpressionWithReturn () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -380,7 +380,7 @@ let CodegenNestedDoExpressions () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -402,7 +402,7 @@ let CodegenFunction () =
           if (n == 0) { 1 } else { n * factorial(n - 1) }; 
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -426,7 +426,7 @@ let CodegenAsyncFunction () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -447,7 +447,7 @@ let CodegenCalls () =
         let array = new Array(1, 2, 3);
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -477,7 +477,7 @@ let CodegenChainedIfElse () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -501,7 +501,7 @@ let CodegenLogicalOperators () =
         let bar = x && y && z;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -528,7 +528,7 @@ let CodegenLogicalOperatorsWithDoExpressions () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -549,7 +549,7 @@ let CodegenTupleLiteral () =
         let tuple = ["hello", 5, true];
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -570,7 +570,7 @@ let CodegenImmutableTupleLiteral () =
         let tuple = #["hello", 5, true];
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -591,7 +591,7 @@ let CodegenObjectLiteral () =
         let object = {a: "hello", b: 5, c: true};
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -612,7 +612,7 @@ let CodegenImmutableObjectLiteral () =
         let object = #{a: "hello", b: 5, c: true};
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -634,7 +634,7 @@ let CodegenDestructureObjects () =
         let {point: {x, y}, color} = object;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -656,7 +656,7 @@ let CodegenDestructureObjectWithRest () =
         let {foo, ...rest} = object;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -678,7 +678,7 @@ let CodegenDestructureTuples () =
         let [msg, [num, flag]] = tuple;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -700,7 +700,7 @@ let CodegenDestructureTupleWithRest () =
         let [foo, ...rest] = tuple;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -726,7 +726,7 @@ let CodegenIfLetObject () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -752,7 +752,7 @@ let CodegenMatchArray () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -785,7 +785,7 @@ let CodegenMatchUnion () =
         };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -814,7 +814,7 @@ let CodegenTryCatch () =
           };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -840,7 +840,7 @@ let CodegenTryFinally () =
           };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -869,7 +869,7 @@ let CodegenTryCatchFinally () =
           };
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -891,7 +891,7 @@ let CodegenJsxElement () =
         </div>;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -916,7 +916,7 @@ let CodegenJsxFragment () =
         </>;
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -942,12 +942,13 @@ let CodegenDtsBasics () =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
       let projectRoot = __SOURCE_DIRECTORY__
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let env = { env with Filename = "input.esc" }
 
       let! env =
         InferModule.inferModule ctx env escAst
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let ctx: Ctx =
@@ -979,13 +980,14 @@ let CodegenDtsGeneric () =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
       let projectRoot = __SOURCE_DIRECTORY__
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let env = { env with Filename = "input.esc" }
       // TODO: as part of generalization, we need to update the function's
       // inferred type
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let ctx: Ctx =
@@ -1016,7 +1018,7 @@ let CodegenFunctionDeclaration () =
         let sum = add(5, 10);
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -1042,7 +1044,7 @@ let CodegenFunctionOverloads () =
         let msg = add("hello, ", "world");
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -1068,7 +1070,7 @@ let CodegenFunctionOverloadsWithDifferentParams () =
         let msg = add("hello, ", "world");
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"
@@ -1096,7 +1098,7 @@ let CodegenFunctionOverloadsWithShadowing () =
         let msg = add("hello, ", "world");
         """
 
-      let! js, dts = parseAndCodegen src
+      let! js, dts = parseAndCodegen src |> Async.RunSynchronously
 
       return
         $"input: %s{src}\n--- output (js) ---\n{js}\n--- output (dts) ---\n{dts}"

--- a/src/Escalier.Compiler.Tests/Tests.fs
+++ b/src/Escalier.Compiler.Tests/Tests.fs
@@ -111,7 +111,9 @@ let BasicsTests (fixtureDir: string) =
       for path in paths do
         printfn "%s" path
 
-      do! Compiler.compileFile mockWriter fixtureDir entryPath
+      do!
+        Compiler.compileFile mockWriter fixtureDir entryPath
+        |> Async.RunSynchronously
 
       let mutable actual: Map<string, Output> = Map.empty
 

--- a/src/Escalier.Compiler/Compiler.fs
+++ b/src/Escalier.Compiler/Compiler.fs
@@ -53,7 +53,7 @@ module Compiler =
   /// <param name="srcFile">The name of the source code file.</param>
   /// <returns>The compiled code.</returns>
   let compileFile (textwriter: TextWriter) (baseDir: string) (srcFile: string) =
-    result {
+    asyncResult {
       let filename = srcFile
       let contents = File.ReadAllText filename
       let! ctx, env = Prelude.getEnvAndCtx baseDir
@@ -65,7 +65,7 @@ module Compiler =
 
       let! env =
         InferModule.inferModule ctx env ast
-        |> Result.mapError CompileError.TypeError
+        |> AsyncResult.mapError CompileError.TypeError
 
       printDiagnostics textwriter ctx.Report.Diagnostics
 
@@ -92,8 +92,8 @@ module Compiler =
     (textwriter: TextWriter)
     (baseDir: string)
     (srcCode: string)
-    : Result<string * string, CompileError> =
-    result {
+    : Async<Result<string * string, CompileError>> =
+    asyncResult {
       let! ctx, env = Prelude.getEnvAndCtx baseDir
 
       let! ast =
@@ -103,7 +103,7 @@ module Compiler =
 
       let! env =
         InferModule.inferModule ctx env ast
-        |> Result.mapError CompileError.TypeError
+        |> AsyncResult.mapError CompileError.TypeError
 
       printDiagnostics textwriter ctx.Report.Diagnostics
 

--- a/src/Escalier.Interop.Tests/Classes.fs
+++ b/src/Escalier.Interop.Tests/Classes.fs
@@ -44,10 +44,11 @@ let InferClassExtendsClassExtendsClass () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -63,6 +64,7 @@ let InferClassExtendsClassExtendsClass () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz")
@@ -93,10 +95,11 @@ let InferClassExtendsClassExtendsClassWithDestructuring () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -110,6 +113,7 @@ let InferClassExtendsClassExtendsClassWithDestructuring () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz")
@@ -140,10 +144,11 @@ let InferClassExtendsClassExtendsClassWithGenerics () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -159,6 +164,7 @@ let InferClassExtendsClassExtendsClassWithGenerics () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz<number>")

--- a/src/Escalier.Interop.Tests/Interfaces.fs
+++ b/src/Escalier.Interop.Tests/Interfaces.fs
@@ -44,10 +44,11 @@ let InferInterfaceExtendsInferfaceExtendsInterface () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -63,6 +64,7 @@ let InferInterfaceExtendsInferfaceExtendsInterface () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz")
@@ -93,10 +95,11 @@ let InferInterfaceExtendsInferfaceExtendsInterfaceWithTypeParams () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -112,6 +115,7 @@ let InferInterfaceExtendsInferfaceExtendsInterfaceWithTypeParams () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz<number>")
@@ -142,10 +146,11 @@ let InferInterfaceExtendsInferfaceExtendsInterfaceWithDestructuring () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -159,6 +164,7 @@ let InferInterfaceExtendsInferfaceExtendsInterfaceWithDestructuring () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz")
@@ -189,10 +195,11 @@ let InferInterfaceExtendsMultipleInterfaces () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -208,6 +215,7 @@ let InferInterfaceExtendsMultipleInterfaces () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz")
@@ -238,10 +246,11 @@ let InferInterfaceExtendsMultipleInterfacesWithDestructuring () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let input =
@@ -255,6 +264,7 @@ let InferInterfaceExtendsMultipleInterfacesWithDestructuring () =
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "x", "Baz")

--- a/src/Escalier.Interop.Tests/Migrate.fs
+++ b/src/Escalier.Interop.Tests/Migrate.fs
@@ -62,10 +62,11 @@ let ParseAndInferBasicDecls () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "a", "number")
@@ -94,10 +95,11 @@ let ParseAndInferTypeAliases () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(env, "Foo", "string")
@@ -128,10 +130,11 @@ let ParseAndInferInterface () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -162,10 +165,11 @@ let ParseAndInferMappedType () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(env, "Partial", "<T>({[P]+?: T[P] for P in keyof T, ...})")
@@ -191,10 +195,11 @@ let ParseAndInferUnorderedTypeParams () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -223,10 +228,11 @@ let ParseAndInferFuncDecl () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "foo", "fn (x: number, y: string) -> boolean")
@@ -253,10 +259,11 @@ let ParseAndInferClassDecl () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "Foo", "{new fn () -> Foo}")
@@ -290,10 +297,11 @@ let ParseAndInferClassDeclWithStatics () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(
@@ -328,10 +336,11 @@ let ImportThirdPartyModules () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -393,10 +402,11 @@ let ParseAndInferPropertyKey () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -426,10 +436,11 @@ let ParseAndMigrateExportDeclareFunction () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "add", "fn ({mut x, mut y}: Point) -> number")
@@ -549,10 +560,11 @@ let ParseAndInferLibEs5 () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal(true, true)

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -33,10 +33,11 @@ let inferModule src =
   result {
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     return ctx, env
@@ -429,10 +430,11 @@ let InferBasicVarDecls () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Value(env, "a", "number")
@@ -466,10 +468,11 @@ let InferTypeDecls () =
 
       let ast = migrateModule ast
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(env, "Pick", "<T, K: keyof T>({[P]: T[P] for P in K, ...})")
@@ -486,7 +489,7 @@ let InferTypeDecls () =
 let InferLibES5 () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
       // let! newEnv = prelude.loadTypeDefinitions ctx env
 
       // printfn "---- Schemes ----"
@@ -508,7 +511,7 @@ let InferLibES5 () =
 let InferOverloadedFunctionsFromLibDOM () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       Assert.Value(
         env,
@@ -523,7 +526,7 @@ let InferOverloadedFunctionsFromLibDOM () =
 let InferArrayPrototype () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let scheme = env.FindScheme "Array"
       // printfn $"Array = {scheme}"
@@ -540,7 +543,7 @@ let InferArrayPrototype () =
 let InferInt8ArrayPrototype () =
   let result =
     result {
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let scheme = env.FindScheme "Int8Array"
 
@@ -713,10 +716,11 @@ let ImportThirdPartyModules () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Type(
@@ -771,10 +775,11 @@ let ImportReact () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       let binding = env.FindValue "createElement"
@@ -817,10 +822,11 @@ let InferHTMLProps () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal<Diagnostic list>(ctx.Report.Diagnostics, [])
@@ -850,10 +856,11 @@ let InferUseQuery () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       Assert.Equal<Diagnostic list>(ctx.Report.Diagnostics, [])
@@ -878,10 +885,11 @@ let InferAssignUnionToObjectProperty () =
       let! ast =
         Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-      let! ctx, env = Prelude.getEnvAndCtx projectRoot
+      let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
       let! env =
         InferModule.inferModule ctx env ast
+        |> Async.RunSynchronously
         |> Result.mapError CompileError.TypeError
 
       ()

--- a/src/Escalier.Playground/Program.fs
+++ b/src/Escalier.Playground/Program.fs
@@ -27,22 +27,26 @@ let Greet () : int32 =
   0
 
 [<UnmanagedCallersOnly(EntryPoint = "compile")>]
-let Compile () : int32 =
-  printfn "Compile called"
+let Compile () : Async<int32> =
+  async {
+    printfn "Compile called"
 
-  let srcCode = Pdk.GetInputString() // filename
-  let textWriter = new StringWriter()
+    let srcCode = Pdk.GetInputString() // filename
+    let textWriter = new StringWriter()
 
-  match Compiler.compileString textWriter "/" srcCode with
-  | Ok(js, dts) ->
-    let js = System.Web.HttpUtility.JavaScriptStringEncode js
-    let dts = System.Web.HttpUtility.JavaScriptStringEncode dts
-    Pdk.SetOutput($"{{\"js\": \"{js}\", \"dts\": \"{dts}\"}}")
-  | Error errorValue ->
-    // TODO: update CompileOutput to include an error field
-    printfn $"errorValue = {errorValue}"
+    let! result = Compiler.compileString textWriter "/" srcCode
 
-  0
+    match result with
+    | Ok(js, dts) ->
+      let js = System.Web.HttpUtility.JavaScriptStringEncode js
+      let dts = System.Web.HttpUtility.JavaScriptStringEncode dts
+      Pdk.SetOutput($"{{\"js\": \"{js}\", \"dts\": \"{dts}\"}}")
+    | Error errorValue ->
+      // TODO: update CompileOutput to include an error field
+      printfn $"errorValue = {errorValue}"
+
+    return 0
+  }
 
 [<EntryPoint>]
 let Main args =

--- a/src/Escalier.Playground/Program.fs
+++ b/src/Escalier.Playground/Program.fs
@@ -27,26 +27,25 @@ let Greet () : int32 =
   0
 
 [<UnmanagedCallersOnly(EntryPoint = "compile")>]
-let Compile () : Async<int32> =
-  async {
-    printfn "Compile called"
+let Compile () : int32 =
+  printfn "Compile called"
 
-    let srcCode = Pdk.GetInputString() // filename
-    let textWriter = new StringWriter()
+  let srcCode = Pdk.GetInputString() // filename
+  let textWriter = new StringWriter()
 
-    let! result = Compiler.compileString textWriter "/" srcCode
+  let result =
+    Compiler.compileString textWriter "/" srcCode |> Async.RunSynchronously
 
-    match result with
-    | Ok(js, dts) ->
-      let js = System.Web.HttpUtility.JavaScriptStringEncode js
-      let dts = System.Web.HttpUtility.JavaScriptStringEncode dts
-      Pdk.SetOutput($"{{\"js\": \"{js}\", \"dts\": \"{dts}\"}}")
-    | Error errorValue ->
-      // TODO: update CompileOutput to include an error field
-      printfn $"errorValue = {errorValue}"
+  match result with
+  | Ok(js, dts) ->
+    let js = System.Web.HttpUtility.JavaScriptStringEncode js
+    let dts = System.Web.HttpUtility.JavaScriptStringEncode dts
+    Pdk.SetOutput($"{{\"js\": \"{js}\", \"dts\": \"{dts}\"}}")
+  | Error errorValue ->
+    // TODO: update CompileOutput to include an error field
+    printfn $"errorValue = {errorValue}"
 
-    return 0
-  }
+  0
 
 [<EntryPoint>]
 let Main args =

--- a/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
+++ b/src/Escalier.TypeChecker.Tests/ArrayTuple.fs
@@ -13,7 +13,7 @@ open TestUtils
 let inferModule src =
   result {
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let prelude =
       """
@@ -29,6 +29,7 @@ let inferModule src =
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
@@ -37,6 +38,7 @@ let inferModule src =
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     return ctx, env

--- a/src/Escalier.TypeChecker.Tests/Mutability.fs
+++ b/src/Escalier.TypeChecker.Tests/Mutability.fs
@@ -20,7 +20,7 @@ let infer src =
         Result.mapError CompileError.ParseError (Result.Error(parserError))
 
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let! t = Result.mapError CompileError.TypeError (inferExpr ctx env None ast)
 

--- a/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
+++ b/src/Escalier.TypeChecker.Tests/QualifiedGraphTests.fs
@@ -18,10 +18,11 @@ let inferModule src =
   result {
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     return ctx, env

--- a/src/Escalier.TypeChecker.Tests/Symbol.fs
+++ b/src/Escalier.TypeChecker.Tests/Symbol.fs
@@ -23,7 +23,7 @@ type CompileError = Prelude.CompileError
 let inferModule src =
   result {
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let prelude =
       """
@@ -37,12 +37,14 @@ let inferModule src =
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     return ctx, env

--- a/src/Escalier.TypeChecker.Tests/TestUtils.fs
+++ b/src/Escalier.TypeChecker.Tests/TestUtils.fs
@@ -17,10 +17,11 @@ let inferModule src =
   result {
     let! ast = Parser.parseModule src |> Result.mapError CompileError.ParseError
 
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let! env =
       InferModule.inferModule ctx env ast
+      |> Async.RunSynchronously
       |> Result.mapError CompileError.TypeError
 
     return ctx, env

--- a/src/Escalier.TypeChecker.Tests/Tests.fs
+++ b/src/Escalier.TypeChecker.Tests/Tests.fs
@@ -23,7 +23,7 @@ let infer src =
         Result.mapError CompileError.ParseError (Result.Error(parserError))
 
     let projectRoot = __SOURCE_DIRECTORY__
-    let! ctx, env = Prelude.getEnvAndCtx projectRoot
+    let! ctx, env = Prelude.getEnvAndCtx projectRoot |> Async.RunSynchronously
 
     let! t = Result.mapError CompileError.TypeError (inferExpr ctx env None ast)
 

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -39,10 +39,12 @@ module rec Env =
         Nodes = Map.empty
         Namespaces = Map.empty }
 
+  // TODO: Move CompileError into its own package so that we can use it here
   type Ctx
     (
-      getExports: Ctx -> string -> Syntax.Import -> Namespace,
-      resolvePath: Ctx -> string -> Syntax.Import -> string,
+      getExports:
+        Ctx -> string -> Syntax.Import -> Async<Result<Namespace, TypeError>>,
+      resolvePath: Ctx -> string -> Syntax.Import -> Async<string>,
       inferExpr:
         Ctx -> Env -> option<Type> -> Syntax.Expr -> Result<Type, TypeError>,
       inferModuleItems:

--- a/src/Escalier.TypeChecker/InferModule.fs
+++ b/src/Escalier.TypeChecker/InferModule.fs
@@ -1326,10 +1326,10 @@ module rec InferModule =
     (ctx: Ctx)
     (env: Env)
     (import: Import)
-    : Result<Env, TypeError> =
+    : Async<Result<Env, TypeError>> =
 
-    result {
-      let exports = ctx.GetExports env.Filename import
+    asyncResult {
+      let! exports = ctx.GetExports env.Filename import
 
       let mutable imports = Namespace.empty
 
@@ -1386,8 +1386,12 @@ module rec InferModule =
             Namespace = env.Namespace.Merge imports }
     }
 
-  let inferModule (ctx: Ctx) (env: Env) (ast: Module) : Result<Env, TypeError> =
-    result {
+  let inferModule
+    (ctx: Ctx)
+    (env: Env)
+    (ast: Module)
+    : Async<Result<Env, TypeError>> =
+    asyncResult {
       // TODO: update this function to accept a filename
       let mutable newEnv = env // { env with Filename = "input.esc" }
 


### PR DESCRIPTION
For the playground, I'd like to use `fetch` to read files from a `node_modules` directly that gets uploaded to GitHub.io.  `fetch` is an asynchronous API so we need to make sure the existing file I/O code is also async.  Eventually, I'll update Prelude.fs and Compiler.fs to use dependency injection so that we pass the file I/O code in.  The tricky part will be figuring out what to do about the `File.Exists` call in Prelude.fs, but that's a problem for tomorrow me.