### PR TITLE
Use decl statements to destructure all patterns

### DIFF
--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenAsyncFunction.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenAsyncFunction.verified.txt
@@ -5,7 +5,8 @@
         };
         
 --- output (js) ---
-var fetchJSON = async function (url) {
+var fetchJSON = async function (temp0) {
+  var url = temp0;
   var res = await fetch(url);
   return res.json();
 };

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDoExpressionWithReturn.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenDoExpressionWithReturn.verified.txt
@@ -13,24 +13,25 @@
         };
         
 --- output (js) ---
-var foo = function (bar) {
-  var temp0;
+var foo = function (temp0) {
+  var bar = temp0;
+  var temp1;
   {
-    var temp1;
+    var temp2;
     if (bar == 0) {
-      temp1 = "none";
+      temp2 = "none";
     } else {
-      var temp2;
+      var temp3;
       if (bar > 1) {
-        temp2 = "many";
+        temp3 = "many";
       } else {
         return null;
       }
-      temp1 = temp2;
+      temp2 = temp3;
     }
-    temp0 = temp1;
+    temp1 = temp2;
   }
-  var res = temp0;
+  var res = temp1;
   return res;
 };
 

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunction.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunction.verified.txt
@@ -3,14 +3,15 @@
           if (n == 0) { 1 } else { n * factorial(n - 1) }; 
         
 --- output (js) ---
-var factorial = (n) => {
-  var temp0;
+var factorial = (temp0) => {
+  var n = temp0;
+  var temp1;
   if (n == 0) {
-    temp0 = 1;
+    temp1 = 1;
   } else {
-    temp0 = n * factorial((n - 1));
+    temp1 = n * factorial((n - 1));
   }
-  return temp0;
+  return temp1;
 };
 
 --- output (dts) ---

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunctionDeclaration.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunctionDeclaration.verified.txt
@@ -5,7 +5,9 @@
         let sum = add(5, 10);
         
 --- output (js) ---
-function add(a, b) {
+function add(temp0, temp1) {
+  var a = temp0;
+  var b = temp1;
   return a + b;
 }
 var sum = add(5, 10);

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunctionOverloadsWithShadowing.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenFunctionOverloadsWithShadowing.verified.txt
@@ -12,7 +12,9 @@
 --- output (js) ---
 function add(__arg0__, __arg1__) {
   if (typeof __arg0__ == "number" && typeof __arg1__ == "number") {
-    var add = (a, b) => {
+    var add = (temp0, temp1) => {
+      var a = temp0;
+      var b = temp1;
       return a + b;
     };
     return add(__arg0__, __arg1__);

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenMatchArray.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenMatchArray.verified.txt
@@ -9,30 +9,35 @@
         };
         
 --- output (js) ---
-var getCount = function (array) {
-  var temp0;
+var getCount = function (temp0) {
+  var array = temp0;
+  var temp1;
   if (array.length == 0) {
-    temp0 = "none";
+    var [] = array;
+    temp1 = "none";
   } else {
-    var temp1;
+    var temp2;
     if (array.length == 1) {
-      temp1 = "one";
+      var [x] = array;
+      temp2 = "one";
     } else {
-      var temp2;
+      var temp3;
       if (array.length == 2) {
-        temp2 = "a couple";
+        var [x, y] = array;
+        temp3 = "a couple";
       } else {
-        var temp3;
+        var temp4;
         if (true) {
-          temp3 = "many";
+          var _ = array;
+          temp4 = "many";
         }
-        temp2 = temp3;
+        temp3 = temp4;
       }
-      temp1 = temp2;
+      temp2 = temp3;
     }
-    temp0 = temp1;
+    temp1 = temp2;
   }
-  return temp0;
+  return temp1;
 };
 
 --- output (dts) ---

--- a/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenMatchUnion.verified.txt
+++ b/src/Escalier.Codegen.Tests/snapshots/Tests.CodegenMatchUnion.verified.txt
@@ -14,20 +14,23 @@
         };
         
 --- output (js) ---
-var getCount = function (shape) {
-  var temp0;
+var getCount = function (temp0) {
+  var shape = temp0;
+  var temp1;
   if (typeof shape == "object" && "kind" in shape && shape["kind"] == "circle" && "radius" in shape) {
+    var {radius: r} = shape;
     var area = Math.PI * r * r;
-    temp0 = area;
+    temp1 = area;
   } else {
-    var temp1;
+    var temp2;
     if (typeof shape == "object" && "kind" in shape && shape["kind"] == "rect" && "width" in shape && "height" in shape) {
+      var {width: w, height: h} = shape;
       var area = w * h;
-      temp1 = area;
+      temp2 = area;
     }
-    temp0 = temp1;
+    temp1 = temp2;
   }
-  return temp0;
+  return temp1;
 };
 
 --- output (dts) ---

--- a/src/Escalier.Compiler.Tests/fixtures/array_tuple/for_in/for_in.js
+++ b/src/Escalier.Compiler.Tests/fixtures/array_tuple/for_in/for_in.js
@@ -1,7 +1,7 @@
-for (const x of [1, 2, 3]) {
+for (const temp0 of [1, 2, 3]) {
   var y = x;
 }
 var array = [1, 2, 3];
-for (const x of array) {
+for (const temp1 of array) {
   var y = x;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/async_await/async_func/async_func.js
+++ b/src/Escalier.Compiler.Tests/fixtures/async_await/async_func/async_func.js
@@ -1,9 +1,10 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = x;
+    temp1 = x;
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/async_await/propagate_async_error/propagate_async_error.js
+++ b/src/Escalier.Compiler.Tests/fixtures/async_await/propagate_async_error/propagate_async_error.js
@@ -1,13 +1,15 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = x;
+    temp1 = x;
   }
-  return temp0;
+  return temp1;
 };
-var bar = async function (x) {
+var bar = async function (temp2) {
+  var x = temp2;
   var y = await foo(x);
   return y + await 10;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/async_await/try_catch_async/try_catch_async.js
+++ b/src/Escalier.Compiler.Tests/fixtures/async_await/try_catch_async/try_catch_async.js
@@ -1,24 +1,26 @@
-var foo = (x) => {
-  var temp0;
-  if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
-  } else {
-    temp0 = x;
-  }
-  return temp0;
-};
-var bar = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   var temp1;
+  if (x < 0) {
+    temp1 = Escalier.throw("RangeError");
+  } else {
+    temp1 = x;
+  }
+  return temp1;
+};
+var bar = (temp2) => {
+  var x = temp2;
+  var temp3;
   try {
     var y = await foo(x);
-    temp1 = y + await 10;
+    temp3 = y + await 10;
   } catch (__error__) {
-    var temp2;
+    var temp4;
     if (__error__ == "RangeError") {
-      temp2 = 0;
+      temp4 = 0;
     } else {
       throw __error__;
     }
   }
-  return temp1;
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test2/test2.js
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test2/test2.js
@@ -1,9 +1,10 @@
-var factorial = (n) => {
-  var temp0;
+var factorial = (temp0) => {
+  var n = temp0;
+  var temp1;
   if (n == 0) {
-    temp0 = 1;
+    temp1 = 1;
   } else {
-    temp0 = n * factorial((n - 1));
+    temp1 = n * factorial((n - 1));
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/basics/test3/test3.js
+++ b/src/Escalier.Compiler.Tests/fixtures/basics/test3/test3.js
@@ -1,4 +1,5 @@
-var foo = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   return x;
 };
 foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_methods_that_take_other_self/class_methods_that_take_other_self.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_methods_that_take_other_self/class_methods_that_take_other_self.js
@@ -1,14 +1,19 @@
 var Point = class {
   x
   y
-  constructor(x, y) {
+  constructor(temp0, temp1) {
+    var x = temp0;
+    var y = temp1;
     self.x = x;
     self.y = y;
   }
-  makePoint(x, y) {
+  makePoint(temp2, temp3) {
+    var x = temp2;
+    var y = temp3;
     return new Self(x, y);
   }
-  add(other) {
+  add(temp4) {
+    var other = temp4;
     return Self.makePoint((self.x + other.x), (self.y + other.y));
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_constructor/class_with_constructor.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_constructor/class_with_constructor.js
@@ -1,6 +1,7 @@
 var Foo = class {
   msg
-  constructor(msg) {
+  constructor(temp0) {
+    var msg = temp0;
     self.msg = msg;
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_methods/class_with_methods.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_methods/class_with_methods.js
@@ -3,7 +3,8 @@ var Foo = class {
   bar() {
     return self.msg;
   }
-  baz(msg) {
+  baz(temp0) {
+    var msg = temp0;
     self.msg = msg;
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_param_and_constructor/class_with_type_param_and_constructor.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_param_and_constructor/class_with_type_param_and_constructor.js
@@ -1,6 +1,7 @@
 var Foo = class {
   msg
-  constructor(msg) {
+  constructor(temp0) {
+    var msg = temp0;
     self.msg = msg;
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_params/class_with_type_params.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/class_with_type_params/class_with_type_params.js
@@ -1,6 +1,7 @@
 var Foo = class {
   bar
-  map(callback) {
+  map(temp0) {
+    var callback = temp0;
     return callback(self.bar);
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/disallow_calling_methods_from_constructor/disallow_calling_methods_from_constructor.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/disallow_calling_methods_from_constructor/disallow_calling_methods_from_constructor.js
@@ -1,6 +1,7 @@
 var Foo = class {
   msg
-  constructor(msg) {
+  constructor(temp0) {
+    var msg = temp0;
     self.msg = self.bar();
   }
   bar() {

--- a/src/Escalier.Compiler.Tests/fixtures/classes/generic_methods/generic_methods.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/generic_methods/generic_methods.js
@@ -1,8 +1,12 @@
 var Foo = class {
-  fst(a, b) {
+  fst(temp0, temp1) {
+    var a = temp0;
+    var b = temp1;
     return a;
   }
-  snd(a, b) {
+  snd(temp2, temp3) {
+    var a = temp2;
+    var b = temp3;
     return b;
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/generic_recursive_class/generic_recursive_class.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/generic_recursive_class/generic_recursive_class.js
@@ -2,7 +2,8 @@ var Node = class {
   value
   left
   right
-  map(mapper) {
+  map(temp0) {
+    var mapper = temp0;
     var node = {value: mapper(self.value), left: self.left.map(mapper), right: self.right.map(mapper)};
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/classes/require_that_all_properties_be_assigned/require_that_all_properties_be_assigned.js
+++ b/src/Escalier.Compiler.Tests/fixtures/classes/require_that_all_properties_be_assigned/require_that_all_properties_be_assigned.js
@@ -1,7 +1,9 @@
 var Point = class {
   x
   y
-  constructor(x, y) {
+  constructor(temp0, temp1) {
+    var x = temp0;
+    var y = temp1;
     self.x = x;
   }
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/catches_exception/catches_exception.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/catches_exception/catches_exception.js
@@ -1,23 +1,25 @@
-var foo = (x) => {
-  var temp0;
-  if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
-  } else {
-    temp0 = x;
-  }
-  return temp0;
-};
-var bar = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   var temp1;
+  if (x < 0) {
+    temp1 = Escalier.throw("RangeError");
+  } else {
+    temp1 = x;
+  }
+  return temp1;
+};
+var bar = (temp2) => {
+  var x = temp2;
+  var temp3;
   try {
-    temp1 = foo(x);
+    temp3 = foo(x);
   } catch (__error__) {
-    var temp2;
+    var temp4;
     if (__error__ == "RangeError") {
-      temp2 = 0;
+      temp4 = 0;
     } else {
       throw __error__;
     }
   }
-  return temp1;
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/catches_multiple_exceptions/catches_multiple_exceptions.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/catches_multiple_exceptions/catches_multiple_exceptions.js
@@ -1,29 +1,31 @@
-var foo = (x) => {
-  var temp0;
-  if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
-  } else {
-    temp0 = Escalier.throw("BoundsError");
-  }
-  return temp0;
-};
-var bar = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   var temp1;
+  if (x < 0) {
+    temp1 = Escalier.throw("RangeError");
+  } else {
+    temp1 = Escalier.throw("BoundsError");
+  }
+  return temp1;
+};
+var bar = (temp2) => {
+  var x = temp2;
+  var temp3;
   try {
-    temp1 = foo(x);
+    temp3 = foo(x);
   } catch (__error__) {
-    var temp2;
+    var temp4;
     if (__error__ == "RangeError") {
-      temp2 = 0;
+      temp4 = 0;
     } else {
-      var temp3;
+      var temp5;
       if (__error__ == "BoundsError") {
-        temp3 = 0;
+        temp5 = 0;
       } else {
         throw __error__;
       }
-      temp2 = temp3;
+      temp4 = temp5;
     }
   }
-  return temp1;
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/catches_one_of_many_exceptions/catches_one_of_many_exceptions.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/catches_one_of_many_exceptions/catches_one_of_many_exceptions.js
@@ -1,23 +1,25 @@
-var foo = (x) => {
-  var temp0;
-  if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
-  } else {
-    temp0 = Escalier.throw("BoundsError");
-  }
-  return temp0;
-};
-var bar = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   var temp1;
+  if (x < 0) {
+    temp1 = Escalier.throw("RangeError");
+  } else {
+    temp1 = Escalier.throw("BoundsError");
+  }
+  return temp1;
+};
+var bar = (temp2) => {
+  var x = temp2;
+  var temp3;
   try {
-    temp1 = foo(x);
+    temp3 = foo(x);
   } catch (__error__) {
-    var temp2;
+    var temp4;
     if (__error__ == "RangeError") {
-      temp2 = 0;
+      temp4 = 0;
     } else {
       throw __error__;
     }
   }
-  return temp1;
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/explicit_throw/explicit_throw.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/explicit_throw/explicit_throw.js
@@ -1,8 +1,9 @@
-var foo = function (x) {
-  var temp0;
+var foo = function (temp0) {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   }
-  temp0;
+  temp1;
   return x;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/just_throws_expression/just_throws_expression.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/just_throws_expression/just_throws_expression.js
@@ -1,3 +1,4 @@
-var foo = (exc) => {
+var foo = (temp0) => {
+  var exc = temp0;
   return Escalier.throw(exc);
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/throws_expression/throws_expression.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/throws_expression/throws_expression.js
@@ -1,9 +1,10 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = x;
+    temp1 = x;
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/throws_from_call/throws_from_call.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/throws_from_call/throws_from_call.js
@@ -1,12 +1,14 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = x;
+    temp1 = x;
   }
-  return temp0;
+  return temp1;
 };
-var bar = (x) => {
+var bar = (temp2) => {
+  var x = temp2;
   return foo(x);
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/throws_multiple_expressions/throws_multiple_expressions.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/throws_multiple_expressions/throws_multiple_expressions.js
@@ -1,9 +1,10 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = Escalier.throw("BoundsError");
+    temp1 = Escalier.throw("BoundsError");
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/try_catch_finally/try_catch_finally.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/try_catch_finally/try_catch_finally.js
@@ -1,28 +1,30 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = x;
+    temp1 = x;
   }
-  return temp0;
+  return temp1;
 };
 var cleanup = () => {
   return {};
 };
-var bar = (x) => {
-  var temp1;
+var bar = (temp2) => {
+  var x = temp2;
+  var temp3;
   try {
-    temp1 = foo(x);
+    temp3 = foo(x);
   } catch (__error__) {
-    var temp2;
+    var temp4;
     if (__error__ == "RangeError") {
-      temp2 = 0;
+      temp4 = 0;
     } else {
       throw __error__;
     }
   } finally {
     cleanup();
   }
-  return temp1;
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/exceptions/try_finally/try_finally.js
+++ b/src/Escalier.Compiler.Tests/fixtures/exceptions/try_finally/try_finally.js
@@ -1,21 +1,23 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x < 0) {
-    temp0 = Escalier.throw("RangeError");
+    temp1 = Escalier.throw("RangeError");
   } else {
-    temp0 = x;
+    temp1 = x;
   }
-  return temp0;
+  return temp1;
 };
 var cleanup = () => {
   return {};
 };
-var bar = (x) => {
-  var temp1;
+var bar = (temp2) => {
+  var x = temp2;
+  var temp3;
   try {
-    temp1 = foo(x);
+    temp3 = foo(x);
   } finally {
     cleanup();
   }
-  return temp1;
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/extractors/basic_extractor/basic_extractor.js
+++ b/src/Escalier.Compiler.Tests/fixtures/extractors/basic_extractor/basic_extractor.js
@@ -1,6 +1,7 @@
 var C = class {
   msg
-  constructor(value) {
+  constructor(temp0) {
+    var value = temp0;
     self.msg = value;
   }
   [Symbol.customMatcher]() {

--- a/src/Escalier.Compiler.Tests/fixtures/extractors/multiple_args/multiple_args.js
+++ b/src/Escalier.Compiler.Tests/fixtures/extractors/multiple_args/multiple_args.js
@@ -1,7 +1,9 @@
 var C = class {
   first
   second
-  constructor(first, second) {
+  constructor(temp0, temp1) {
+    var first = temp0;
+    var second = temp1;
     self.first = first;
     self.second = second;
   }

--- a/src/Escalier.Compiler.Tests/fixtures/extractors/object_arg/object_arg.js
+++ b/src/Escalier.Compiler.Tests/fixtures/extractors/object_arg/object_arg.js
@@ -1,6 +1,7 @@
 var C = class {
   data
-  constructor(data) {
+  constructor(temp0) {
+    var data = temp0;
     self.data = data;
   }
   [Symbol.customMatcher]() {

--- a/src/Escalier.Compiler.Tests/fixtures/functions/apply_generic_type_arg_without_calling_function/apply_generic_type_arg_without_calling_function.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/apply_generic_type_arg_without_calling_function/apply_generic_type_arg_without_calling_function.js
@@ -1,4 +1,5 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   return x;
 };
 var bar = foo;

--- a/src/Escalier.Compiler.Tests/fixtures/functions/basic_function/basic_function.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/basic_function/basic_function.js
@@ -1,3 +1,5 @@
-var add = (a, b) => {
+var add = (temp0, temp1) => {
+  var a = temp0;
+  var b = temp1;
   return a + b;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/functions/binary_op_stress_test/binary_op_stress_test.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/binary_op_stress_test/binary_op_stress_test.js
@@ -1,10 +1,15 @@
-var foo = function (a, b, c) {
+var foo = function (temp0, temp1, temp2) {
+  var a = temp0;
+  var b = temp1;
+  var c = temp2;
   return a * b + c;
 };
-var double = function (x) {
+var double = function (temp3) {
+  var x = temp3;
   return 2 * x;
 };
-var inc = function (x) {
+var inc = function (temp4) {
+  var x = temp4;
   return x + 1;
 };
 var bar = foo(double(1), inc(2), 3);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/call_func_with_single_wrong_arg/call_func_with_single_wrong_arg.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/call_func_with_single_wrong_arg/call_func_with_single_wrong_arg.js
@@ -1,4 +1,6 @@
-var add = (x, y) => {
+var add = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
   return {value: x + y};
 };
 var sum = add("hello", "world");

--- a/src/Escalier.Compiler.Tests/fixtures/functions/call_func_with_wrong_args/call_func_with_wrong_args.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/call_func_with_wrong_args/call_func_with_wrong_args.js
@@ -1,4 +1,6 @@
-var add = (x, y) => {
+var add = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 };
 var sum = "hello" + "world";

--- a/src/Escalier.Compiler.Tests/fixtures/functions/call_generic_func_with_complex_return_and_wrong_arg/call_generic_func_with_complex_return_and_wrong_arg.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/call_generic_func_with_complex_return_and_wrong_arg/call_generic_func_with_complex_return_and_wrong_arg.js
@@ -1,4 +1,5 @@
-var foo = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   return {value: x};
 };
 var bar = foo("hello");

--- a/src/Escalier.Compiler.Tests/fixtures/functions/call_generic_func_with_wrong_arg/call_generic_func_with_wrong_arg.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/call_generic_func_with_wrong_arg/call_generic_func_with_wrong_arg.js
@@ -1,4 +1,5 @@
-var foo = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   return x;
 };
 var bar = foo("bar");

--- a/src/Escalier.Compiler.Tests/fixtures/functions/factorial/factorial.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/factorial/factorial.js
@@ -1,9 +1,10 @@
-var factorial = (n) => {
-  var temp0;
+var factorial = (temp0) => {
+  var n = temp0;
+  var temp1;
   if (n == 0) {
-    temp0 = 1;
+    temp1 = 1;
   } else {
-    temp0 = n * factorial((n - 1));
+    temp1 = n * factorial((n - 1));
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_decl/func_decl.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_decl/func_decl.js
@@ -1,3 +1,5 @@
-function fst(x, y) {
+function fst(temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
   return x;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_generalization/func_generalization.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_generalization/func_generalization.js
@@ -1,3 +1,5 @@
-var fst = (x, y) => {
+var fst = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
   return x;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_generic_func/func_generic_func.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_generic_func/func_generic_func.js
@@ -1,4 +1,5 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   return x;
 };
 var bar = foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_params/func_params.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_params/func_params.js
@@ -1,7 +1,11 @@
-var addNums = function (x, y) {
+var addNums = function (temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 };
-var addStrs = function (x, y) {
+var addStrs = function (temp2, temp3) {
+  var x = temp2;
+  var y = temp3;
   return x + y;
 };
 var msg = addStrs("Hello, ", "world!");

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_params_with_typeanns/func_params_with_typeanns.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_params_with_typeanns/func_params_with_typeanns.js
@@ -1,6 +1,10 @@
-var addNums = function (x, y) {
+var addNums = function (temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 };
-var addStrs = function (x, y) {
+var addStrs = function (temp2, temp3) {
+  var x = temp2;
+  var y = temp3;
   return x + y;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_type_annotation/func_type_annotation.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_type_annotation/func_type_annotation.js
@@ -1,4 +1,5 @@
-var foo = (x) => {
+var foo = (temp0) => {
+  var x = temp0;
   return x;
 };
 var x = foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/func_with_multiple_returns/func_with_multiple_returns.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/func_with_multiple_returns/func_with_multiple_returns.js
@@ -1,9 +1,11 @@
-var foo = function (x, y) {
-  var temp0;
+var foo = function (temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
+  var temp2;
   if (x > 0) {
     return x;
   }
-  temp0;
+  temp2;
   return y;
 };
 var bar = foo(5, "hello");

--- a/src/Escalier.Compiler.Tests/fixtures/functions/function_with_optional_params/function_with_optional_params.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/function_with_optional_params/function_with_optional_params.js
@@ -1,4 +1,6 @@
-var foo = (a, b) => {
+var foo = (temp0, temp1) => {
+  var a = temp0;
+  var b = temp1;
   return a;
 };
 var a = foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/function_with_rest_params/function_with_rest_params.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/function_with_rest_params/function_with_rest_params.js
@@ -1,4 +1,6 @@
-var foo = (a, ...b) => {
+var foo = (temp0, temp1) => {
+  var a = temp0;
+  var ...b = temp1;
   return a;
 };
 var a = foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/generic_func_with_explicit_type_params/generic_func_with_explicit_type_params.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/generic_func_with_explicit_type_params/generic_func_with_explicit_type_params.js
@@ -1,4 +1,5 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   return x;
 };
 var bar = foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint/generic_with_constraint.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint/generic_with_constraint.js
@@ -1,4 +1,5 @@
-var foo = (obj) => {
+var foo = (temp0) => {
+  var obj = temp0;
   return obj;
 };
 var bar = foo({a: 5, b: "hello"});

--- a/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param/generic_with_constraint_referencing_other_type_param.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param/generic_with_constraint_referencing_other_type_param.js
@@ -1,4 +1,6 @@
-var foo = (t, u) => {
+var foo = (temp0, temp1) => {
+  var t = temp0;
+  var u = temp1;
   return u;
 };
 var bar = foo({a: 5}, {a: 5, b: "hello"});

--- a/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param_and_other_type_ref_using_let_fn/generic_with_constraint_referencing_other_type_param_and_other_type_ref_using_let_fn.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param_and_other_type_ref_using_let_fn/generic_with_constraint_referencing_other_type_param_and_other_type_ref_using_let_fn.js
@@ -1,4 +1,6 @@
-var foo = (t, u) => {
+var foo = (temp0, temp1) => {
+  var t = temp0;
+  var u = temp1;
   return u;
 };
 var bar = foo({a: 5}, {a: 5, b: "hello"});

--- a/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param_and_other_type_refs/generic_with_constraint_referencing_other_type_param_and_other_type_refs.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param_and_other_type_refs/generic_with_constraint_referencing_other_type_param_and_other_type_refs.js
@@ -1,4 +1,6 @@
-function foo(t, u) {
+function foo(temp0, temp1) {
+  var t = temp0;
+  var u = temp1;
   return u;
 }
 var bar = foo({a: 5}, {a: 5, b: "hello"});

--- a/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param_misordered/generic_with_constraint_referencing_other_type_param_misordered.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/generic_with_constraint_referencing_other_type_param_misordered/generic_with_constraint_referencing_other_type_param_misordered.js
@@ -1,4 +1,6 @@
-var foo = (t, u) => {
+var foo = (temp0, temp1) => {
+  var t = temp0;
+  var u = temp1;
   return u;
 };
 var bar = foo({a: 5}, {a: 5, b: "hello"});

--- a/src/Escalier.Compiler.Tests/fixtures/functions/lambda/lambda.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/lambda/lambda.js
@@ -1,3 +1,5 @@
-var add = (x, y) => {
+var add = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/functions/params_from_callback_type/params_from_callback_type.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/params_from_callback_type/params_from_callback_type.js
@@ -1,3 +1,4 @@
-var result = foo((p) => {
+var result = foo((temp0) => {
+  var p = temp0;
   return p.x;
 });

--- a/src/Escalier.Compiler.Tests/fixtures/functions/passing_incorrect_args_as_rest_param/passing_incorrect_args_as_rest_param.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/passing_incorrect_args_as_rest_param/passing_incorrect_args_as_rest_param.js
@@ -1,4 +1,6 @@
-var foo = (a, ...b) => {
+var foo = (temp0, temp1) => {
+  var a = temp0;
+  var ...b = temp1;
   return a;
 };
 var c = foo(10, "hello", true);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/passing_too_few_args_is_an_error/passing_too_few_args_is_an_error.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/passing_too_few_args_is_an_error/passing_too_few_args_is_an_error.js
@@ -1,4 +1,6 @@
-var add = (x, y) => {
+var add = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 };
 var sum = add(5);

--- a/src/Escalier.Compiler.Tests/fixtures/functions/passing_too_many_args_is_okay/passing_too_many_args_is_okay.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/passing_too_many_args_is_okay/passing_too_many_args_is_okay.js
@@ -1,4 +1,6 @@
-var add = (x, y) => {
+var add = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 };
 var sum = add(5, 10, "hello");

--- a/src/Escalier.Compiler.Tests/fixtures/functions/type_alias_of_type_param/type_alias_of_type_param.js
+++ b/src/Escalier.Compiler.Tests/fixtures/functions/type_alias_of_type_param/type_alias_of_type_param.js
@@ -1,8 +1,10 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   var y = x;
   return y;
 };
-var bar = function (x) {
+var bar = function (temp1) {
+  var x = temp1;
   var y = x;
   return y;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/jsx/functional_component/functional_component.js
+++ b/src/Escalier.Compiler.Tests/fixtures/jsx/functional_component/functional_component.js
@@ -1,5 +1,6 @@
 import {jsx as _jsx} from "react/jsx-runtime"
-var Comp = function (props) {
+var Comp = function (temp0) {
+  var props = temp0;
   return _jsx("div", {children: [_jsx("p", {children: [props.message]})]});
 };
 var comp = _jsx(Comp, {message: "Hello, world!"});

--- a/src/Escalier.Compiler.Tests/fixtures/jsx/functional_component_qualified_ident/functional_component_qualified_ident.js
+++ b/src/Escalier.Compiler.Tests/fixtures/jsx/functional_component_qualified_ident/functional_component_qualified_ident.js
@@ -1,5 +1,6 @@
 import {jsx as _jsx} from "react/jsx-runtime"
-var Comps = {Comp: function (props) {
+var Comps = {Comp: function (temp0) {
+  var props = temp0;
   return _jsx("div", {children: [_jsx("p", {children: [props.message]})]});
 }};
 var comp = _jsx(Comps.Comp, {message: "Hello, world!"});

--- a/src/Escalier.Compiler.Tests/fixtures/jsx/handler/handler.js
+++ b/src/Escalier.Compiler.Tests/fixtures/jsx/handler/handler.js
@@ -1,4 +1,5 @@
-var handler = function (e) {
+var handler = function (temp0) {
+  var e = temp0;
   var x = e.clientX;
   var y = e.clientY;
   var slope = y / x;

--- a/src/Escalier.Compiler.Tests/fixtures/jsx/jsx_with_callback/jsx_with_callback.js
+++ b/src/Escalier.Compiler.Tests/fixtures/jsx/jsx_with_callback/jsx_with_callback.js
@@ -1,5 +1,6 @@
 import {jsx as _jsx} from "react/jsx-runtime"
-var foo = _jsx("div", {onClick: function (event) {
+var foo = _jsx("div", {onClick: function (temp0) {
+  var event = temp0;
   var x = event.clientX;
   var y = event.clientY;
   var slope = y / x;

--- a/src/Escalier.Compiler.Tests/fixtures/jsx/props_type_object/props_type_object.js
+++ b/src/Escalier.Compiler.Tests/fixtures/jsx/props_type_object/props_type_object.js
@@ -1,4 +1,5 @@
-var props = {id: "foo", onClick: function (event) {
+var props = {id: "foo", onClick: function (temp0) {
+  var event = temp0;
   var x = event.clientX;
   var y = event.clientY;
   var slope = y / x;

--- a/src/Escalier.Compiler.Tests/fixtures/modules/basic_module/basic_module.js
+++ b/src/Escalier.Compiler.Tests/fixtures/modules/basic_module/basic_module.js
@@ -1,6 +1,10 @@
-var add = (a, b) => {
+var add = (temp0, temp1) => {
+  var a = temp0;
+  var b = temp1;
   return a + b;
 };
-var sub = (a, b) => {
+var sub = (temp2, temp3) => {
+  var a = temp2;
+  var b = temp3;
   return a - b;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/modules/module_with_top_level_expressions_no_errors/module_with_top_level_expressions_no_errors.js
+++ b/src/Escalier.Compiler.Tests/fixtures/modules/module_with_top_level_expressions_no_errors/module_with_top_level_expressions_no_errors.js
@@ -1,4 +1,5 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   console.log(x);
 };
 foo(5);

--- a/src/Escalier.Compiler.Tests/fixtures/modules/module_with_top_level_expressions_recoverable_errors/module_with_top_level_expressions_recoverable_errors.js
+++ b/src/Escalier.Compiler.Tests/fixtures/modules/module_with_top_level_expressions_recoverable_errors/module_with_top_level_expressions_recoverable_errors.js
@@ -1,4 +1,5 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   console.log(x);
 };
 foo("hello");

--- a/src/Escalier.Compiler.Tests/fixtures/modules/module_with_top_level_for_loop/module_with_top_level_for_loop.js
+++ b/src/Escalier.Compiler.Tests/fixtures/modules/module_with_top_level_for_loop/module_with_top_level_for_loop.js
@@ -1,5 +1,5 @@
 var sum = 0;
-for (const x of [1, 2, 3]) {
+for (const temp0 of [1, 2, 3]) {
   var square = x * x;
   sum = sum + square;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/modules/mutual_recursion/mutual_recursion.js
+++ b/src/Escalier.Compiler.Tests/fixtures/modules/mutual_recursion/mutual_recursion.js
@@ -1,18 +1,20 @@
-var even = (x) => {
-  var temp0;
-  if (x == 0) {
-    temp0 = true;
-  } else {
-    temp0 = !odd((x - 1));
-  }
-  return temp0;
-};
-var odd = (x) => {
+var even = (temp0) => {
+  var x = temp0;
   var temp1;
-  if (x == 1) {
+  if (x == 0) {
     temp1 = true;
   } else {
-    temp1 = !even((x - 1));
+    temp1 = !odd((x - 1));
   }
   return temp1;
+};
+var odd = (temp2) => {
+  var x = temp2;
+  var temp3;
+  if (x == 1) {
+    temp3 = true;
+  } else {
+    temp3 = !even((x - 1));
+  }
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/fn_with_mutable_param/fn_with_mutable_param.js
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/fn_with_mutable_param/fn_with_mutable_param.js
@@ -1,4 +1,5 @@
-var foo = function (array) {
+var foo = function (temp0) {
+  var array = temp0;
   array[0] = 5;
   array[1] = "hello";
   array.push(10);

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/immutable_params_are_covariant/immutable_params_are_covariant.js
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/immutable_params_are_covariant/immutable_params_are_covariant.js
@@ -1,4 +1,5 @@
-var foo = function (array) {
+var foo = function (temp0) {
+  var array = temp0;
   return array.length;
 };
 var numbers = [1, 2, 3];

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_params_are_invariant/mutable_params_are_invariant.js
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_params_are_invariant/mutable_params_are_invariant.js
@@ -1,4 +1,5 @@
-var foo = function (array) {
+var foo = function (temp0) {
+  var array = temp0;
   array[0] = 5;
   array[1] = "hello";
 };

--- a/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_params_cant_be_covariant/mutable_params_cant_be_covariant.js
+++ b/src/Escalier.Compiler.Tests/fixtures/mutability/mutable_params_cant_be_covariant/mutable_params_cant_be_covariant.js
@@ -1,4 +1,5 @@
-var foo = function (array) {
+var foo = function (temp0) {
+  var array = temp0;
   array[0] = 5;
   array[1] = "hello";
 };

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/arrays/arrays.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/arrays/arrays.js
@@ -1,31 +1,37 @@
-var sum = (array) => {
-  var temp0;
+var sum = (temp0) => {
+  var array = temp0;
+  var temp1;
   if (array.length == 0) {
-    temp0 = 0;
+    var [] = array;
+    temp1 = 0;
   } else {
-    var temp1;
+    var temp2;
     if (array.length == 1) {
-      temp1 = x;
+      var [x] = array;
+      temp2 = x;
     } else {
-      var temp2;
+      var temp3;
       if (array.length == 2) {
-        temp2 = x + y;
+        var [x, y] = array;
+        temp3 = x + y;
       } else {
-        var temp3;
+        var temp4;
         if (array.length == 3) {
-          temp3 = x + y + z;
+          var [x, y, z] = array;
+          temp4 = x + y + z;
         } else {
-          var temp4;
+          var temp5;
           if (array.length == 4) {
-            temp4 = x + y + z + sum(rest);
+            var [x, y, z, ...rest] = array;
+            temp5 = x + y + z + sum(rest);
           }
-          temp3 = temp4;
+          temp4 = temp5;
         }
-        temp2 = temp3;
+        temp3 = temp4;
       }
-      temp1 = temp2;
+      temp2 = temp3;
     }
-    temp0 = temp1;
+    temp1 = temp2;
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/basic_pattern_matching/basic_pattern_matching.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/basic_pattern_matching/basic_pattern_matching.js
@@ -1,25 +1,28 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x == 0) {
-    temp0 = "none";
+    temp1 = "none";
   } else {
-    var temp1;
+    var temp2;
     if (x == 1) {
-      temp1 = "one";
+      temp2 = "one";
     } else {
-      var temp2;
+      var temp3;
       if (true) {
-        temp2 = "negative";
+        var n = x;
+        temp3 = "negative";
       } else {
-        var temp3;
+        var temp4;
         if (true) {
-          temp3 = "other";
+          var _ = x;
+          temp4 = "other";
         }
-        temp2 = temp3;
+        temp3 = temp4;
       }
-      temp1 = temp2;
+      temp2 = temp3;
     }
-    temp0 = temp1;
+    temp1 = temp2;
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/disallow_extra_properties/disallow_extra_properties.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/disallow_extra_properties/disallow_extra_properties.js
@@ -1,5 +1,6 @@
 var temp0;
 if (typeof value == "object" && "a" in value && "b" in value && "c" in value) {
+  var {a, b: _, c: _} = value;
   temp0 = a;
 }
 var result = temp0;

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/disallow_partial_matching_of_tuples/disallow_partial_matching_of_tuples.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/disallow_partial_matching_of_tuples/disallow_partial_matching_of_tuples.js
@@ -1,5 +1,6 @@
 var temp0;
 if (value.length == 1) {
+  var [a] = value;
   temp0 = a;
 }
 var result = temp0;

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/immutable_types/immutable_types.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/immutable_types/immutable_types.js
@@ -1,9 +1,11 @@
 var temp0;
 if (value.length == 2) {
+  var [a, b] = value;
   temp0 = a;
 } else {
   var temp1;
   if (typeof value == "object" && "a" in value && "b" in value) {
+    var {a, b} = value;
     temp1 = a;
   }
   temp0 = temp1;

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/infer_expr/infer_expr.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/infer_expr/infer_expr.js
@@ -1,25 +1,28 @@
-var foo = (x) => {
-  var temp0;
+var foo = (temp0) => {
+  var x = temp0;
+  var temp1;
   if (x == 0) {
-    temp0 = "none";
+    temp1 = "none";
   } else {
-    var temp1;
+    var temp2;
     if (x == 1) {
-      temp1 = "one";
+      temp2 = "one";
     } else {
-      var temp2;
+      var temp3;
       if (true) {
-        temp2 = "negative";
+        var n = x;
+        temp3 = "negative";
       } else {
-        var temp3;
+        var temp4;
         if (true) {
-          temp3 = "other";
+          var _ = x;
+          temp4 = "other";
         }
-        temp2 = temp3;
+        temp3 = temp4;
       }
-      temp1 = temp2;
+      temp2 = temp3;
     }
-    temp0 = temp1;
+    temp1 = temp2;
   }
-  return temp0;
+  return temp1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/infer_expr_with_multiple_type_variables/infer_expr_with_multiple_type_variables.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/infer_expr_with_multiple_type_variables/infer_expr_with_multiple_type_variables.js
@@ -1,50 +1,62 @@
-var foo = (x, y) => {
-  var temp0;
+var foo = (temp0, temp1) => {
+  var x = temp0;
+  var y = temp1;
+  var temp2;
   if (typeof {x, y} == "object" && "x" in {x, y} && {x, y}["x"] == 0 && "y" in {x, y} && {x, y}["y"] == 0) {
-    temp0 = "origin";
+    var {} = {x, y};
+    temp2 = "origin";
   } else {
-    var temp1;
+    var temp3;
     if (typeof {x, y} == "object" && "x" in {x, y} && "y" in {x, y} && {x, y}["y"] == 0) {
-      temp1 = "x-axis";
+      var {x} = {x, y};
+      temp3 = "x-axis";
     } else {
-      var temp2;
+      var temp4;
       if (typeof {x, y} == "object" && "x" in {x, y} && {x, y}["x"] == 0 && "y" in {x, y}) {
-        temp2 = "y-axis";
+        var {y} = {x, y};
+        temp4 = "y-axis";
       } else {
-        var temp3;
+        var temp5;
         if (true) {
-          temp3 = "other";
+          var _ = {x, y};
+          temp5 = "other";
         }
-        temp2 = temp3;
+        temp4 = temp5;
       }
-      temp1 = temp2;
+      temp3 = temp4;
     }
-    temp0 = temp1;
+    temp2 = temp3;
   }
-  return temp0;
+  return temp2;
 };
-var bar = (x, y) => {
-  var temp4;
+var bar = (temp6, temp7) => {
+  var x = temp6;
+  var y = temp7;
+  var temp8;
   if (typeof {x, y} == "object" && "x" in {x, y} && {x, y}["x"] == 0 && "y" in {x, y} && {x, y}["y"] == 0) {
-    temp4 = "origin";
+    var {} = {x, y};
+    temp8 = "origin";
   } else {
-    var temp5;
+    var temp9;
     if (typeof {x, y} == "object" && "x" in {x, y} && "y" in {x, y} && {x, y}["y"] == 0) {
-      temp5 = "x-axis";
+      var {x} = {x, y};
+      temp9 = "x-axis";
     } else {
-      var temp6;
+      var temp10;
       if (typeof {x, y} == "object" && "x" in {x, y} && {x, y}["x"] == 0 && "y" in {x, y}) {
-        temp6 = "y-axis";
+        var {y} = {x, y};
+        temp10 = "y-axis";
       } else {
-        var temp7;
+        var temp11;
         if (typeof {x, y} == "object" && "x" in {x, y} && "y" in {x, y}) {
-          temp7 = "other";
+          var {x, y} = {x, y};
+          temp11 = "other";
         }
-        temp6 = temp7;
+        temp10 = temp11;
       }
-      temp5 = temp6;
+      temp9 = temp10;
     }
-    temp4 = temp5;
+    temp8 = temp9;
   }
-  return temp4;
+  return temp8;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/nested_types/nested_types.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/nested_types/nested_types.js
@@ -1,17 +1,21 @@
 var temp0;
 if (typeof value == "object" && "a" in value && value["a"].length == 1) {
+  var {a: [x]} = value;
   temp0 = x;
 } else {
   var temp1;
   if (typeof value == "object" && "a" in value && typeof value["a"] == "object" && "x" in value["a"]) {
+    var {a: {x}} = value;
     temp1 = x;
   } else {
     var temp2;
     if (typeof value == "object" && "b" in value && value["b"].length == 1) {
+      var {b: [y]} = value;
       temp2 = y;
     } else {
       var temp3;
       if (typeof value == "object" && "b" in value && typeof value["b"] == "object" && "y" in value["b"]) {
+        var {b: {y}} = value;
         temp3 = y;
       }
       temp2 = temp3;

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/objects/objects.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/objects/objects.js
@@ -1,9 +1,11 @@
 var temp0;
 if (typeof shape == "object" && "type" in shape && shape["type"] == "circle") {
+  var {...rest} = shape;
   temp0 = rest.center;
 } else {
   var temp1;
   if (typeof shape == "object" && "type" in shape && shape["type"] == "line" && "start" in shape && "end" in shape) {
+    var {start, end} = shape;
     temp1 = {x: (start.x + end.x) / 2, y: (start.y + end.y) / 2};
   }
   temp0 = temp1;

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/objects_with_block_body/objects_with_block_body.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/objects_with_block_body/objects_with_block_body.js
@@ -1,9 +1,11 @@
 var temp0;
 if (typeof shape == "object" && "type" in shape && shape["type"] == "circle") {
+  var {...rest} = shape;
   temp0 = rest.center;
 } else {
   var temp1;
   if (typeof shape == "object" && "type" in shape && shape["type"] == "line" && "start" in shape && "end" in shape) {
+    var {start, end} = shape;
     var x = (start.x + end.x) / 2;
     var y = (start.y + end.y) / 2;
     temp1 = {x, y};

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/partial_object_matching/partial_object_matching.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/partial_object_matching/partial_object_matching.js
@@ -1,9 +1,11 @@
 var temp0;
 if (value.length == 2) {
+  var [a, _] = value;
   temp0 = a;
 } else {
   var temp1;
   if (typeof value == "object" && "b" in value) {
+    var {b} = value;
     temp1 = b;
   }
   temp0 = temp1;

--- a/src/Escalier.Compiler.Tests/fixtures/pattern_matching/primitive_assertions/primitive_assertions.js
+++ b/src/Escalier.Compiler.Tests/fixtures/pattern_matching/primitive_assertions/primitive_assertions.js
@@ -1,13 +1,16 @@
 var temp0;
 if (true) {
+  var n = value;
   temp0 = n + 1;
 } else {
   var temp1;
   if (true) {
+    var s = value;
     temp1 = s + "!";
   } else {
     var temp2;
     if (true) {
+      var _ = value;
       temp2 = true;
     }
     temp1 = temp2;

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/basic_graph_infer_function_decl/basic_graph_infer_function_decl.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/basic_graph_infer_function_decl/basic_graph_infer_function_decl.js
@@ -1,6 +1,10 @@
-function add(x, y) {
+function add(temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 }
-function fst(x, y) {
+function fst(temp2, temp3) {
+  var x = temp2;
+  var y = temp3;
   return x;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/function_decls_with_local_variables/function_decls_with_local_variables.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/function_decls_with_local_variables/function_decls_with_local_variables.js
@@ -1,4 +1,5 @@
-function add5(x) {
+function add5(temp0) {
+  var x = temp0;
   var y = 5;
   return x + y;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/function_return_type_from_body/function_return_type_from_body.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/function_return_type_from_body/function_return_type_from_body.js
@@ -1,3 +1,5 @@
-function add(x, y) {
+function add(temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
   return x + y;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/mutually_recursive_function_decls/mutually_recursive_function_decls.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/mutually_recursive_function_decls/mutually_recursive_function_decls.js
@@ -1,18 +1,20 @@
-function isEven(n) {
-  var temp0;
-  if (n == 0) {
-    temp0 = true;
-  } else {
-    temp0 = isOdd((n - 1));
-  }
-  return temp0;
-}
-function isOdd(n) {
+function isEven(temp0) {
+  var n = temp0;
   var temp1;
   if (n == 0) {
-    temp1 = false;
+    temp1 = true;
   } else {
-    temp1 = isEven((n - 1));
+    temp1 = isOdd((n - 1));
   }
   return temp1;
+}
+function isOdd(temp2) {
+  var n = temp2;
+  var temp3;
+  if (n == 0) {
+    temp3 = false;
+  } else {
+    temp3 = isEven((n - 1));
+  }
+  return temp3;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/mutually_recursive_functions/mutually_recursive_functions.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/mutually_recursive_functions/mutually_recursive_functions.js
@@ -1,18 +1,20 @@
-var isEven = (n) => {
-  var temp0;
-  if (n == 0) {
-    temp0 = true;
-  } else {
-    temp0 = isOdd((n - 1));
-  }
-  return temp0;
-};
-var isOdd = (n) => {
+var isEven = (temp0) => {
+  var n = temp0;
   var temp1;
   if (n == 0) {
-    temp1 = false;
+    temp1 = true;
   } else {
-    temp1 = isEven((n - 1));
+    temp1 = isOdd((n - 1));
   }
   return temp1;
+};
+var isOdd = (temp2) => {
+  var n = temp2;
+  var temp3;
+  if (n == 0) {
+    temp3 = false;
+  } else {
+    temp3 = isEven((n - 1));
+  }
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/return_function_decl_with_captures/return_function_decl_with_captures.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/return_function_decl_with_captures/return_function_decl_with_captures.js
@@ -1,6 +1,7 @@
 var getAdd5 = function () {
   var y = 5;
-  return function (x) {
+  return function (temp0) {
+    var x = temp0;
     return x + y;
   };
 };

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/return_self_recursive_function/return_self_recursive_function.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/return_self_recursive_function/return_self_recursive_function.js
@@ -1,12 +1,13 @@
 var ret_fact = function () {
-  var fact = (n) => {
-    var temp0;
+  var fact = (temp0) => {
+    var n = temp0;
+    var temp1;
     if (n == 0) {
-      temp0 = 1;
+      temp1 = 1;
     } else {
-      temp0 = n * fact((n - 1));
+      temp1 = n * fact((n - 1));
     }
-    return temp0;
+    return temp1;
   };
   return fact;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/self_recursive_function_decls/self_recursive_function_decls.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/self_recursive_function_decls/self_recursive_function_decls.js
@@ -1,18 +1,20 @@
-function fact(n) {
-  var temp0;
-  if (n == 0) {
-    temp0 = 1;
-  } else {
-    temp0 = n * fact((n - 1));
-  }
-  return temp0;
-}
-function fib(n) {
+function fact(temp0) {
+  var n = temp0;
   var temp1;
-  if (n <= 1) {
-    temp1 = n;
+  if (n == 0) {
+    temp1 = 1;
   } else {
-    temp1 = fib((n - 1)) + fib((n - 2));
+    temp1 = n * fact((n - 1));
   }
   return temp1;
+}
+function fib(temp2) {
+  var n = temp2;
+  var temp3;
+  if (n <= 1) {
+    temp3 = n;
+  } else {
+    temp3 = fib((n - 1)) + fib((n - 2));
+  }
+  return temp3;
 }

--- a/src/Escalier.Compiler.Tests/fixtures/qualified_graph/self_recursive_functions/self_recursive_functions.js
+++ b/src/Escalier.Compiler.Tests/fixtures/qualified_graph/self_recursive_functions/self_recursive_functions.js
@@ -1,18 +1,20 @@
-var fact = (n) => {
-  var temp0;
-  if (n == 0) {
-    temp0 = 1;
-  } else {
-    temp0 = n * fact((n - 1));
-  }
-  return temp0;
-};
-var fib = (n) => {
+var fact = (temp0) => {
+  var n = temp0;
   var temp1;
-  if (n <= 1) {
-    temp1 = n;
+  if (n == 0) {
+    temp1 = 1;
   } else {
-    temp1 = fib((n - 1)) + fib((n - 2));
+    temp1 = n * fact((n - 1));
   }
   return temp1;
+};
+var fib = (temp2) => {
+  var n = temp2;
+  var temp3;
+  if (n <= 1) {
+    temp3 = n;
+  } else {
+    temp3 = fib((n - 1)) + fib((n - 2));
+  }
+  return temp3;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/let_else_early_return/let_else_early_return.js
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/let_else_early_return/let_else_early_return.js
@@ -1,4 +1,5 @@
-var foo = function (x) {
+var foo = function (temp0) {
+  var x = temp0;
   var y = x;
   return y + 1;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/object_destructuring/object_destructuring.js
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/object_destructuring/object_destructuring.js
@@ -1,6 +1,7 @@
 var {x, y} = {x: 5, y: 10};
 var p = {x, y};
-var foo = ({x, y}) => {
+var foo = (temp0) => {
+  var {x, y} = temp0;
   return x + y;
 };
 var sum = foo({x: 5, y: 10});

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/object_rest_spread/object_rest_spread.js
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/object_rest_spread/object_rest_spread.js
@@ -1,7 +1,8 @@
 var obj1 = {a: 5, b: "hello", c: true};
 var {a, ...rest} = obj1;
 var obj2 = {a, ...rest};
-var foo = ({a, ...rest}) => {
+var foo = (temp0) => {
+  var {a, ...rest} = temp0;
   return a;
 };
 foo(obj2);

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/private_decl/private_decl.js
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/private_decl/private_decl.js
@@ -1,4 +1,6 @@
-var makePoint = function (x, y) {
+var makePoint = function (temp0, temp1) {
+  var x = temp0;
+  var y = temp1;
   var point = {x, y};
   return point;
 };

--- a/src/Escalier.Compiler.Tests/fixtures/uncategorized/tuple/tuple.js
+++ b/src/Escalier.Compiler.Tests/fixtures/uncategorized/tuple/tuple.js
@@ -1,5 +1,6 @@
 var foo = [1, 2, 3];
-var bar = (nums) => {
+var bar = (temp0) => {
+  var nums = temp0;
   return nums;
 };
 var baz = bar(foo);


### PR DESCRIPTION
This change is to support nested extractor patterns which require multiple statements in the codegen output.