### PR TITLE
Update type kinds that can be mutable to have a 'Mutable' field

### DIFF
--- a/src/Escalier.Compiler/Prelude.fs
+++ b/src/Escalier.Compiler/Prelude.fs
@@ -14,32 +14,6 @@ let makeParam (name: string) (ty: Type) : FuncParam =
     Optional = false }
 
 let getGlobalEnv () : Env =
-  let tpA =
-    { Name = "A"
-      Constraint = Some(numType)
-      Default = None }
-
-  let tpB =
-    { Name = "B"
-      Constraint = Some(numType)
-      Default = None }
-
-  let typeRefA =
-    { Kind =
-        { Name = QualifiedIdent.Ident "A"
-          TypeArgs = None
-          Scheme = None }
-        |> TypeKind.TypeRef
-      Provenance = None }
-
-  let typeRefB =
-    { Kind =
-        { Name = QualifiedIdent.Ident "B"
-          TypeArgs = None
-          Scheme = None }
-        |> TypeKind.TypeRef
-      Provenance = None }
-
   let arithemtic (op: string) : Binding =
     let t =
       makeFunctionType
@@ -122,32 +96,6 @@ let getGlobalEnv () : Env =
           never
       Mutable = false
       Export = false }
-
-  let tpA =
-    { Name = "A"
-      Constraint = Some(strType)
-      Default = None }
-
-  let tpB =
-    { Name = "B"
-      Constraint = Some(strType)
-      Default = None }
-
-  let typeRefA =
-    { Kind =
-        { Name = (QualifiedIdent.Ident "A")
-          TypeArgs = None
-          Scheme = None }
-        |> TypeKind.TypeRef
-      Provenance = None }
-
-  let typeRefB =
-    { Kind =
-        { Name = (QualifiedIdent.Ident "B")
-          TypeArgs = None
-          Scheme = None }
-        |> TypeKind.TypeRef
-      Provenance = None }
 
   let stringConcat =
     { Type =

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -723,6 +723,7 @@ module Type =
   type TypeRef =
     { mutable Name: Common.QualifiedIdent
       TypeArgs: option<list<Type>>
+      Mutable: bool
       Scheme: option<Scheme> }
 
     // TODO: include `Scheme` in the equality check
@@ -947,8 +948,14 @@ module Type =
       Implements: option<list<TypeRef>>
       Elems: list<ObjTypeElem>
       Exact: bool // Can't be true if any of Interface, Implements, or Extends are true
-      Immutable: bool // True for #{...}, False for {...}
+      Immutable: bool // True for `#{...}`, False for `{...}`
+      Mutable: bool // True for `mut {...}`, False for `{...}`
       Interface: bool }
+
+  type Tuple =
+    { Elems: list<Type>
+      Mutable: bool
+      Immutable: bool }
 
   type Index = { Target: Type; Index: Type }
 
@@ -975,7 +982,7 @@ module Type =
     | Keyword of Keyword
     | Function of Function
     | Object of Object
-    | Tuple of Common.Tuple<Type>
+    | Tuple of Tuple
     | RestSpread of Type // whether it's rest or spread depends on how the type is being used
     | Literal of Common.Literal
     | UniqueSymbol of id: int

--- a/src/Escalier.GraphQL/Library.fs
+++ b/src/Escalier.GraphQL/Library.fs
@@ -78,10 +78,11 @@ let rec getTypeForField
         { Kind =
             TypeKind.Object
               { Elems = List.rev elems
-                Exact = true
-                Immutable = false
                 Extends = None
                 Implements = None
+                Exact = true
+                Mutable = false
+                Immutable = false
                 Interface = false }
           Provenance = None }
 
@@ -141,6 +142,7 @@ let rec getTypeForField
         TypeKind.TypeRef
           { Name = QualifiedIdent.Ident "Array"
             TypeArgs = Some [ t ]
+            Mutable = false
             Scheme = None }
       Provenance = None }
   | _ -> failwith "unexpected field type"

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -140,6 +140,7 @@ module rec Env =
   let makeTypeRefKind name =
     { Name = name
       TypeArgs = None
+      Mutable = false
       Scheme = None }
     |> TypeKind.TypeRef
 

--- a/src/Escalier.TypeChecker/Folder.fs
+++ b/src/Escalier.TypeChecker/Folder.fs
@@ -56,10 +56,10 @@ module Folder =
         | TypeKind.Function f ->
           { Kind = TypeKind.Function(foldFn f)
             Provenance = None }
-        | TypeKind.Tuple { Elems = elems; Immutable = immutable } ->
+        | TypeKind.Tuple({ Elems = elems } as tuple) ->
           let elems = List.map fold elems
 
-          { Kind = TypeKind.Tuple { Elems = elems; Immutable = immutable }
+          { Kind = TypeKind.Tuple { tuple with Elems = elems }
             Provenance = None }
         | TypeKind.TypeRef typeRef ->
           // NOTE: We explicitly don't fold the scheme type here because
@@ -73,25 +73,19 @@ module Folder =
             Provenance = None }
         | TypeKind.Literal _ -> t
         | TypeKind.Wildcard -> t
-        | TypeKind.Object { Extends = extends
+        | TypeKind.Object({ Extends = extends
                             Implements = impls
-                            Elems = elems
-                            Exact = exact
-                            Immutable = immutable
-                            Interface = int } ->
+                            Elems = elems } as obj) ->
           let elems = List.map foldObjElem elems
-
           let extends = extends |> Option.map (List.map foldTypeRef)
           let impls = impls |> Option.map (List.map foldTypeRef)
 
           { Kind =
               TypeKind.Object
-                { Extends = extends
-                  Implements = impls
-                  Elems = elems
-                  Exact = exact
-                  Immutable = immutable
-                  Interface = int }
+                { obj with
+                    Extends = extends
+                    Implements = impls
+                    Elems = elems }
             Provenance = None }
         | TypeKind.RestSpread t ->
           { Kind = TypeKind.RestSpread(fold t)

--- a/src/Escalier.TypeChecker/Helpers.fs
+++ b/src/Escalier.TypeChecker/Helpers.fs
@@ -163,6 +163,7 @@ let maybeWrapInPromise (t: Type) (e: Type) : Type =
         TypeKind.TypeRef
           { Name = QualifiedIdent.Ident "Promise"
             TypeArgs = Some([ t; e ])
+            Mutable = false
             Scheme = None }
       Provenance = None }
 
@@ -421,6 +422,7 @@ let qualifyTypeRefs
       match t.Kind with
       | TypeKind.TypeRef { Name = QualifiedIdent.Ident name
                            Scheme = scheme
+                           Mutable = mut
                            TypeArgs = typeArgs } ->
         match nsScheme.TryFind name with
         | Some _ ->
@@ -430,6 +432,7 @@ let qualifyTypeRefs
             TypeKind.TypeRef
               { Name = name
                 TypeArgs = typeArgs
+                Mutable = mut
                 Scheme = scheme }
 
           Some { t with Kind = kind }

--- a/src/Escalier.TypeChecker/InferClass.fs
+++ b/src/Escalier.TypeChecker/InferClass.fs
@@ -9,12 +9,8 @@ open Escalier.Data.Type
 open Escalier.Data.Visitor
 
 open Error
-open Prune
 open Env
-open Mutability
 open Poly
-open Unify
-open Helpers
 open InferExpr
 open InferTypeAnn
 
@@ -58,6 +54,7 @@ module InferClass =
                 TypeKind.TypeRef
                   { Name = QualifiedIdent.Ident typeParam.Name
                     TypeArgs = None
+                    Mutable = false
                     Scheme = None }
               Provenance = None }))
 
@@ -66,6 +63,7 @@ module InferClass =
             TypeKind.TypeRef
               { Name = QualifiedIdent.Ident className
                 TypeArgs = typeArgs
+                Mutable = false
                 Scheme = Some placeholder }
           Provenance = None }
 
@@ -280,6 +278,7 @@ module InferClass =
                 Elems = instanceElems
                 Exact = false
                 Immutable = false
+                Mutable = false
                 Interface = false }
           Provenance = None }
 
@@ -309,6 +308,7 @@ module InferClass =
                 Elems = staticElems
                 Exact = true
                 Immutable = false
+                Mutable = false
                 Interface = false }
           Provenance = None }
 
@@ -496,6 +496,7 @@ module InferClass =
                     Elems = instanceElems
                     Exact = false
                     Immutable = false
+                    Mutable = false
                     Interface = false }
               Provenance = None }
 
@@ -528,6 +529,7 @@ module InferClass =
             Elems = staticElems
             Exact = true
             Immutable = false
+            Mutable = false
             Interface = false }
 
       return staticObjType, placeholder

--- a/src/Escalier.TypeChecker/InferExpr.fs
+++ b/src/Escalier.TypeChecker/InferExpr.fs
@@ -192,7 +192,11 @@ module rec InferExpr =
           let! elems = List.traverseResultM (inferExpr ctx env None) elems
 
           return
-            { Kind = TypeKind.Tuple { Elems = elems; Immutable = immutable }
+            { Kind =
+                TypeKind.Tuple
+                  { Elems = elems
+                    Immutable = immutable
+                    Mutable = true }
               Provenance = None }
         | ExprKind.IfElse { Condition = condition
                             Then = thenBranch
@@ -343,6 +347,7 @@ module rec InferExpr =
                     Elems = elems
                     Exact = exact
                     Immutable = immutable
+                    Mutable = not immutable
                     Interface = false }
               Provenance = None }
 
@@ -614,6 +619,7 @@ module rec InferExpr =
                     "ReactNode"
                   )
                 TypeArgs = None
+                Mutable = false
                 Scheme = None }
           Provenance = None }
 
@@ -658,6 +664,7 @@ module rec InferExpr =
                       "ReactNode"
                     )
                   TypeArgs = None
+                  Mutable = false
                   Scheme = None }
             Provenance = None }
 
@@ -670,6 +677,7 @@ module rec InferExpr =
                       "IntrinsicElements"
                     )
                   TypeArgs = None
+                  Mutable = false
                   Scheme = None }
             Provenance = None }
 
@@ -799,6 +807,7 @@ module rec InferExpr =
                     TypeKind.TypeRef
                       { Name = QualifiedIdent.Ident "Self"
                         Scheme = scheme
+                        Mutable = identPat.IsMut
                         TypeArgs = None }
                   Provenance = None }
 

--- a/src/Escalier.TypeChecker/InferPattern.fs
+++ b/src/Escalier.TypeChecker/InferPattern.fs
@@ -116,6 +116,7 @@ module InferPattern =
                   Elems = elems
                   Exact = true // TODO: This should depend what the pattern is matching/destructuring
                   Immutable = immutable
+                  Mutable = false
                   Interface = false }
             Provenance = Some(Provenance.Pattern pat) }
 
@@ -123,7 +124,11 @@ module InferPattern =
       | PatternKind.Tuple { Elems = elems; Immutable = immutable } ->
         let elems = List.map infer_pattern_rec elems
 
-        { Kind = TypeKind.Tuple { Elems = elems; Immutable = immutable }
+        { Kind =
+            TypeKind.Tuple
+              { Elems = elems
+                Immutable = immutable
+                Mutable = false }
           Provenance = None }
       | PatternKind.Enum variant ->
         printfn $"Looking up tag for {variant.Ident}"
@@ -146,6 +151,7 @@ module InferPattern =
                     Elems = elems
                     Exact = true // TODO: This should depend what the pattern is matching/destructuring
                     Immutable = true
+                    Mutable = false
                     Interface = false }
               Provenance = None }
           | Result.Error _ -> failwith "Can't find enum type"

--- a/src/Escalier.TypeChecker/InferTypeAnn.fs
+++ b/src/Escalier.TypeChecker/InferTypeAnn.fs
@@ -64,10 +64,16 @@ module rec InferTypeAnn =
                 Elems = elems
                 Exact = exact
                 Immutable = immutable
+                Mutable = false // TODO
                 Interface = false }
         | TypeAnnKind.Tuple { Elems = elems; Immutable = immutable } ->
           let! elems = List.traverseResultM (inferTypeAnn ctx env) elems
-          return TypeKind.Tuple { Elems = elems; Immutable = immutable }
+
+          return
+            TypeKind.Tuple
+              { Elems = elems
+                Immutable = immutable
+                Mutable = false }
         | TypeAnnKind.Union types ->
           let! types = List.traverseResultM (inferTypeAnn ctx env) types
           return (union types).Kind
@@ -159,6 +165,7 @@ module rec InferTypeAnn =
           return
             { Name = name
               TypeArgs = Some(typeArgs)
+              Mutable = false // TODO
               Scheme = Some scheme }
             |> TypeKind.TypeRef
         | None ->
@@ -166,6 +173,7 @@ module rec InferTypeAnn =
           return
             { Name = name
               TypeArgs = None
+              Mutable = false // TODO
               Scheme = Some scheme }
             |> TypeKind.TypeRef
       | Error _ ->

--- a/src/Escalier.TypeChecker/Poly.fs
+++ b/src/Escalier.TypeChecker/Poly.fs
@@ -71,6 +71,7 @@ module Poly =
                   TypeKind.TypeRef
                     { Name = QualifiedIdent.Ident name
                       TypeArgs = None
+                      Mutable = false
                       Scheme = None }
                 Provenance = None }
             )
@@ -84,6 +85,7 @@ module Poly =
                   TypeKind.TypeRef
                     { Name = QualifiedIdent.Ident tpName
                       TypeArgs = None
+                      Mutable = false
                       Scheme = None }
                 Provenance = None }
             )

--- a/src/Escalier.TypeChecker/QualifiedGraph.fs
+++ b/src/Escalier.TypeChecker/QualifiedGraph.fs
@@ -213,6 +213,7 @@ let mergeType (imutType: Type) (mutType: Type) : Type =
           Elems = List.ofSeq elems @ unnamedElems
           Exact = false // MergeType should only be used with interfaces which can't be exact
           Immutable = false
+          Mutable = false
           Interface = false }
 
     { Kind = kind; Provenance = None }

--- a/src/Escalier.TypeChecker/Unify.fs
+++ b/src/Escalier.TypeChecker/Unify.fs
@@ -206,6 +206,7 @@ module rec Unify =
                       List.map
                         (fun (param: FuncParam) -> param.Type)
                         (List.skip nonRestParams2.Length f1.ParamList)
+                    Mutable = false
                     Immutable = false }
               Provenance = None }
 
@@ -368,6 +369,7 @@ module rec Unify =
                     Elems = combinedElems
                     Exact = false
                     Immutable = false // TODO: figure out what do do with `Immutable`
+                    Mutable = false // TODO: figure out what do do with `Mutable`
                     Interface = false }
               Provenance = None }
 
@@ -395,20 +397,21 @@ module rec Unify =
                     Elems = objElems
                     Exact = false
                     Immutable = false // TODO: figure out what do do with `Immutable`
+                    Mutable = false // TODO: figure out what do do with `Mutable`
                     Interface = false }
               Provenance = None }
 
           do! unify ctx env ips newObjType objType
 
           let newRestType =
-            // TODO: figure out what do do with `Immutable`
             { Kind =
                 TypeKind.Object
                   { Extends = None
                     Implements = None
                     Elems = restElems
                     Exact = false
-                    Immutable = false
+                    Immutable = false // TODO: figure out what do do with `Immutable`
+                    Mutable = false // TODO: figure out what do do with `Mutable`
                     Interface = false }
               Provenance = None }
 
@@ -455,6 +458,7 @@ module rec Unify =
                     Elems = combinedElems
                     Exact = false
                     Immutable = false // TODO: figure out what do do with `Immutable`
+                    Mutable = false // TODO: figure out what do do with `Mutable`
                     Interface = false }
               Provenance = None }
 
@@ -473,28 +477,28 @@ module rec Unify =
               obj.Elems
 
           let newObjType =
-            // TODO: figure out what do do with `Immutable`
             { Kind =
                 TypeKind.Object
                   { Extends = None
                     Implements = None
                     Elems = objElems
                     Exact = false
-                    Immutable = false
+                    Immutable = false // TODO: figure out what do do with `Immutable`
+                    Mutable = false // TODO: figure out what do do with `Mutable`
                     Interface = false }
               Provenance = None }
 
           do! unify ctx env ips objType newObjType
 
           let newRestType =
-            // TODO: figure out what do do with `Immutable`
             { Kind =
                 TypeKind.Object
                   { Extends = None
                     Implements = None
                     Elems = restElems
                     Exact = false
-                    Immutable = false
+                    Immutable = false // TODO: figure out what do do with `Immutable`
+                    Mutable = false // TODO: figure out what do do with `Mutable`
                     Interface = false }
               Provenance = None }
 
@@ -685,6 +689,7 @@ module rec Unify =
                     Elems = List.rev spreadProps
                     Exact = false // TODO
                     Immutable = false // TODO
+                    Mutable = false // TODO
                     Interface = false }
               Provenance = None }
 
@@ -745,6 +750,7 @@ module rec Unify =
                     Elems = List.rev restProps
                     Exact = obj1.Exact
                     Immutable = false // TODO
+                    Mutable = false // TODO
                     Interface = false }
               Provenance = None }
 
@@ -768,6 +774,7 @@ module rec Unify =
                     Elems = List.rev leftoverProperties
                     Exact = false // TODO
                     Immutable = false // TODO
+                    Mutable = false // TODO
                     Interface = false }
               Provenance = None }
 
@@ -1464,6 +1471,7 @@ module rec Unify =
                     Elems = elems
                     Exact = exact
                     Immutable = immutable
+                    Mutable = false // TODO
                     Interface = false }
               Provenance = None // TODO: set provenance
             }
@@ -1485,13 +1493,14 @@ module rec Unify =
                 TypeKind.TypeRef
                   { Name = QualifiedIdent.Ident "Array"
                     TypeArgs = Some [ arrayElem ]
+                    Mutable = false // TODO
                     Scheme = scheme }
               Provenance = None }
-        | TypeKind.Tuple { Elems = elems; Immutable = immutable } ->
+        | TypeKind.Tuple({ Elems = elems } as tuple) ->
           let! elems = elems |> List.traverseResultM (expand mapping)
 
           return
-            { Kind = TypeKind.Tuple { Elems = elems; Immutable = immutable }
+            { Kind = TypeKind.Tuple { tuple with Elems = elems }
               Provenance = None }
         | TypeKind.TypeRef { Name = name
                              TypeArgs = typeArgs
@@ -1578,8 +1587,9 @@ module rec Unify =
                     { Extends = None
                       Implements = None
                       Elems = allElems
-                      Exact = false
-                      Immutable = false
+                      Exact = false // TODO
+                      Immutable = false // TODO
+                      Mutable = false // TODO
                       Interface = false }
                 Provenance = None }
         | TypeKind.TemplateLiteral { Exprs = elems; Parts = quasis } ->

--- a/src/Escalier.TypeChecker/UnifyCall.fs
+++ b/src/Escalier.TypeChecker/UnifyCall.fs
@@ -265,7 +265,11 @@ module rec UnifyCall =
           let! args = List.traverseResultM (ctx.InferExpr ctx env None) args
 
           let tuple =
-            { Kind = TypeKind.Tuple { Elems = args; Immutable = false }
+            { Kind =
+                TypeKind.Tuple
+                  { Elems = args
+                    Immutable = false
+                    Mutable = false }
               Provenance = None }
 
           match unify ctx env ips tuple param.Type with


### PR DESCRIPTION
Currently the `Mutable` field doesn't do anything.  I wanted to get it in place first.  The next step will be updating the parser to support the new `mut T` syntax.

I also removed `inferExprStructuralPlacholder` since it wasn't being used and it's unlikely we'll need it anytime soon (if at all).