### PR TITLE
mutate Elems field when merging interface decls

### DIFF
--- a/src/Escalier.Data/Library.fs
+++ b/src/Escalier.Data/Library.fs
@@ -939,7 +939,7 @@ module Type =
   type Object =
     { Extends: option<list<TypeRef>> // classes can only have one, interfaces can have many
       Implements: option<list<TypeRef>>
-      Elems: list<ObjTypeElem>
+      mutable Elems: list<ObjTypeElem> // this is mutable to support interface merging
       Exact: bool // Can't be true if any of Interface, Implements, or Extends are true
       Immutable: bool // True for `#{...}`, False for `{...}`
       Mutable: bool // True for `mut {...}`, False for `{...}`


### PR DESCRIPTION
In a future PR we'll want to add a `customMatch` to the `SymbolContructor` interface when the compiler is initializing the environment.  In order for `Symbol.customMatch` to work, we need to mutate `SymbolConstructor` instead of replacing it with a new object type.  This is because the `SymbolConstructor` TypeRef in the `declare var Symbol: SymbolConstructor` declaration can only reference the object type that `SymbolConstructor` was pointing at the time.