### PR TITLE
Add 'unify' to Ctx so that we can reorder TypeChecker files in another PR

### DIFF
--- a/src/Escalier.Compiler/Compiler.fs
+++ b/src/Escalier.Compiler/Compiler.fs
@@ -584,7 +584,8 @@ module Compiler =
             InferModule.inferModuleItems,
             InferPattern.inferPattern,
             InferTypeAnn.inferTypeAnn,
-            InferClass.inferClass
+            InferClass.inferClass,
+            Unify.unify
           )
 
         return ctx

--- a/src/Escalier.TypeChecker/Env.fs
+++ b/src/Escalier.TypeChecker/Env.fs
@@ -56,7 +56,14 @@ module rec Env =
           -> Result<(BindingAssump * Type), TypeError>,
       inferTypeAnn: Ctx -> Env -> Syntax.TypeAnn -> Result<Type, TypeError>,
       inferClass:
-        Ctx -> Env -> Syntax.Class -> bool -> Result<(Type * Scheme), TypeError>
+        Ctx -> Env -> Syntax.Class -> bool -> Result<(Type * Scheme), TypeError>,
+      unify:
+        Ctx
+          -> Env
+          -> option<list<list<string>>>
+          -> Type
+          -> Type
+          -> Result<unit, TypeError>
     ) =
 
     let mutable nextTypeVarId = 0
@@ -130,7 +137,8 @@ module rec Env =
           inferModuleItems,
           inferPattern,
           inferTypeAnn,
-          inferClass
+          inferClass,
+          unify
         )
 
       clone.NextTypeVarId <- this.NextTypeVarId


### PR DESCRIPTION
In particular I want to move `Helpers.fs` above `Unify.fs` so that we can use its `getPropType` method when checking if an object type can unify with an extractor.