### PR TITLE
Enums: remove object variant, use parens for tuple variant

### DIFF
--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/enum/enum.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/enum/enum.esc
@@ -1,6 +1,6 @@
 enum MyEnum {
-  Foo[number, string, boolean],
-  Bar[[number, number]],
-  Baz[number | string],
+  Foo(number, string, boolean),
+  Bar([number, number]),
+  Baz(number | string),
 }
 let value = MyEnum.Foo(5, "hello", true);

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/enum_pattern_matching/enum_pattern_matching.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/enum_pattern_matching/enum_pattern_matching.esc
@@ -1,12 +1,10 @@
 enum MyEnum {
-  Foo[number, string, boolean],
-  Bar[[number, number]],
-  Baz {x: number, y: number},
+  Foo(number, string, boolean),
+  Bar([number, number]),
 }
 let value: MyEnum = MyEnum.Foo(5, "hello", true);
 
 let x = match value {
-  MyEnum.Foo[x, y, z] => x,
-  MyEnum.Bar[[x, y]] => x,
-  MyEnum.Baz {x, y} => x,
+  MyEnum.Foo(x, y, z) => x,
+  MyEnum.Bar([x, y]) => x,
 };

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/enum_variant_is_subtype_of_enum/enum_variantis_subtype_of_enum.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/enum_variant_is_subtype_of_enum/enum_variantis_subtype_of_enum.esc
@@ -1,6 +1,6 @@
 enum MyEnum {
-  Foo[number, string, boolean],
-  Bar[[number, number]],
-  Baz[number | string],
+  Foo(number, string, boolean),
+  Bar([number, number]),
+  Baz(number | string),
 }
 let value: MyEnum = MyEnum.Foo(5, "hello", true);

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/generic_enum/generic_enum.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/generic_enum/generic_enum.esc
@@ -1,6 +1,6 @@
 enum MyEnum<A, B, C> {
-  Foo[A],
-  Bar[B],
-  Baz[C],
+  Foo(A),
+  Bar(B),
+  Baz(C),
 }
 let value = MyEnum.Foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/generic_enum_pattern_matching/generic_enum_pattern_matching.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/generic_enum_pattern_matching/generic_enum_pattern_matching.esc
@@ -1,10 +1,10 @@
 enum Option<T> {
-  Some[T],
+  Some(T),
   None,
 }
 declare let value: Option<number>;
 
 let x = match value {
-  Option.Some[value] => value,
+  Option.Some(value) => value,
   Option.None => 0,
 };

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/generic_enum_with_subtyping/generic_enum_with_subtyping.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/generic_enum_with_subtyping/generic_enum_with_subtyping.esc
@@ -1,11 +1,11 @@
 enum MyEnum<A, B, C> {
-  Foo[A],
-  Bar[B],
-  Baz[C],
+  Foo(A),
+  Bar(B),
+  Baz(C),
 }
 let value: MyEnum<number, string, boolean> = MyEnum.Foo(5);
 let x = match value {
-  MyEnum.Foo[a] => a,
-  MyEnum.Bar[b] => b,
-  MyEnum.Baz[c] => c,
+  MyEnum.Foo(a) => a,
+  MyEnum.Bar(b) => b,
+  MyEnum.Baz(c) => c,
 };

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -491,8 +491,8 @@ let ParseEnum () =
   let src =
     """
     enum MyEnum {
-      Foo[number, string, boolean],
-      Bar {x: number, y: number},
+      Foo(number, string, boolean),
+      Bar,
     }
     let value = MyEnum.Foo(5, "hello", true);
     """
@@ -508,7 +508,7 @@ let ParseOptionEnum () =
     """
     enum Option<T> {
       None,
-      Some[T],
+      Some(T),
     }
     let value: Option<string> = Option.Some("hello");
     """
@@ -523,9 +523,9 @@ let ParseGenericEnum () =
   let src =
     """
     enum MyEnum<A, B, C> {
-      Foo[A],
-      Bar[B],
-      Baz[C],
+      Foo(A),
+      Bar(B),
+      Baz(C),
     }
     """
 
@@ -539,9 +539,9 @@ let ParseEnumPatternMatching () =
   let src =
     """
     match value {
-      MyEnum.Foo[a, b, c] => a + b + c,
-      MyEnum.Bar[x, y] => x * y,
-      MyEnum.Baz[z] => z,
+      MyEnum.Foo(a, b, c) => a + b + c,
+      MyEnum.Bar(x, y) => x * y,
+      MyEnum.Baz(z) => z,
     }
     """
 
@@ -737,7 +737,7 @@ let ParseTypeof () =
 let ParseIfLet () =
   let src =
     """
-    if let Option.Some[x] = maybe {
+    if let Option.Some(x) = maybe {
       print(x);
     };
     """
@@ -769,7 +769,7 @@ let ParseIfLetChaining () =
     """
     if let x = maybe1?.x {
       print(x);
-    } else if let Result.Ok[y] = result {
+    } else if let Result.Ok(y) = result {
       print(y);
     };
     """

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnum.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
     enum MyEnum {
-      Foo[number, string, boolean],
-      Bar {x: number, y: number},
+      Foo(number, string, boolean),
+      Bar,
     }
     let value = MyEnum.Foo(5, "hello", true);
     
@@ -43,40 +43,7 @@ output: Ok
                         Span = { Start = (Ln: 3, Col: 7)
                                  Stop = (Ln: 4, Col: 7) } };
                       { Name = "Bar"
-                        TypeAnn =
-                         Some
-                           { Kind =
-                              Object
-                                { Elems =
-                                   [Property
-                                      { Name = Ident "x"
-                                        TypeAnn =
-                                         Some
-                                           { Kind = Keyword Number
-                                             Span = { Start = (Ln: 4, Col: 15)
-                                                      Stop = (Ln: 4, Col: 21) }
-                                             InferredType = None }
-                                        Value = None
-                                        Optional = false
-                                        Readonly = false
-                                        Static = false };
-                                    Property
-                                      { Name = Ident "y"
-                                        TypeAnn =
-                                         Some
-                                           { Kind = Keyword Number
-                                             Span = { Start = (Ln: 4, Col: 26)
-                                                      Stop = (Ln: 4, Col: 32) }
-                                             InferredType = None }
-                                        Value = None
-                                        Optional = false
-                                        Readonly = false
-                                        Static = false }]
-                                  Immutable = false
-                                  Exact = true }
-                             Span = { Start = (Ln: 4, Col: 11)
-                                      Stop = (Ln: 4, Col: 33) }
-                             InferredType = None }
+                        TypeAnn = None
                         Init = None
                         Span = { Start = (Ln: 4, Col: 7)
                                  Stop = (Ln: 5, Col: 5) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnumPatternMatching.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseEnumPatternMatching.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: 
     match value {
-      MyEnum.Foo[a, b, c] => a + b + c,
-      MyEnum.Bar[x, y] => x * y,
-      MyEnum.Baz[z] => z,
+      MyEnum.Foo(a, b, c) => a + b + c,
+      MyEnum.Bar(x, y) => x * y,
+      MyEnum.Baz(z) => z,
     }
     
 output: Ok
@@ -47,7 +47,7 @@ output: Ok
                                                        Stop = (Ln: 3, Col: 25) }
                                               InferredType = None }]
                                           Immutable = false }
-                                     Span = { Start = (Ln: 3, Col: 17)
+                                     Span = { Start = (Ln: 3, Col: 7)
                                               Stop = (Ln: 3, Col: 27) }
                                      InferredType = None } }
                            Span = { Start = (Ln: 3, Col: 7)
@@ -107,7 +107,7 @@ output: Ok
                                                        Stop = (Ln: 4, Col: 22) }
                                               InferredType = None }]
                                           Immutable = false }
-                                     Span = { Start = (Ln: 4, Col: 17)
+                                     Span = { Start = (Ln: 4, Col: 7)
                                               Stop = (Ln: 4, Col: 24) }
                                      InferredType = None } }
                            Span = { Start = (Ln: 4, Col: 7)
@@ -148,7 +148,7 @@ output: Ok
                                                        Stop = (Ln: 5, Col: 19) }
                                               InferredType = None }]
                                           Immutable = false }
-                                     Span = { Start = (Ln: 5, Col: 17)
+                                     Span = { Start = (Ln: 5, Col: 7)
                                               Stop = (Ln: 5, Col: 21) }
                                      InferredType = None } }
                            Span = { Start = (Ln: 5, Col: 7)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseGenericEnum.verified.txt
@@ -1,8 +1,8 @@
 ﻿input: 
     enum MyEnum<A, B, C> {
-      Foo[A],
-      Bar[B],
-      Baz[C],
+      Foo(A),
+      Bar(B),
+      Baz(C),
     }
     
 output: Ok

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLet.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLet.verified.txt
@@ -1,5 +1,5 @@
 ﻿input: 
-    if let Option.Some[x] = maybe {
+    if let Option.Some(x) = maybe {
       print(x);
     };
     
@@ -26,7 +26,7 @@ output: Ok
                                                    Stop = (Ln: 2, Col: 25) }
                                           InferredType = None }]
                                       Immutable = false }
-                                 Span = { Start = (Ln: 2, Col: 23)
+                                 Span = { Start = (Ln: 2, Col: 12)
                                           Stop = (Ln: 2, Col: 27) }
                                  InferredType = None } }
                        Span = { Start = (Ln: 2, Col: 12)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLetChaining.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseIfLetChaining.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
     if let x = maybe1?.x {
       print(x);
-    } else if let Result.Ok[y] = result {
+    } else if let Result.Ok(y) = result {
       print(y);
     };
     
@@ -82,7 +82,7 @@ output: Ok
                                                            (Ln: 4, Col: 30) }
                                                        InferredType = None }]
                                                    Immutable = false }
-                                              Span = { Start = (Ln: 4, Col: 28)
+                                              Span = { Start = (Ln: 4, Col: 19)
                                                        Stop = (Ln: 4, Col: 32) }
                                               InferredType = None } }
                                     Span = { Start = (Ln: 4, Col: 19)

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseOptionEnum.verified.txt
@@ -1,7 +1,7 @@
 ﻿input: 
     enum Option<T> {
       None,
-      Some[T],
+      Some(T),
     }
     let value: Option<string> = Option.Some("hello");
     


### PR DESCRIPTION
This updates the enum syntax to match RFC 5.