### PR TITLE
Use PropName instead Expr for TsTypeElement variants

### DIFF
--- a/src/Escalier.Codegen/Codegen.fs
+++ b/src/Escalier.Codegen/Codegen.fs
@@ -1929,12 +1929,12 @@ module rec Codegen =
     | Callable callable -> failwith "TODO: buildObjTypeElem - Callable"
     | Constructor ctor -> failwith "TODO: buildObjTypeElem - Constructor"
     | Property prop ->
+      // TODO: match all cases
       match prop.Name with
       | PropName.String s ->
         TsTypeElement.TsPropertySignature
           { Readonly = false
-            Key = Expr.Ident { Name = s; Loc = None }
-            Computed = false
+            Key = TS.PropName.Ident { Name = s; Loc = None }
             Optional = false
             TypeAnn = buildTypeAnn ctx prop.Type
             Loc = None }

--- a/src/Escalier.Codegen/Printer.fs
+++ b/src/Escalier.Codegen/Printer.fs
@@ -1004,9 +1004,11 @@ module rec Printer =
       $"new {typeParams}({ps}){typeAnn}"
     | TsPropertySignature propSig ->
       let key =
-        match propSig.Computed with
-        | true -> $"[{printExpr ctx propSig.Key}]"
-        | false -> printExpr ctx propSig.Key
+        match propSig.Key with
+        | PropName.Ident id -> id.Name
+        | PropName.Str { Value = value } -> $"\"{value}\""
+        | PropName.Num { Value = value } -> $"{value}"
+        | PropName.Computed { Expr = expr } -> $"[{printExpr ctx expr}]"
 
       let typeAnn = printTypeAnn ctx propSig.TypeAnn
 
@@ -1124,3 +1126,10 @@ module rec Printer =
       let right = right.Name
       $"{left}.{right}"
     | Identifier { Name = name } -> name
+
+  let printPropName (ctx: PrintCtx) (name: PropName) : string =
+    match name with
+    | PropName.Ident id -> id.Name
+    | PropName.Str { Value = value } -> $"\"{value}\""
+    | PropName.Num { Value = value } -> $"{value}"
+    | PropName.Computed { Expr = expr } -> $"[{printExpr ctx expr}]"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseDomInterface.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseDomInterface.verified.txt
@@ -23,7 +23,6 @@ output: Success: { Body =
                      { Readonly = false
                        Key = Ident { Name = "newURL"
                                      Loc = None }
-                       Computed = false
                        Optional = true
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsStringKeyword
@@ -34,7 +33,6 @@ output: Success: { Body =
                      { Readonly = false
                        Key = Ident { Name = "oldURL"
                                      Loc = None }
-                       Computed = false
                        Optional = true
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsStringKeyword

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseIndexedType.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseIndexedType.verified.txt
@@ -48,10 +48,13 @@ output: Success: { Body =
                                         [TsPropertySignature
                                            { Readonly = false
                                              Key =
-                                              Ident
-                                                { Name = "UNDEFINED_VOID_ONLY"
+                                              Computed
+                                                { Expr =
+                                                   Ident
+                                                     { Name =
+                                                        "UNDEFINED_VOID_ONLY"
+                                                       Loc = None }
                                                   Loc = None }
-                                             Computed = true
                                              Optional = false
                                              TypeAnn =
                                               { TypeAnn =

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithComputedPropertyAndComputedMethod.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithComputedPropertyAndComputedMethod.verified.txt
@@ -18,14 +18,16 @@ output: Success: { Body =
                { Body =
                   [TsPropertySignature
                      { Readonly = false
-                       Key = Member { Object = Ident { Name = "Bar"
-                                                       Loc = None }
-                                      Property = Ident { Name = "Baz"
-                                                         Loc = None }
-                                      Computed = false
-                                      OptChain = false
-                                      Loc = None }
-                       Computed = true
+                       Key =
+                        Computed
+                          { Expr = Member { Object = Ident { Name = "Bar"
+                                                             Loc = None }
+                                            Property = Ident { Name = "Baz"
+                                                               Loc = None }
+                                            Computed = false
+                                            OptChain = false
+                                            Loc = None }
+                            Loc = None }
                        Optional = false
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
@@ -40,7 +42,7 @@ output: Success: { Body =
                                       Computed = false
                                       OptChain = false
                                       Loc = None }
-                       Computed = true
+                       Computed = false
                        Optional = false
                        Params =
                         [{ Pat = Ident { Id = { Name = "hint"

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithOptionalMethodAndProperty.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaceWithOptionalMethodAndProperty.verified.txt
@@ -21,7 +21,6 @@ output: Success: { Body =
                      { Readonly = false
                        Key = Ident { Name = "foo"
                                      Loc = None }
-                       Computed = false
                        Optional = true
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsBooleanKeyword

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaces.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseInterfaces.verified.txt
@@ -24,7 +24,6 @@ output: Success: { Body =
                      { Readonly = false
                        Key = Ident { Name = "x"
                                      Loc = None }
-                       Computed = false
                        Optional = false
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
@@ -35,7 +34,6 @@ output: Success: { Body =
                      { Readonly = false
                        Key = Ident { Name = "y"
                                      Loc = None }
-                       Computed = false
                        Optional = false
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsNumberKeyword
@@ -67,7 +65,6 @@ output: Success: { Body =
                      { Readonly = false
                        Key = Ident { Name = "length"
                                      Loc = None }
-                       Computed = false
                        Optional = false
                        TypeAnn =
                         { TypeAnn = TsKeywordType { Kind = TsNumberKeyword

--- a/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypeAliases.verified.txt
+++ b/src/Escalier.Interop.Tests/snapshots/Tests.ParseTypeAliases.verified.txt
@@ -34,7 +34,6 @@ output: Success: { Body =
                        { Readonly = false
                          Key = Ident { Name = "value"
                                        Loc = None }
-                         Computed = false
                          Optional = false
                          TypeAnn =
                           { TypeAnn =
@@ -48,7 +47,6 @@ output: Success: { Body =
                        { Readonly = false
                          Key = Ident { Name = "next"
                                        Loc = None }
-                         Computed = false
                          Optional = false
                          TypeAnn =
                           { TypeAnn =

--- a/src/Escalier.Interop/Migrate.fs
+++ b/src/Escalier.Interop/Migrate.fs
@@ -180,14 +180,14 @@ module rec Migrate =
     | TsPropertySignature { Key = key
                             TypeAnn = typeAnn
                             Optional = optional
-                            Readonly = readonly
-                            Computed = _computed } ->
+                            Readonly = readonly } ->
       let name =
         match key with
-        | Expr.Ident id -> PropName.String id.Name
-        | Expr.Lit(Lit.Str str) -> PropName.String str.Value
-        | Expr.Lit(Lit.Num num) -> PropName.Number(num.Value)
-        | expr -> Syntax.PropName.Computed(migrateExpr expr)
+        | PropName.Ident id -> PropName.String id.Name
+        | PropName.Str { Value = value } -> PropName.String value
+        | PropName.Num { Value = value } -> PropName.Number value
+        | PropName.Computed { Expr = expr } ->
+          Syntax.PropName.Computed(migrateExpr expr)
 
       ObjTypeAnnElem.Property
         { Name = name
@@ -200,8 +200,7 @@ module rec Migrate =
                           TypeParams = typeParams
                           Params = fnParams
                           TypeAnn = retType
-                          Optional = _optional
-                          Computed = _computed } ->
+                          Optional = _optional } ->
 
       let typeParams =
         Option.map
@@ -253,8 +252,7 @@ module rec Migrate =
       ObjTypeAnnElem.Mapped mapped
     | TsGetterSignature { Key = key
                           TypeAnn = retType
-                          Optional = _optional
-                          Computed = _computed } ->
+                          Optional = _optional } ->
       let retType =
         match retType with
         | Some t -> migrateTypeAnn t
@@ -273,8 +271,7 @@ module rec Migrate =
           Throws = None }
     | TsSetterSignature { Key = key
                           Param = fnParam
-                          Optional = _optional
-                          Computed = _computed } ->
+                          Optional = _optional } ->
       // TODO: warn if there's a setter on a Readonly interface
       let fnParam = migrateFnParam fnParam
 

--- a/src/Escalier.Interop/TypeScript.fs
+++ b/src/Escalier.Interop/TypeScript.fs
@@ -1164,8 +1164,7 @@ module rec TypeScript =
 
   type TsPropertySignature =
     { Readonly: bool
-      Key: Expr
-      Computed: bool
+      Key: PropName
       Optional: bool
       // Init: Option<Expr>
       // Params: list<TsFnParam>

--- a/src/Escalier.TypeChecker/InferExpr.fs
+++ b/src/Escalier.TypeChecker/InferExpr.fs
@@ -30,11 +30,14 @@ module rec InferExpr =
       | Syntax.PropName.Computed value ->
         let! t = inferExpr ctx env None value
 
-        match t.Kind with
+        match (prune t).Kind with
         | TypeKind.Literal(Literal.String value) -> return PropName.String value
         | TypeKind.Literal(Literal.Number value) -> return PropName.Number value
         | TypeKind.UniqueSymbol id -> return PropName.Symbol id
-        | _ -> return! Error(TypeError.SemanticError "Invalid key type")
+        | _ ->
+          printfn $"Invalid key type: {t}"
+          printfn "%A" t
+          return! Error(TypeError.SemanticError "Invalid key type")
     }
 
   /// Computes the type of the expression given by node.


### PR DESCRIPTION
This uncovered some issues in BuildGraph.fs, namely that we weren't considering identifiers that appeared in computed properties when build the dependency graph for a module.