### PR TITLE
Don't require 'new' when constructing instances

### DIFF
--- a/src/Escalier.Codegen.Tests/Tests.fs
+++ b/src/Escalier.Codegen.Tests/Tests.fs
@@ -449,7 +449,7 @@ let CodegenCalls () =
         """
         declare fn parseInt(input: string) -> number;
         let num = parseInt("123");
-        let array = new Array(1, 2, 3);
+        let array = Array(1, 2, 3);
         """
 
       let! js, dts = parseAndCodegen src |> Async.RunSynchronously

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenCalls.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenCalls.verified.txt
@@ -1,15 +1,15 @@
 ﻿input: 
         declare fn parseInt(input: string) -> number;
         let num = parseInt("123");
-        let array = new Array(1, 2, 3);
+        let array = Array(1, 2, 3);
         
 --- output (js) ---
 var num = parseInt("123");
-var array = new Array(1, 2, 3);
+var array = Array(1, 2, 3);
 
 --- output (dts) ---
 function parseInt(input: string): number;
 // @escType - number
 const num: number;
-// @escType - Array<_>
-const array: Array<any>;
+// @escType - Array<1 | 2 | 3>
+const array: Array<1 | 2 | 3>;

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_methods_that_call_the_constructor/class_methods_that_call_the_constructor.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_methods_that_call_the_constructor/class_methods_that_call_the_constructor.esc
@@ -2,7 +2,7 @@ let Point = class {
   x: number;
   y: number;
   fn makePoint() {
-    let p = new Self();
+    let p = Self();
     return p;
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_methods_that_take_other_self/class_methods_that_take_other_self.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_methods_that_take_other_self/class_methods_that_take_other_self.esc
@@ -6,12 +6,12 @@ let Point = class {
     self.y = y;
   }
   fn makePoint(x: number, y: number) {
-    return new Self(x, y);
+    return Self(x, y);
   }
   fn add(self, other: Self) -> Self {
     return Self.makePoint(self.x + other.x, self.y + other.y);
   }
 };
-let p1 = new Point(1, 0);
-let p2 = new Point(0, 1);
+let p1 = Point(1, 0);
+let p2 = Point(0, 1);
 let p3 = p1.add(p2);

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_constructor/class_with_constructor.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_constructor/class_with_constructor.esc
@@ -4,4 +4,4 @@ let Foo = class {
     self.msg = msg;
   }
 };
-let foo = new Foo("hello");
+let foo = Foo("hello");

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_fluent_methods/class_with_fluent_methods.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_fluent_methods/class_with_fluent_methods.esc
@@ -4,5 +4,5 @@ let Foo = class {
     return self;
   }
 };
-let foo = new Foo();
+let foo = Foo();
 let bar = foo.bar();

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_fluent_methods_without_typeann/class_with_fluent_methods_without_typeann.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_fluent_methods_without_typeann/class_with_fluent_methods_without_typeann.esc
@@ -4,5 +4,5 @@ let Foo = class {
     return self;
   }
 };
-let foo = new Foo();
+let foo = Foo();
 let bar = foo.bar();

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_fluent_methods_without_typeann_with_type_param/class_with_fluent_methods_without_typeann_with_type_param.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_fluent_methods_without_typeann_with_type_param/class_with_fluent_methods_without_typeann_with_type_param.esc
@@ -4,5 +4,5 @@ let Foo = class<T> {
     return self;
   }
 };
-let foo = new Foo<string>();
+let foo = Foo<string>();
 let bar = foo.bar();

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_methods/class_with_methods.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_methods/class_with_methods.esc
@@ -7,4 +7,4 @@ let Foo = class {
     self.msg = msg;
   }
 };
-let foo = new Foo();
+let foo = Foo();

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_param_and_constructor/class_with_type_param_and_constructor.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_param_and_constructor/class_with_type_param_and_constructor.esc
@@ -4,4 +4,4 @@ let Foo = class<T> {
     self.msg = msg;
   }
 };
-let foo = new Foo<string>("hello");
+let foo = Foo<string>("hello");

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_params/class_with_type_params.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_params/class_with_type_params.esc
@@ -4,4 +4,4 @@ let Foo = class<T> {
     return callback(self.bar);
   }
 };
-let foo = new Foo<string>();
+let foo = Foo<string>();

--- a/src/Escalier.Compiler.Tests/fixtures/classes/disallow_calling_methods_from_constructor/disallow_calling_methods_from_constructor.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/disallow_calling_methods_from_constructor/disallow_calling_methods_from_constructor.esc
@@ -7,4 +7,4 @@ let Foo = class {
     return self.msg;
   }
 };
-let foo = new Foo("hello");
+let foo = Foo("hello");

--- a/src/Escalier.Compiler.Tests/fixtures/classes/require_that_all_properties_be_assigned/require_that_all_properties_be_assigned.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/require_that_all_properties_be_assigned/require_that_all_properties_be_assigned.esc
@@ -5,4 +5,4 @@ let Point = class {
     self.x = x;
   }
 };
-let p = new Point(5, 10);
+let p = Point(5, 10);

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/cant_pass_immutable_args_to_mutable_params/cant_pass_immutable_args_to_mutable_params.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/cant_pass_immutable_args_to_mutable_params/cant_pass_immutable_args_to_mutable_params.esc
@@ -2,5 +2,5 @@ let foo = fn (mut array: Array<number>) {
   array[0] = 5;
   array[1] = 10
 };
-let numbers: number[] = [1, 2, 3];
+let numbers: Array<number> = [1, 2, 3];
 foo(numbers);

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/cant_pass_immutable_args_to_mutable_params/errors.txt
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/cant_pass_immutable_args_to_mutable_params/errors.txt
@@ -1,2 +1,1 @@
-ParseError: Error in Ln: 5 Col: 5
-Expecting: ';' or '}'
+TypeError: SemanticError: immutable binding 'array' cannot alias 'numbers'

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/errors.txt
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/errors.txt
@@ -1,2 +1,2 @@
-ParseError: Error in Ln: 1 Col: 5
-Expecting: ';' or '}'
+ERROR: Initializer doesn't match declared type
+- Type mismatch: number and number | string

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/mutable_assignment_cant_be_covariant.d.ts
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/mutable_assignment_cant_be_covariant.d.ts
@@ -1,0 +1,4 @@
+// @escType - Array<number>
+const foo: Array<number>;
+// @escType - Array<number | string>
+const bar: Array<number | string>;

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/mutable_assignment_cant_be_covariant.esc
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/mutable_assignment_cant_be_covariant.esc
@@ -1,2 +1,2 @@
-let mut foo: number[] = [1, 2, 3];
-let mut bar: (number | string)[] = foo;
+let mut foo: Array<number> = [1, 2, 3];
+let mut bar: Array<number | string> = foo;

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/mutable_assignment_cant_be_covariant.js
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_assignment_cant_be_covariant/mutable_assignment_cant_be_covariant.js
@@ -1,0 +1,2 @@
+var foo = [1, 2, 3];
+var bar = foo;

--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -236,12 +236,6 @@ module Syntax =
       OptChain: bool
       mutable Throws: option<Type.Type> }
 
-  type New =
-    { Callee: Expr
-      TypeArgs: option<list<TypeAnn>>
-      Args: option<list<Expr>>
-      mutable Throws: option<Type.Type> }
-
   type ExprWithTypeArgs = { Expr: Expr; TypeArgs: list<TypeAnn> }
 
   type Class =
@@ -343,7 +337,6 @@ module Syntax =
     | Literal of Common.Literal
     | Function of Function
     | Call of Call
-    | New of New
     | ExprWithTypeArgs of ExprWithTypeArgs
     | Object of Common.Object<ObjElem>
     | Class of Class

--- a/src/Escalier.Data/Visitor.fs
+++ b/src/Escalier.Data/Visitor.fs
@@ -34,10 +34,6 @@ module rec ExprVisitor =
       | ExprKind.Call call ->
         walk call.Callee
         List.iter walk call.Args
-      | ExprKind.New { Callee = callee; Args = args } ->
-        walk callee
-        // TODO: make args required
-        Option.iter (List.iter walk) args
       | ExprKind.Tuple { Elems = elems } -> List.iter walk elems
       | ExprKind.Index { Target = target; Index = index } ->
         walk target

--- a/src/Escalier.Interop.Tests/Tests.fs
+++ b/src/Escalier.Interop.Tests/Tests.fs
@@ -623,7 +623,7 @@ let CallArrayConstructor () =
     result {
       let src =
         """
-        let mut a: Array<number> = new Array();
+        let mut a: Array<number> = Array();
         a.push(5);
         """
 
@@ -641,14 +641,13 @@ let CallArrayConstructorWithTypeArgs () =
     result {
       let src =
         """
-        let mut a = new Array<number>();
+        let mut a = Array<number>();
         a.push(5);
         """
 
       let! ctx, env = inferModule src
 
-      // TODO(#259): Fix function overloads
-      Assert.Value(env, "a", "Array<_>")
+      Assert.Value(env, "a", "Array<number>")
     }
 
   Assert.False(Result.isError result)
@@ -659,13 +658,13 @@ let CallArrayConstructorWithNoTypeAnnotations () =
     result {
       let src =
         """
-        let mut a = new Array();
+        let mut a = Array();
         a.push(5);
         """
 
       let! ctx, env = inferModule src
 
-      Assert.Value(env, "a", "Array<_>")
+      Assert.Value(env, "a", "Array<never>")
     }
 
   Assert.False(Result.isError result)
@@ -692,7 +691,7 @@ let AcessNamespaceValue () =
     result {
       let src =
         """
-        let fmt = new Intl.NumberFormat("en-CA");
+        let fmt = Intl.NumberFormat("en-CA");
         fmt.format(1.23);
         """
 

--- a/src/Escalier.Parser.Tests/Tests.fs
+++ b/src/Escalier.Parser.Tests/Tests.fs
@@ -116,7 +116,7 @@ let ParseCallWithTypeParam () =
 
 [<Fact>]
 let ParseConstructorCall () =
-  let src = "new Array();"
+  let src = "Array();"
   let ast = Parser.parseModule src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -124,7 +124,7 @@ let ParseConstructorCall () =
 
 [<Fact>]
 let ParseConstructorCallWithTypeParam () =
-  let src = "new Array<number>();"
+  let src = "Array<number>();"
   let ast = Parser.parseModule src
   let result = $"input: %s{src}\noutput: %A{ast}"
 
@@ -398,7 +398,7 @@ let ParseNamespacedType () =
 
 [<Fact>]
 let ParseNamespacedValue () =
-  let src = """let fmt = new Intl.NumberFormat("en-CA");"""
+  let src = """let fmt = Intl.NumberFormat("en-CA");"""
   let ast = Parser.parseModule src
   let result = $"input: %s{src}\noutput: %A{ast}"
 

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCall.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCall.verified.txt
@@ -1,17 +1,18 @@
-﻿input: new Array();
+﻿input: Array();
 output: Ok
   { Items =
      [Stmt
         { Kind =
-           Expr { Kind = New { Callee = { Kind = Identifier { Name = "Array" }
-                                          Span = { Start = (Ln: 1, Col: 5)
-                                                   Stop = (Ln: 1, Col: 10) }
-                                          InferredType = None }
-                               TypeArgs = None
-                               Args = Some []
-                               Throws = None }
-                  Span = { Start = (Ln: 1, Col: 5)
-                           Stop = (Ln: 1, Col: 12) }
+           Expr { Kind = Call { Callee = { Kind = Identifier { Name = "Array" }
+                                           Span = { Start = (Ln: 1, Col: 1)
+                                                    Stop = (Ln: 1, Col: 6) }
+                                           InferredType = None }
+                                TypeArgs = None
+                                Args = []
+                                OptChain = false
+                                Throws = None }
+                  Span = { Start = (Ln: 1, Col: 1)
+                           Stop = (Ln: 1, Col: 8) }
                   InferredType = None }
-          Span = { Start = (Ln: 1, Col: 5)
-                   Stop = (Ln: 1, Col: 12) } }] }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 8) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCallWithTypeParam.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseConstructorCallWithTypeParam.verified.txt
@@ -1,22 +1,23 @@
-﻿input: new Array<number>();
+﻿input: Array<number>();
 output: Ok
   { Items =
      [Stmt
         { Kind =
            Expr
              { Kind =
-                New { Callee = { Kind = Identifier { Name = "Array" }
-                                 Span = { Start = (Ln: 1, Col: 5)
-                                          Stop = (Ln: 1, Col: 10) }
-                                 InferredType = None }
-                      TypeArgs = Some [{ Kind = Keyword Number
-                                         Span = { Start = (Ln: 1, Col: 11)
-                                                  Stop = (Ln: 1, Col: 17) }
-                                         InferredType = None }]
-                      Args = Some []
-                      Throws = None }
-               Span = { Start = (Ln: 1, Col: 5)
-                        Stop = (Ln: 1, Col: 20) }
+                Call { Callee = { Kind = Identifier { Name = "Array" }
+                                  Span = { Start = (Ln: 1, Col: 1)
+                                           Stop = (Ln: 1, Col: 6) }
+                                  InferredType = None }
+                       TypeArgs = Some [{ Kind = Keyword Number
+                                          Span = { Start = (Ln: 1, Col: 7)
+                                                   Stop = (Ln: 1, Col: 13) }
+                                          InferredType = None }]
+                       Args = []
+                       OptChain = false
+                       Throws = None }
+               Span = { Start = (Ln: 1, Col: 1)
+                        Stop = (Ln: 1, Col: 16) }
                InferredType = None }
-          Span = { Start = (Ln: 1, Col: 5)
-                   Stop = (Ln: 1, Col: 20) } }] }
+          Span = { Start = (Ln: 1, Col: 1)
+                   Stop = (Ln: 1, Col: 16) } }] }

--- a/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedValue.verified.txt
+++ b/src/Escalier.Parser.Tests/snapshots/Tests.ParseNamespacedValue.verified.txt
@@ -1,4 +1,4 @@
-﻿input: let fmt = new Intl.NumberFormat("en-CA");
+﻿input: let fmt = Intl.NumberFormat("en-CA");
 output: Ok
   { Items =
      [Stmt
@@ -18,31 +18,32 @@ output: Ok
                     Init =
                      Some
                        { Kind =
-                          New
+                          Call
                             { Callee =
                                { Kind =
                                   Member
                                     { Target =
                                        { Kind = Identifier { Name = "Intl" }
-                                         Span = { Start = (Ln: 1, Col: 15)
-                                                  Stop = (Ln: 1, Col: 19) }
+                                         Span = { Start = (Ln: 1, Col: 11)
+                                                  Stop = (Ln: 1, Col: 15) }
                                          InferredType = None }
                                       Name = "NumberFormat"
                                       OptChain = false }
-                                 Span = { Start = (Ln: 1, Col: 15)
-                                          Stop = (Ln: 1, Col: 32) }
+                                 Span = { Start = (Ln: 1, Col: 11)
+                                          Stop = (Ln: 1, Col: 28) }
                                  InferredType = None }
                               TypeArgs = None
-                              Args = Some [{ Kind = Literal (String "en-CA")
-                                             Span = { Start = (Ln: 1, Col: 33)
-                                                      Stop = (Ln: 1, Col: 40) }
-                                             InferredType = None }]
+                              Args = [{ Kind = Literal (String "en-CA")
+                                        Span = { Start = (Ln: 1, Col: 29)
+                                                 Stop = (Ln: 1, Col: 36) }
+                                        InferredType = None }]
+                              OptChain = false
                               Throws = None }
-                         Span = { Start = (Ln: 1, Col: 15)
-                                  Stop = (Ln: 1, Col: 41) }
+                         Span = { Start = (Ln: 1, Col: 11)
+                                  Stop = (Ln: 1, Col: 37) }
                          InferredType = None }
                     Else = None }
                Span = { Start = (Ln: 1, Col: 1)
-                        Stop = (Ln: 1, Col: 42) } }
+                        Stop = (Ln: 1, Col: 38) } }
           Span = { Start = (Ln: 1, Col: 1)
-                   Stop = (Ln: 1, Col: 42) } }] }
+                   Stop = (Ln: 1, Col: 38) } }] }

--- a/src/Escalier.Parser/Parser.fs
+++ b/src/Escalier.Parser/Parser.fs
@@ -1364,23 +1364,6 @@ module Parser =
 
   exprParser.RegisterInfix("<", typeArgsParselet 17)
 
-  let newingParselet: Pratt.PrefixParselet<Expr> =
-    prefixExprParslet 16 (fun operand ->
-      match operand.Kind with
-      | ExprKind.Call call ->
-        { Expr.Kind =
-            ExprKind.New
-              { Callee = call.Callee
-                TypeArgs = call.TypeArgs
-                Args = Some call.Args
-                Throws = None }
-          Span = operand.Span
-          InferredType = None }
-      // TODO: return a Reply
-      | _ -> failwith "Expected call expression")
-
-  exprParser.RegisterPrefix("new", newingParselet)
-
   exprParser.RegisterPrefix("!", unaryExprParslet 14 "!")
   // bitwise not (14)
   exprParser.RegisterPrefix("+", unaryExprParslet 14 "+")

--- a/src/Escalier.TypeChecker/UnifyCall.fs
+++ b/src/Escalier.TypeChecker/UnifyCall.fs
@@ -53,6 +53,11 @@ module rec UnifyCall =
               Some
                 { Kind = TypeKind.Function c
                   Provenance = None }
+          | Constructor c ->
+            callable <-
+              Some
+                { Kind = TypeKind.Function c
+                  Provenance = None }
           | _ -> ()
 
         match callable with


### PR DESCRIPTION
This makes the language cleaner.  In particular it'll mean that constructing "extractor"-based enums will look the same as destructuring (extracting data from) them.